### PR TITLE
Dhcpd changes

### DIFF
--- a/lenses/dhcpd.aug
+++ b/lenses/dhcpd.aug
@@ -236,14 +236,25 @@ let stmt_hardware     = [ indent
  *************************************************************************)
 (* The general case is considering options as a list *)
 
+
+let stmt_option_list  = ([ label "arg" . bare ] | [ label "arg" . quote ])
+                        . ( sep_com . ([ label "arg" . bare ] | [ label "arg" . quote ]))*
+
+let stmt_opt_multi = ([ label "arg" . bare ] | [ label "arg" .  quote ])
+                        . ( sep_com . ([ label "arg" . bare ] | [ label "arg" . quote ]))*
+
 let stmt_option_code  = [ label "label" . store word . sep_spc ]
                         . [ key "code" . sep_spc . store word ]
                         . sep_eq
                         . [ label "type" . store word ]
 
-
-let stmt_option_list  = ([ label "arg" . bare ] | [ label "arg" . quote ])
-                        . ( sep_com . ([ label "arg" . bare ] | [ label "arg" . quote ]))*
+let stmt_option_code_multi = [ label "label" . store word . sep_spc ]
+                        . [ key "code" . sep_spc . store word ]
+                        . sep_eq
+                        . del /\{/ "{"   (* needed because sep_eq handles blank space up to the brace *)
+                        . sep_spc
+                        . [ label "multi" . stmt_opt_multi ]
+                        . sep_cbr
 
 let stmt_option_basic = [ key word . sep_spc . stmt_option_list ]
 let stmt_option_extra = [ key word . sep_spc . store /true|false/ . sep_spc . stmt_option_list ]
@@ -260,10 +271,9 @@ let stmt_option1  = [ indent
 let stmt_option2  = [ indent
                         . dels "option" . label "rfc-code"
                         . sep_spc
-                        . stmt_option_code
+                        . (stmt_option_code|stmt_option_code_multi)
                         . sep_scl
                         . eos ]
-
 
 let stmt_option = stmt_option1 | stmt_option2
 

--- a/lenses/tests/test_dhcpd.aug
+++ b/lenses/tests/test_dhcpd.aug
@@ -267,6 +267,17 @@ failover peer \"redondance01\" {
     { "load balance max seconds" = "3" }
   }
 
+test Dhcpd.lns get "option test.arrays code 123 = { string, ip-address, jabberwockys };" =
+ { "rfc-code" 
+   { "label" = "test.arrays" }
+   { "code" = "123" }
+   { "multi"
+     { "arg" = "string" }
+     { "arg" = "ip-address" }
+     { "arg" = "jabberwockys" }
+   }
+ }
+
 test Dhcpd.lns get "
 option CallManager code 150 = ip-address;
 option slp-directory-agent true 10.1.1.1, 10.2.2.2;


### PR DESCRIPTION
This adds support for omapi-key and dhcpd named groups, as well as option arrays.  Here is an example of a config with these features:

```
key staging-key {
    algorithm hmac-md5;
    secret "secret==";
}

omapi-key staging-key;
option test.test code 119 = { string, string, string };

# DHCP_GROUP: Atlanta
group Atlanta {

}
```

I have many more things in my dhcpd.conf file that don't work with augeas, so I'm going to be slowly going through and probably will have a few more patches over the next few days or weeks.  The DHCP server config I'm testing is from V3.0.6 so it should be supported, but it's a very complicated config which uses things most people don't know about (it's from an ISP that was doing DOCSIS and IPTV, IP phones and various other things with the config)
