### PR TITLE
Slapd: smart quotes and access_to refactoring

### DIFF
--- a/lenses/slapd.aug
+++ b/lenses/slapd.aug
@@ -28,13 +28,13 @@ let empty       = Util.empty
 
 let access_re   = "access to"
 let control_re  = "stop" | "continue" | "break"
-let who         = [ spc . label "who"     . sto_to_spc ]
 let what        = [ spc . label "access"
                   . store (/[^\\# \t\n]+/ - ("by" | control_re)) ]
 
 (* TODO: parse the control field, see man slapd.access (5) *)
 let control     = [ spc . label "control" . store control_re ]
-let by          = [ sep . key "by". who . what? . control? ]
+let by          = [ sep . key "by" . spc . sto_to_spc
+                  . what? . control? ]
 
 let access      = [ key access_re . spc. sto_to_spc . by+ . eol ]
 

--- a/lenses/tests/test_slapd.aug
+++ b/lenses/tests/test_slapd.aug
@@ -51,17 +51,13 @@ test Slapd.lns get conf =
      { "suffix"   = "dc=nodomain" }
      {}
      { "access to" = "attrs=userPassword,shadowLastChange"
-        { "by"
-           { "who" = "dn=\"cn=admin,dc=nodomain\"" }
+        { "by" = "dn=\"cn=admin,dc=nodomain\""
            { "access" = "write" } }
-        { "by"
-           { "who" = "anonymous" }
+        { "by" = "anonymous"
            { "access" = "auth" } }
-        { "by"
-           { "who" = "self" }
+        { "by" = "self"
            { "access" = "write" } }
-        { "by"
-           { "who" = "*" }
+        { "by" = "*"
            { "access" = "none" } } } }
 
 (* Test: Slapd.lns
@@ -69,8 +65,7 @@ test Slapd.lns get conf =
 test Slapd.lns get "access to dn.subtree=\"dc=example,dc=com\"
   by self write stop\n" =
   { "access to" = "dn.subtree=\"dc=example,dc=com\""
-    { "by"
-      { "who" = "self" }
+    { "by" = "self"
       { "access" = "write" }
       { "control" = "stop" } } }
 
@@ -79,16 +74,14 @@ test Slapd.lns get "access to dn.subtree=\"dc=example,dc=com\"
 test Slapd.lns get "access to dn.subtree=\"dc=example,dc=com\"
   by self\n" =
   { "access to" = "dn.subtree=\"dc=example,dc=com\""
-    { "by"
-      { "who" = "self" } } }
+    { "by" = "self" } }
 
 (* Test: Slapd.lns
      access test with who/access *)
 test Slapd.lns get "access to dn.subtree=\"dc=example,dc=com\"
   by self write\n" =
   { "access to" = "dn.subtree=\"dc=example,dc=com\""
-    { "by"
-      { "who" = "self" }
+    { "by" = "self"
       { "access" = "write" } } }
 
 (* Test: Slapd.lns
@@ -96,7 +89,6 @@ test Slapd.lns get "access to dn.subtree=\"dc=example,dc=com\"
 test Slapd.lns get "access to dn.subtree=\"dc=example,dc=com\"
   by self stop\n" =
   { "access to" = "dn.subtree=\"dc=example,dc=com\""
-    { "by"
-      { "who" = "self" }
+    { "by" = "self"
       { "control" = "stop" } } }
 


### PR DESCRIPTION
This PR compiles two **non backward compatible** changes:
- It uses smart quotes for database entries
- It changes the tree for `access to` nodes to match the official documentation.
