### PR TITLE
Fix MongoDB Server lens - MongoDB doesn't accept quoted values

### DIFF
--- a/lenses/mongodbserver.aug
+++ b/lenses/mongodbserver.aug
@@ -41,7 +41,7 @@ autoload xfm
 
 (* View: entry *)
 let entry =
-  Build.key_value_line Rx.word Sep.space_equal Quote.double_opt
+  Build.key_value_line Rx.word Sep.space_equal (store Rx.space_in)
 
 (* View: lns *)
 let lns = (Util.empty | Util.comment | entry)*

--- a/lenses/tests/test_mongodbserver.aug
+++ b/lenses/tests/test_mongodbserver.aug
@@ -26,6 +26,6 @@ test MongoDBServer.lns get conf =
   { "nohttpinterface" = "true" }
 
 (* Test: MongoDBServer.lns
-   Quotes are not mandatory *)
-test MongoDBServer.lns get "port = \"27017\"\n" =
+   Values have to be without quotes *)
+test MongoDBServer.lns get "port = 27017\n" =
   { "port" = "27017" }


### PR DESCRIPTION
This lens worked for already defined values, but once you wanted to
add new value, it was created with quotes and MongoDB failed to start
