### PR TITLE
Fix in logrotate.aug

### DIFF
--- a/lenses/logrotate.aug
+++ b/lenses/logrotate.aug
@@ -17,7 +17,7 @@ module Logrotate =
    let sep_spc = Sep.space
    let sep_val = del /[ \t]*=[ \t]*|[ \t]+/ " "
    let eol = Util.eol
-   let num = Rx.integer
+   let num = Rx.relinteger
    let word = /[^,#= \n\t{}]+/
    let filename = /\/[^,#= \n\t{}]+/
    let size = num . /[kMG]?/

--- a/lenses/rx.aug
+++ b/lenses/rx.aug
@@ -52,7 +52,7 @@ let integer    = /[0-9]+/
 
 (* Variable: integer
    A relative <integer> *)
-let relinteger = /-?[0-9]+/
+let relinteger = /[-+]?[0-9]+/
 
 (* Variable: decimal
    A decimal value (using ',' or '.' as a separator) *)

--- a/lenses/tests/test_logrotate.aug
+++ b/lenses/tests/test_logrotate.aug
@@ -86,6 +86,19 @@ include /etc/logrotate.d
             [ -f '/var/run/mailman/mailman.pid' ] && /usr/lib/mailman/bin/mailmanctl -q reopen || exit 0
         endscript
 }
+/var/log/ntp {
+    compress
+    dateext
+    maxage 365
+    rotate 99
+    size=+2048k
+    notifempty
+    missingok
+    copytruncate
+    postrotate
+        chmod 644 /var/log/ntp
+    endscript
+}
 "
 
 test Logrotate.lns get conf =
@@ -171,6 +184,17 @@ test Logrotate.lns get conf =
            { "delaycompress" = "delaycompress" }
            { "sharedscripts" = "sharedscripts" }
            { "postrotate"    = "            [ -f '/var/run/mailman/mailman.pid' ] && /usr/lib/mailman/bin/mailmanctl -q reopen || exit 0" } }
+      { "rule"
+           { "file" = "/var/log/ntp" }
+           { "compress" = "compress" }
+           { "dateext" = "dateext" }
+           { "maxage" = "365" }
+           { "rotate" = "99" }
+           { "size" = "+2048k" }
+           { "ifempty" = "notifempty" }
+           { "missingok" = "missingok" }
+           { "copytruncate" = "copytruncate" }
+           { "postrotate" = "        chmod 644 /var/log/ntp" } }
 
 test Logrotate.lns get "/var/log/file {\n dateext\n}\n" =
     { "rule"


### PR DESCRIPTION
numbers in appropriate config files can be prefixed by a sign. e.g. **size=+2048k**

I've inserted a config file used in SLES which contains such setting into test_logrotate.aug
