### PR TITLE
Enable indented line for key_value pair when desired

### DIFF
--- a/lenses/build.aug
+++ b/lenses/build.aug
@@ -14,7 +14,8 @@ About: Reference
 
 module Build =
 
-let eol = Util.eol
+let eol     = Util.eol
+let indent  = Util.indent
 
 (************************************************************************
  * Group:               GENERIC CONSTRUCTIONS
@@ -105,6 +106,19 @@ let key_value_line (kw:regexp) (sep:lens) (sto:lens) =
                                    [ key kw . sep . sto . eol ]
 
 (************************************************************************
+ * View: key_value_indented_line
+ *   A subnode with any kind of indentation or none, keyword, a separator and
+ *   a storing lens, and an end of line
+ *
+ *   Parameters:
+ *     kw:regexp - the pattern to match as key
+ *     sep:lens  - the separator lens, which can be taken from the <Sep> module
+ *     sto:lens  - the storing lens
+ ************************************************************************)
+let key_value_indented_line (kw:regexp) (sep:lens) (sto:lens) =
+                                   [ indent . key kw . sep . sto . eol ]
+
+(************************************************************************
  * View: key_value_line_comment
  *   Same as <key_value_line>, but allows to have a comment in the end of a line
  *   and an end of line
@@ -117,6 +131,20 @@ let key_value_line (kw:regexp) (sep:lens) (sto:lens) =
  ************************************************************************)
 let key_value_line_comment (kw:regexp) (sep:lens) (sto:lens) (comment:lens) =
                                    [ key kw . sep . sto . (eol|comment) ]
+
+(************************************************************************
+ * View: key_value_indented_line_comment
+ *   Same as <key_value_indented_line>, but allows to have a comment in the
+ *   end of a line and an end of line
+ *
+ *   Parameters:
+ *     kw:regexp    - the pattern to match as key
+ *     sep:lens     - the separator lens, which can be taken from the <Sep> module
+ *     sto:lens     - the storing lens
+ *     comment:lens - the comment lens, which can be taken from <Util>
+ ************************************************************************)
+let key_value_indented_line_comment (kw:regexp) (sep:lens) (sto:lens) (comment:lens) =
+                                   [ indent . key kw . sep . sto . (eol|comment) ]
 
 (************************************************************************
  * View: key_value

--- a/lenses/tests/test_build.aug
+++ b/lenses/tests/test_build.aug
@@ -64,12 +64,26 @@ let key_value_line = Build.key_value_line Rx.word Sep.equal (store Rx.word)
 (* Test: key_value_line *)
 test key_value_line get "foo=bar\n" = { "foo" = "bar" }
 
+(* View: key_value_indented_line *)
+let key_value_indented_line = Build.key_value_indented_line Rx.word Sep.equal (store Rx.word)
+
+(* Test: key_value_indented_line *)
+test key_value_indented_line get "      foo=bar\n" = { "foo" = "bar" }
+
 (* View: key_value_line_comment *)
 let key_value_line_comment = Build.key_value_line_comment Rx.word
                              Sep.equal (store Rx.word) Util.comment
 
 (* Test: key_value_line_comment *)
 test key_value_line_comment get "foo=bar # comment\n" =
+    { "foo" = "bar" { "#comment" = "comment" } }
+
+(* View: key_value_line_indented_comment *)
+let key_value_indented_line_comment = Build.key_value_indented_line_comment Rx.word
+                             Sep.equal (store Rx.word) Util.comment
+
+(* Test: key_value_line_indented_comment *)
+test key_value_indented_line_comment get "      foo=bar # comment\n" =
     { "foo" = "bar" { "#comment" = "comment" } }
 
 (* View: key_value *)


### PR DESCRIPTION
As of today key_value_line functions are made of the key the separator
and the value not leaving any space for leading indentation. Some software
configuration file could benefit from this feature as they are less strict
about it
