### PR TITLE
fixes #278 multipath: allow devices to override defaults

### DIFF
--- a/lenses/multipath.aug
+++ b/lenses/multipath.aug
@@ -46,31 +46,35 @@ let common_setting =
  |kv "no_path_retry" (Rx.integer | /fail|queue/)
  |kv "rr_min_io" Rx.integer
 
+let default_setting =
+  kv "polling_interval" Rx.integer
+  |kv "udev_dir" Rx.fspath
+  |qstr "selector"
+  |kv "user_friendly_names" /yes|no/
+  |kv "dev_loss_tmo" Rx.integer
+  |kv "fast_io_fail_tmo" Rx.integer
+  |kv "verbosity" /[0-6]/
+  |kv "reassign_maps" /yes|no/
+  (* These are not in the manpage but in the example multipath.conf *)
+  |kv "prio" Rx.word
+  |kv "max_fds" Rx.integer
+  (* SUSE extensions *)
+  |kv "async_timeout" Rx.integer
+  |kv "max_polling_interval" Rx.integer
+
 (* A device subsection *)
 let device =
   let setting =
     qstr /vendor|product|product_blacklist|hardware_handler/
-   |common_setting in
+   |common_setting
+   |default_setting in
   section "device" setting
 
 (* The defaults section *)
 let defaults =
   let setting =
     common_setting
-   |kv "polling_interval" Rx.integer
-   |kv "udev_dir" Rx.fspath
-   |qstr "selector"
-   |kv "user_friendly_names" /yes|no/
-   |kv "dev_loss_tmo" Rx.integer
-   |kv "fast_io_fail_tmo" Rx.integer
-   |kv "verbosity" /[0-6]/
-   |kv "reassign_maps" /yes|no/
-   (* These are not in the manpage but in the example multipath.conf *)
-   |kv "prio" Rx.word
-   |kv "max_fds" Rx.integer
-   (* SUSE extensions *)
-   |kv "async_timeout" Rx.integer
-   |kv "max_polling_interval" Rx.integer
+   |default_setting
   in section "defaults" setting
 
 (* The blacklist and blacklist_exceptions sections *)

--- a/lenses/tests/test_multipath.aug
+++ b/lenses/tests/test_multipath.aug
@@ -84,6 +84,7 @@ devices {
 		vendor			\"COMPAQ  \"
 		product			\"MSA1000         \"
 		path_grouping_policy	multibus
+		polling_interval	9
 	}
 }\n"
 
@@ -162,4 +163,5 @@ test Multipath.lns get conf =
     { "device"
       { "vendor" = "COMPAQ  " }
       { "product" = "MSA1000         " }
-      { "path_grouping_policy" = "multibus" } } }
+      { "path_grouping_policy" = "multibus" }
+      { "polling_interval" = "9" } } }


### PR DESCRIPTION
Multipath lens only allows device subsections to set items in 'common_settings' in addition to a couple of 'unique' items (qstr /vendor|product|product_blacklist|hardware_handler).

A device should be able to 'override' or set items that are definable in the defaults section as well.

Attached is a diff of how things are now and what I am currently using to address some issues we ran into.

Addressed the following issues you brought up:

What about the SuSe? extensions async_timeout and max_polling_interval ? Your patch removes them
  Not anymore :)

Can you add some tests to lenses/tests/test_multipath.aug to check the device sections accept settings ?
  Added test for polling_interval in device section which previously wasn't allowed

Currently, the tests fail with your patch ...
  I checked that after I made my changes the original test still worked, then added additional checks with the test still working
