### PR TITLE
Fix NagiosCfg lense so /etc/nagios/nrpe.cfg is parsed by Nrpe and not NagiosCfg

### DIFF
--- a/lenses/nagioscfg.aug
+++ b/lenses/nagioscfg.aug
@@ -68,6 +68,7 @@ let filter = incl "/etc/nagios3/*.cfg"
 	   . incl "/etc/icinga/*.cfg"
 	   . excl "/etc/nagios3/commands.cfg"
 	   . excl "/etc/nagios/commands.cfg"
+	   . excl "/etc/nagios/nrpe.cfg"
 	   . incl "/etc/icinga/commands.cfg"
 
 let xfm = transform lns filter


### PR DESCRIPTION
Currently NagiosCfg lense is in charge of parsing all files under `/etc/nagios/*.cfg`
but`/etc/nagios/commands.cfg`. `/etc/nagios/nrpe.cfg` should also be added as an exception
since it needs to be parsed by the Nrpe lense. This issue currently causes the following
error : `Lenses @NagiosCfg and @Nrpe could be used to load this file`
