### PR TITLE
Enhance Nagiosobjects lens

### DIFF
--- a/lenses/nagiosobjects.aug
+++ b/lenses/nagiosobjects.aug
@@ -25,11 +25,14 @@ module NagiosObjects =
 
     let keyword      = key /[A-Za-z0-9_]+/
 
+    (* optional, but preferred, whitespace *)
+    let opt_ws = del Rx.opt_space " "
+
     (* define an empty line *)
     let empty = Util.empty
 
     (* define a comment *)
-    let comment = Util.comment
+    let comment = Util.comment_generic /[ \t]*[#;][ \t]*/ "# "
 
     (* define a field *)
     let object_field    =
@@ -43,10 +46,10 @@ module NagiosObjects =
        let object_type = keyword in
           [ Util.indent
           . Util.del_str "define" . ws
-          . object_type . ws
+          . object_type . opt_ws
           . Util.del_str "{" . eol
           . ( empty | comment | object_field )*
-          . Util.del_str "}" . eol ]
+          . Util.indent . Util.del_str "}" . eol ]
 
     (* main structure *)
     let lns = ( empty | comment | object_def )*

--- a/lenses/tests/test_nagiosobjects.aug
+++ b/lenses/tests/test_nagiosobjects.aug
@@ -19,6 +19,14 @@ define service {
     check_command           nopassivecheckreceived
     contact_groups          admins
 }
+
+; This is a semicolon comment
+
+define service{
+    service_description     gen2
+    use                     generic_template_passive
+    host_name               plonk
+    }
 "
 
     test NagiosObjects.lns get conf =
@@ -41,5 +49,13 @@ define service {
             { "host_name"               = "plonk" }
             { "check_command"           = "nopassivecheckreceived" }
             { "contact_groups"          = "admins" }
+        }
+        {}
+        { "#comment" = "This is a semicolon comment" }
+        {}
+        { "service"
+            { "service_description"     = "gen2" }
+            { "use"                     = "generic_template_passive" }
+            { "host_name"               = "plonk" }
         }
 


### PR DESCRIPTION
This adds support and tests for three additional Nagios
supported behaviors:
- An optional space between the object name and the {
  Example: "define host{"
- An optional indent prior to the closing }
  Example: "    }"
- Whole-line comments that start with ;
  Example: "; This is a comment"

It does not add support for end-of-line comments with ;
