### PR TITLE
fixes #297 ntp: add tos directive

### DIFF
--- a/lenses/ntp.aug
+++ b/lenses/ntp.aug
@@ -110,12 +110,23 @@ module Ntp =
       let arg = [ key arg_names . sep_spc . store Rx.decimal ] in
       [ key "tinker" . (sep_spc . arg)* . eol ]
 
+    (* tos [beacon beacon | ceiling ceiling | cohort {0 | 1} |
+            floor floor | maxclock maxclock | maxdist maxdist |
+            minclock minclock | mindist mindist | minsane minsane |
+            orphan stratum | orphanwait delay] *)
+
+    let tos =
+      let arg_names = /beacon|ceiling|cohort|floor|maxclock|maxdist|
+                      minclock|mindist|minsane|orphan|orphanwait/ in
+      let arg = [ key arg_names . sep_spc . store Rx.decimal ] in
+      [ key "tos" . (sep_spc . arg)* . eol ]
+
     (* Define lens *)
 
     let lns = ( comment | empty | command_record | fudge_record
               | restrict_record | simple_settings | statistics_record
               | filegen_record | broadcastclient
-              | auth_command | tinker )*
+              | auth_command | tinker | tos)*
 
     let filter = (incl "/etc/ntp.conf")
         . Util.stdexcl

--- a/lenses/tests/test_ntp.aug
+++ b/lenses/tests/test_ntp.aug
@@ -151,3 +151,8 @@ test Ntp.tinker get "tinker panic 0 huffpuff 3.14\n" =
   { "tinker"
     { "panic" = "0" }
     { "huffpuff" = "3.14" } }
+
+(* Bug #297: tos directive *)
+test Ntp.tos get "tos maxdist 16\n" =
+  { "tos"
+    { "maxdist" = "16" } }


### PR DESCRIPTION
Add tos directive to ntp lens

Basically modeled if after the tinker directive that was added from #103 with its own specific 'arg_names'

Added test as well for 'tos maxdist 16' which is what we were trying to set when running into this issue of no lens support
