### PR TITLE
Fix in cron.aug.

### DIFF
--- a/lenses/cron.aug
+++ b/lenses/cron.aug
@@ -51,6 +51,8 @@ let alpha      = /[A-Za-z]{3}/
 (* Variable: alphanum *)
 let alphanum   = (num|alpha) . ("-" . (num|alpha))?
 
+(* Variable: entry_prefix *)
+let entry_prefix = /-/
 
 (* Group: Separators *)
 
@@ -77,6 +79,8 @@ let shellvar =
   let sto_to_eol = store /[^\n]*[^ \t\n]/ in
   [ key key_re . sep_eq . sto_to_eol . eol ]
 
+(* View: - prefix of an entry *)
+let prefix     = [ label "prefix"       . store entry_prefix ]
 
 (* View: minute *)
 let minute     = [ label "minute"       . store num ]
@@ -124,6 +128,7 @@ let schedule    = [ label "schedule" . Util.del_str "@"
  *************************************************************************)
 
 let entry       = [ label "entry" . indent
+                   . prefix?
                    . ( time | schedule )
                    . sep_spc . user
                    . sep_spc . store Rx.space_in . eol ]


### PR DESCRIPTION
Crontab entries can be prefixed by '-'. crontab.aug used to fail for such entries.
