### PR TITLE
Add %check to RPM spec, fix download URL

### DIFF
--- a/augeas.spec.in
+++ b/augeas.spec.in
@@ -6,7 +6,7 @@ Summary:        A library for changing configuration files
 Group:          System Environment/Libraries
 License:        LGPLv2+
 URL:            http://augeas.net/
-Source0:        http://augeas.net/download/%{name}-%{version}.tar.gz
+Source0:        http://download.augeas.net/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  readline-devel libselinux-devel libxml2-devel
@@ -50,10 +50,25 @@ The libraries for %{name}.
 %configure --disable-static
 make %{?_smp_mflags}
 
+%check
+# Disable test-preserve.sh SELinux testing. This fails when run under mock due
+# to differing SELinux labelling.
+export SKIP_TEST_PRESERVE_SELINUX=1
+
+make %{?_smp_mflags} check || {
+  echo '===== tests/test-suite.log ====='
+  cat tests/test-suite.log
+  exit 1
+}
+
 %install
 rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT INSTALL="%{__install} -p"
 find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
+
+# The tests/ subdirectory contains lenses used only for testing, and
+# so it shouldn't be packaged.
+rm -r $RPM_BUILD_ROOT%{_datadir}/augeas/lenses/dist/tests
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -87,6 +102,14 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/pkgconfig/augeas.pc
 
 %changelog
+* Tue Oct 15 2013 Dominic Cleal <dcleal@redhat.com> - 1.1.0-2
+- Add %check stage to run make check (rjones@redhat.com)
+- Don't package lenses in tests/ subdirectory (rjones@redhat.com)
+- Fix source URL to download.augeas.net (RHBZ#996033)
+
+* Fri Jun 14 2013 David Lutterkort <lutter@watzmann.net> - 1.1.0-1
+- New version
+
 * Fri Dec 21 2012 David Lutterkort <lutter@redhat.com> - 1.0.0-1
 - New version
 

--- a/tests/test-preserve.sh
+++ b/tests/test-preserve.sh
@@ -26,6 +26,7 @@ group=$(groups | tr ' ' '\n' | tail -1)
 chgrp $group $hosts
 
 [ -x /usr/bin/chcon ] && selinux=yes || selinux=no
+[ x$SKIP_TEST_PRESERVE_SELINUX = x1 ] && selinux=no
 if [ $selinux = yes ] ; then
   /usr/bin/chcon -t etc_t $hosts > /dev/null 2>/dev/null || selinux=no
 fi


### PR DESCRIPTION
- augeas.spec.in: add %check to run `make check` during build, skipping
  SELinux tests which don't work in a mock environment

Original %check patch from Richard Jones rjones@redhat.com
