### PR TITLE
Added node config for OpenShift

### DIFF
--- a/lenses/openshift_config.aug
+++ b/lenses/openshift_config.aug
@@ -5,6 +5,7 @@ Module: OpenShift_Config
     - /etc/openshift/broker-dev.conf
     - /etc/openshift/console.conf
     - /etc/openshift/console-dev.conf
+    - /etc/openshift/node.conf
     - /etc/openshift/plugins.d/*.conf
 
 Author: Brian Redbeard <redbeard@dead-city.org>
@@ -36,6 +37,7 @@ About: Configuration files
             console running in production mode.
         /etc/openshift/console-dev.conf - Configuration file for an OpenShift
             console running in development mode.
+        /etc/openshift/node.conf - Configuration file for an OpenShift node
         /etc/openshift/plugins.d/*.conf - Configuration files for OpenShift
             plugins (i.e. mcollective configuration, remote auth, dns updates)
 
@@ -63,6 +65,7 @@ let filter = incl "/etc/openshift/broker.conf"
             . incl "/etc/openshift/console.conf"
             . incl "/etc/openshift/resource_limits.conf"
             . incl "/etc/openshift/console-dev.conf"
+            . incl "/etc/openshift/node.conf"
             . incl "/etc/openshift/plugins.d/*.conf"
             . incl "/var/www/openshift/broker/conf/broker.conf"
             . incl "/var/www/openshift/broker/conf/plugins.d/*.conf"


### PR DESCRIPTION
When the intial lens was developed there was a missing transform
on /etc/openshift/node.conf

This is a fix for bug hercules-team/augeas#22
