### PR TITLE
Allow 'ssh-ed25519' as a valid authorized_key type

### DIFF
--- a/lenses/authorized_keys.aug
+++ b/lenses/authorized_keys.aug
@@ -43,7 +43,7 @@ let key_options = [ label "options" . Build.opt_list option Sep.comma ]
 
 (* View: key_type *)
 let key_type =
-  let key_type_re = /ecdsa-sha2-nistp[0-9]+/ | /ssh-[a-z]+/
+  let key_type_re = /ecdsa-sha2-nistp[0-9]+/ | /ssh-[a-z0-9]+/
   in [ label "type" . store key_type_re ]
 
 (* View: key_comment *)

--- a/lenses/tests/test_authorized_keys.aug
+++ b/lenses/tests/test_authorized_keys.aug
@@ -24,6 +24,7 @@ let keys = "# Example keys, one of each type
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDpWrKYsEsVUyuwMN4ReBN/TMGsaUWzDKDz/uQr6MlNNM95MDK/BPyJ+DiBiNMFVLpRt3gH3eCJBLJKMuUDaTNy5uym2zNgAaAIVct6M2GHI68W3iY3Ja8/MaRPbyTpMh1O74S+McpAW1SGL2YzFchYMjTnu/kOD3lxiWNiDLvdLFZu0wPOi7CYG37VXR4Thb0cC92zqnCjaP1TwfhpEYUZoowElYkoV2vG+19O6cRm/zduYcf8hmegZKB4GFUJTtZ2gZ18XJDSQd0ykK3KPt/+bKskdrtfiOwSZAmUZmd2YuAlY6+CBn1T3UBdQntueukd0z1xhd6SX7Bl8+qyqLQ3 user@example
 ssh-dsa AAAA user@example
 ecdsa-sha2-nistp256 AAAA user@example
+ssh-ed25519 AAAA user@example
 
 # Example comments
 ssh-dsa AAAA
@@ -47,6 +48,10 @@ test Authorized_Keys.lns get keys =
     { "type" = "ecdsa-sha2-nistp256" }
     { "comment" = "user@example" }
   }
+  { "key" = "AAAA"
+    { "type" = "ssh-ed25519" }
+    { "comment" = "user@example" }
+  }
   {  }
   { "#comment" = "Example comments" }
   { "key" = "AAAA"
@@ -60,6 +65,7 @@ test Authorized_Keys.lns get keys =
 (* Variable: options *)
 let options = "# Example options
 no-pty ssh-dsa AAAA
+no-pty ssh-ed25519 AAAA
 no-pty,command=\"foo\" ssh-dsa AAAA
 no-pty,command=\"foo bar\" ssh-dsa AAAA
 no-pty,from=\"example.com,10.1.1.0/16\" ssh-dsa AAAA
@@ -74,6 +80,12 @@ test Authorized_Keys.lns get options =
       { "no-pty" }
     }
     { "type" = "ssh-dsa" }
+  }
+  { "key" = "AAAA"
+    { "options"
+      { "no-pty" }
+    }
+    { "type" = "ssh-ed25519" }
   }
   { "key" = "AAAA"
     { "options"


### PR DESCRIPTION
OpenSSH recently added a new key type named 'ssh-ed25519'; this PR allows this particular key name and loosens the `key_type_re` a bit so it doesn't need to be updated for future keys that are being added.
