### PR TITLE
Add dhclient.conf path for Debian/Ubuntu

### DIFF
--- a/lenses/dhclient.aug
+++ b/lenses/dhclient.aug
@@ -164,6 +164,7 @@ let lns               = ( empty
                         | statement )*
 
 let filter            = incl "/etc/dhcp3/dhclient.conf"
+                      . incl "/etc/dhcp/dhclient.conf"
                       . incl "/etc/dhclient.conf"
 
 let xfm                = transform lns filter


### PR DESCRIPTION
Augeas fails to detect the dhclient.conf file on Debian/Ubuntu. This pull request adds an extra path to the dhclient lense that matches the contents of the [isc-dhcp-client](http://packages.debian.org/wheezy/amd64/isc-dhcp-client/filelist) package.
