### PR TITLE
Logrotate.aug : the unavailable su option make augeas parse failed

### DIFF
--- a/lenses/logrotate.aug
+++ b/lenses/logrotate.aug
@@ -47,12 +47,19 @@ module Logrotate =
      [ key "create" .
          ( mode | mode . owner | mode . owner . group )? ]
 
+   let su =
+     let owner = sep_spc . [ label "owner" . store word ] in
+     let group = sep_spc . [ label "group" . store word ] in
+     [ key "su" .
+         ( owner | owner . group )? ]
+
    let tabooext = [ key "tabooext" . ( sep_spc . store /\+/ )? . list_item+ ]
 
    let attrs = select_to_eol "schedule" /(daily|weekly|monthly|yearly)/
                 | value_to_eol "rotate" num
 		| create
 		| flag_to_eol "nocreate"
+		| su
 		| value_to_eol "include" word
 		| select_to_eol "missingok" /(no)?missingok/
 		| select_to_eol "compress" /(no)?compress/

--- a/lenses/tests/test_logrotate.aug
+++ b/lenses/tests/test_logrotate.aug
@@ -73,6 +73,19 @@ include /etc/logrotate.d
                 fi
         endscript
 }
+/var/log/mailman/digest {
+    su root list
+    monthly
+    missingok
+    create 0664 list list
+    rotate 4
+    compress
+    delaycompress
+        sharedscripts
+        postrotate
+            [ -f '/var/run/mailman/mailman.pid' ] && /usr/lib/mailman/bin/mailmanctl -q reopen || exit 0
+        endscript
+}
 "
 
 test Logrotate.lns get conf =
@@ -119,7 +132,7 @@ test Logrotate.lns get conf =
            { "rotate" = "1" } }
       { "rule"
            { "file"      = "/var/log/vsftpd.log" }
-           { "#comment"   = "ftpd doesn't handle SIGHUP properly" }
+           { "#comment"  = "ftpd doesn't handle SIGHUP properly" }
            { "compress"  = "nocompress" }
            { "missingok" = "missingok" }
            { "ifempty"   = "notifempty" }
@@ -142,6 +155,22 @@ test Logrotate.lns get conf =
            { "prerotate" = "                if [ -f /var/run/apache2.pid ]; then
                         /etc/init.d/apache2 restart > /dev/null
                 fi" } }
+      { "rule"
+           { "file" = "/var/log/mailman/digest" }
+           { "su"
+               { "owner" = "root" }
+               { "group" = "list" } }
+           { "schedule"  = "monthly" }
+           { "missingok" = "missingok" }
+           { "create"
+               { "mode"  = "0664" }
+               { "owner" = "list" }
+               { "group" = "list" } }
+           { "rotate"        = "4" }
+           { "compress"      = "compress" }
+           { "delaycompress" = "delaycompress" }
+           { "sharedscripts" = "sharedscripts" }
+           { "postrotate"    = "            [ -f '/var/run/mailman/mailman.pid' ] && /usr/lib/mailman/bin/mailmanctl -q reopen || exit 0" } }
 
 test Logrotate.lns get "/var/log/file {\n dateext\n}\n" =
     { "rule"


### PR DESCRIPTION
Logrotate has an su option which wasn't in the logrotate lens, which make augeas fail to parse the file.
An example of su utilisation is in debian mailman logrotate conf.

Here's a correct patch and the test.
