### PR TITLE
Add aug_cp and the cp and copy commands

### DIFF
--- a/src/augeas.h
+++ b/src/augeas.h
@@ -243,6 +243,19 @@ int aug_rm(augeas *aug, const char *path);
  */
 int aug_mv(augeas *aug, const char *src, const char *dst);
 
+/* Function: aug_cp
+ *
+ * Copy the node SRC to DST. SRC must match exactly one node in the
+ * tree. DST must either match exactly one node in the tree, or may not
+ * exist yet. If DST exists already, it and all its descendants are
+ * deleted. If DST does not exist yet, it and all its missing ancestors are
+ * created.
+ *
+ * Returns:
+ * 0 on success and -1 on failure.
+ */
+int aug_cp(augeas *aug, const char *src, const char *dst);
+
 /* Function: aug_rename
  *
  * Rename the label of all nodes matching SRC to LBL.
@@ -433,7 +446,8 @@ typedef enum {
     AUG_EMVDESC,        /* Cannot move node into its descendant */
     AUG_ECMDRUN,        /* Failed to execute command */
     AUG_EBADARG,        /* Invalid argument in funcion call */
-    AUG_ELABEL          /* Invalid label */
+    AUG_ELABEL,         /* Invalid label */
+    AUG_ECPDESC         /* Cannot copy node into its descendant */
 } aug_errcode_t;
 
 /* Return the error code from the last API call */

--- a/src/augeas_sym.version
+++ b/src/augeas_sym.version
@@ -60,3 +60,8 @@ AUGEAS_0.16.0 {
       aug_transform;
       aug_label;
 } AUGEAS_0.15.0;
+
+AUGEAS_0.17.0 {
+    global:
+      aug_cp;
+} AUGEAS_0.16.0;

--- a/src/augrun.c
+++ b/src/augrun.c
@@ -537,6 +537,48 @@ static const struct command_def cmd_move_def = {
     .help = cmd_mv_help
 };
 
+static void cmd_cp(struct command *cmd) {
+    const char *src = arg_value(cmd, "src");
+    const char *dst = arg_value(cmd, "dst");
+    int r;
+
+    r = aug_cp(cmd->aug, src, dst);
+    if (r < 0)
+        ERR_REPORT(cmd, AUG_ECMDRUN,
+                   "Copying %s to %s failed", src, dst);
+}
+
+static const struct command_opt_def cmd_cp_opts[] = {
+    { .type = CMD_PATH, .name = "src", .optional = false,
+      .help = "the tree to copy" },
+    { .type = CMD_PATH, .name = "dst", .optional = false,
+      .help = "where to copy the source tree" },
+    CMD_OPT_DEF_LAST
+};
+
+static const char const cmd_cp_help[] =
+    "Copy node  SRC to DST.  SRC must match  exactly one node in  "
+    "the tree.\n DST  must either  match  exactly one  node  in the  tree,  "
+    "or may  not\n exist  yet. If  DST exists  already, it  and all  its  "
+    "descendants are\n deleted.  If  DST  does  not   exist  yet,  it  and  "
+    "all  its  missing\n ancestors are created.";
+
+static const struct command_def cmd_cp_def = {
+    .name = "cp",
+    .opts = cmd_cp_opts,
+    .handler = cmd_cp,
+    .synopsis = "copy a subtree",
+    .help = cmd_cp_help
+};
+
+static const struct command_def cmd_copy_def = {
+    .name = "copy",
+    .opts = cmd_cp_opts,
+    .handler = cmd_cp,
+    .synopsis = "copy a subtree (alias of 'cp')",
+    .help = cmd_cp_help
+};
+
 static void cmd_rename(struct command *cmd) {
     const char *src = arg_value(cmd, "src");
     const char *lbl = arg_value(cmd, "lbl");
@@ -1178,6 +1220,8 @@ static const struct command_grp_def cmd_grp_write_def = {
         &cmd_insert_def,
         &cmd_mv_def,
         &cmd_move_def,
+        &cmd_cp_def,
+        &cmd_copy_def,
         &cmd_rename_def,
         &cmd_rm_def,
         &cmd_set_def,

--- a/src/augtool.c
+++ b/src/augtool.c
@@ -169,7 +169,7 @@ static char *readline_command_generator(const char *text, int state) {
     static const char *const commands[] = {
         "quit", "clear", "defnode", "defvar",
         "get", "label", "ins", "load", "ls", "match",
-        "mv", "rename", "print", "dump-xml", "rm", "save", "set", "setm",
+        "mv", "cp", "rename", "print", "dump-xml", "rm", "save", "set", "setm",
         "clearm", "span", "store", "retrieve", "transform",
         "help", NULL };
 


### PR DESCRIPTION
This Pull Request adds an `aug_cp` API entry (as per [ticket #2](https://fedorahosted.org/augeas/ticket/2)), as well as the `cp`/`copy` srun commands associated with it.
