### PR TITLE
Fix umask handling when creating new files

### DIFF
--- a/src/transform.c
+++ b/src/transform.c
@@ -1144,7 +1144,7 @@ int transform_save(struct augeas *aug, struct tree *xfm,
         mode_t curumsk = umask(022);
         umask(curumsk);
 
-        if (fchmod(fileno(fp), 0666 - curumsk) < 0) {
+        if (fchmod(fileno(fp), 0666 & ~curumsk) < 0) {
             err_status = "create_chmod";
             return -1;
         }


### PR DESCRIPTION
- src/transform.c (transform_save): faulty umask arithmetic would cause
  overly-open file modes when the umask contains "7", as the umask was
  incorrectly subtracted from the target file mode

Fixes CVE-2013-6412, RHBZ#1034261

https://bugzilla.redhat.com/show_bug.cgi?id=1034261 for reference.
