### PR TITLE
Issue 45: Patch yum lens to allow spaces around'=' equals sign.

### DIFF
--- a/lenses/yum.aug
+++ b/lenses/yum.aug
@@ -6,7 +6,7 @@ module Yum =
  * INI File settings
  *************************************************************************)
 
-let comment  = IniFile.comment "#" "#"
+let comment  = IniFile.comment / *# */ "#"
 let sep      = IniFile.sep "=" "="
 let empty    = Util.empty
 let eol      = IniFile.eol


### PR DESCRIPTION
yum lens currently fails to process yum files with spaces around the equals sign.
Issue 45 [1] illustrates this with an example from rpmforge:
[rpmforge]
name = RHEL $releasever - RPMforge.net - dag
baseurl = http://apt.sw.be/redhat/el6/en/$basearch/rpmforge

This patch seems to allow the spaces.

[1]https://github.com/hercules-team/augeas/issues/45
