### PR TITLE
Support a wider variety of DHCP allow/deny/ignore statement

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@
   - Lens changes/additions
     * Automounter: Handle hostnames with dashes in them, GH issue #27
     * Dhcpd: support conditionals, GH issue #34
+    * Dhcpd: support a wider variety of allow/deny statement (including
+      booting and bootp)
     * PHP: allow php-fpm syntax in keys, GH issue #35
     * Properties: support multiline starting with an empty string, GH issue #19
     * Sysconfig_Route: New lens for RedHat's route configs

--- a/lenses/dhcpd.aug
+++ b/lenses/dhcpd.aug
@@ -283,9 +283,17 @@ let stmt_subclass = [ indent . key "subclass" . sep_spc .
   to avoid ambiguity in the put direction *)
 
 let allow_deny_re     = "unknown-clients"
+                      | "known-clients"
+                      | /all[ ]+clients/
                       | /dynamic[ ]+bootp[ ]+clients/
                       | /authenticated[ ]+clients/
                       | /unauthenticated[ ]+clients/
+                      | "bootp"
+                      | "booting"
+                      | "duplicates"
+                      | "declines"
+                      | "client-updates"
+                      | "leasequery"
 
 let stmt_secu_re      = "allow"
                       | "deny"

--- a/lenses/tests/test_dhcpd.aug
+++ b/lenses/tests/test_dhcpd.aug
@@ -28,6 +28,9 @@ max-lease-time 7200;
 # network, the authoritative directive should be uncommented.
 authoritative;
 
+allow booting;
+allow bootp;
+
 # Use this to send dhcp log messages to a different log file (you also
 # have to hack syslog.conf to complete the redirection).
 log-facility local7;
@@ -180,6 +183,8 @@ fixed-address 10.1.1.1;}}" =
   }
 
 test Dhcpd.stmt_secu get "allow members of \"foo\";" =  { "allow-members-of" = "foo" }
+test Dhcpd.stmt_secu get "allow booting;" =  { "allow" = "booting" }
+test Dhcpd.stmt_secu get "allow bootp;" =  { "allow" = "bootp" }
 test Dhcpd.stmt_option get "option voip-boot-server code 66 = string;" =
   { "rfc-code"
     { "label" = "voip-boot-server" }


### PR DESCRIPTION
The Dhcpd.aug was missing a part of the allow/deny/ignore possible
statement. This commit updates the lense so it supports the list
of options available here

http://www.ipamworldwide.com/declarations-topological/declarations-allowdenyignore.html

Also this bug was preventing a Foreman user to parse the dhcpd.conf
generated by theforeman/dhcp puppet module
