### PR TITLE
Add in support for the source stanza in /etc/network/interfaces files.

### DIFF
--- a/lenses/interfaces.aug
+++ b/lenses/interfaces.aug
@@ -37,7 +37,7 @@ let stanza_id    (t:string) = key t . sep_spc . sto_to_spc
 let stanza_param (l:string) = [ sep_spc . label l . sto_to_spc ]
 
 (* Define reseverved words *)
-let stanza_word = /(iface|auto|allow-[a-z-]+|mapping)/
+let stanza_word = /(source|iface|auto|allow-[a-z-]+|mapping)/
 
 (* Define additional lines for multi-line stanzas *)
 let stanza_option = [  del /[ \t]*/ "   "
@@ -82,6 +82,12 @@ let iface   = [ Util.indent
               . (stanza_option|comment|empty)* ]
 
 (************************************************************************
+ *                              SOURCE
+ *************************************************************************)
+
+let source = [ key "source" . sep_spc . sto_to_eol ]
+
+(************************************************************************
  *                              STANZAS
  *************************************************************************)
 
@@ -91,7 +97,7 @@ let iface   = [ Util.indent
    come after an auto or hotplug stanza, otherwise they are considered part
    of a iface or mapping block *)
 
-let stanza_single = (auto|allow) . (comment|empty)*
+let stanza_single = (auto|allow|source) . (comment|empty)*
 let stanza_multi  = iface|mapping
 
 (************************************************************************

--- a/lenses/tests/test_interfaces.aug
+++ b/lenses/tests/test_interfaces.aug
@@ -4,6 +4,8 @@ module Test_interfaces =
 # and how to activate them. For more information, see interfaces(5).
 # The loopback network interface
 
+source /etc/network/interfaces.d/*.conf
+
 auto lo eth0 #foo
 allow-hotplug eth1
 
@@ -35,12 +37,16 @@ mapping eth1
 
 	script\
  /usr/local/sbin/map-scheme
+
+source /etc/network.d/*.net.conf
 "
 
     test Interfaces.lns get conf =
         { "#comment" = "This file describes the network interfaces available on your system"}
         { "#comment" = "and how to activate them. For more information, see interfaces(5)." }
         { "#comment" = "The loopback network interface" }
+        {}
+        {"source" = "/etc/network/interfaces.d/*.conf"}
         {}
         { "auto"
             { "1" = "lo" }
@@ -80,10 +86,16 @@ mapping eth1
             { "#comment" = "I like mapping ..." }
             { "#comment" = "... and I like comments" }
             {}
-            { "script" = "/usr/local/sbin/map-scheme"} }
+            { "script" = "/usr/local/sbin/map-scheme"}
+        {} }
+        {"source" = "/etc/network.d/*.net.conf"}
 
 test Interfaces.lns put "" after
 	set "/iface[1]" "eth0";
 	set "/iface[1]/family" "inet";
 	set "/iface[1]/method" "dhcp"
 = "iface eth0 inet dhcp\n"
+
+test Interfaces.lns put "" after
+    set "/source[0]" "/etc/network/conf.d/*.conf"
+= "source /etc/network/conf.d/*.conf\n"

--- a/tests/root/etc/network/interfaces
+++ b/tests/root/etc/network/interfaces
@@ -37,3 +37,6 @@ iface adsl0 inet dhcp
   pre-up /usr/sbin/adictrl -f
   pre-up /usr/sbin/adictrl -d
   pre-up /usr/sbin/adictrl -s
+
+
+source /etc/network/interfaces.d/*.conf


### PR DESCRIPTION
It looks like this stanza was added in Ubuntu 11.10's ifupdown (0.7~alpha4), but did not have support in the Augeas lens.
