### PR TITLE
TOML lens

### DIFF
--- a/lenses/tests/test_toml.aug
+++ b/lenses/tests/test_toml.aug
@@ -1,0 +1,187 @@
+module Test_Toml =
+
+(* Test: Toml.lns
+     Global parameters *)
+test Toml.lns get "# Globals
+foo = \"bar\"\n" =
+  { "#comment" = "Globals" }
+  { "foo" = "bar" }
+
+(* Test: Toml.lns
+     Simple section/value *)
+test Toml.lns get "[foo]
+bar = \"baz\"\n" =
+  { "@table" = "foo" { "bar" = "baz" } }
+
+(* Test: Toml.lns
+     Subsections *)
+test Toml.lns get "[foo]
+title = bar
+  [foo.one]
+  hello = world\n" =
+  { "@table" = "foo"
+    { "title" = "bar" } }
+  { "@table" = "foo.one"
+    { "hello" = "world" } }
+
+(* Test: Toml.lns
+     Nested subsections *)
+test Toml.lns get "[foo]
+[foo.one]
+[foo.one.two]
+bar = baz\n" =
+  { "@table" = "foo" }
+  { "@table" = "foo.one" }
+  { "@table" = "foo.one.two"
+    { "bar" = "baz" } }
+
+(* Test: Toml.lns
+     Integer type *)
+test Toml.lns get "foo = 42
+bar = -17\n" =
+  { "foo" = "42" }
+  { "bar" = "-17" }
+
+(* Test: Toml.lns
+     Float type *)
+test Toml.lns get "foo = 3.1415
+bar = -0.01\n" =
+  { "foo" = "3.1415" }
+  { "bar" = "-0.01" }
+
+(* Test: Toml.lns
+     Boolean type *)
+test Toml.lns get "foo = true
+bar = false\n" =
+  { "foo" = "true" }
+  { "bar" = "false" }
+
+(* Test: Toml.lns
+     Datetime type *)
+test Toml.lns get "foo = 1979-05-27T07:32:00Z\n" =
+  { "foo" = "1979-05-27T07:32:00Z" }
+
+(* Test: Toml.lns
+    Array values *)
+test Toml.lns get "foo = [ \"bar\", 2 ]\n" =
+  { "foo"
+    { "elem" = "bar" }
+    { "elem" = "2" } }
+
+(* Test: Toml.lns
+     Nested arrays *)
+test Toml.lns get "foo = [ \"bar\",
+  [ 1, 2, [\"hello\"]], \"baz\"
+]\n" =
+  { "foo"
+    { "elem" = "bar" }
+    { "elem" { "elem" = "1" }
+          { "elem" = "2" }
+          { "elem" { "elem" = "hello" } } }
+    { "elem" = "baz" } }
+
+(* Test: Toml.lns
+     Arrays of tables *)
+test Toml.lns get "[[products]]
+name = \"Hammer\"
+sku = 738594937
+
+[[products]]
+
+[[products]]
+name = \"Nail\"
+sku = 284758393
+color = \"gray\"\n" =
+  { "@@table" = "products"
+    { "name" = "Hammer" }
+    { "sku" = "738594937" }
+    { } }
+  { "@@table" = "products" { } }
+  { "@@table" = "products"
+    { "name" = "Nail" }
+    { "sku" = "284758393" }
+    { "color" = "gray" } }
+
+(* Test: Toml.lns
+     Multiline values *)
+test Toml.lns get "foo = \"bar\nbaz\"\n" =
+  { "foo" = "bar\nbaz" }
+
+(* Variable: example
+     The example from https://github.com/mojombo/toml *)
+let example = "# This is a TOML document. Boom.
+
+title = \"TOML Example\"
+
+[owner]
+name = \"Tom Preston-Werner\"
+organization = \"GitHub\"
+bio = \"GitHub Cofounder & CEO\nLikes tater tots and beer.\"
+dob = 1979-05-27T07:32:00Z # First class dates? Why not?
+
+[database]
+server = \"192.168.1.1\"
+ports = [ 8001, 8001, 8002 ]
+connection_max = 5000
+enabled = true
+
+[servers]
+
+  # You can indent as you please. Tabs or spaces. TOML don't care.
+  [servers.alpha]
+  ip = \"10.0.0.1\"
+  dc = \"eqdc10\"
+
+  [servers.beta]
+  ip = \"10.0.0.2\"
+  dc = \"eqdc10\"
+
+[clients]
+data = [ [\"gamma\", \"delta\"], [1, 2] ]
+
+# Line breaks are OK when inside arrays
+hosts = [
+  \"alpha\",
+  \"omega\"
+]\n"
+
+
+(* Test: Toml.lns
+     Parse <example> *)
+test Toml.lns get example = 
+  { "#comment" = "This is a TOML document. Boom." }
+  { }
+  { "title" = "TOML Example" }
+  { }
+  { "@table" = "owner"
+    { "name" = "Tom Preston-Werner" }
+    { "organization" = "GitHub" }
+    { "bio" = "GitHub Cofounder & CEO\nLikes tater tots and beer." }
+    { "dob" = "1979-05-27T07:32:00Z" { "#comment" = "First class dates? Why not?" } }
+    { } }
+  { "@table" = "database"
+    { "server" = "192.168.1.1" }
+    { "ports" { "elem" = "8001" } { "elem" = "8001" } { "elem" = "8002" } }
+    { "connection_max" = "5000" }
+    { "enabled" = "true" }
+    { } }
+  { "@table" = "servers"
+    { }
+    { "#comment" = "You can indent as you please. Tabs or spaces. TOML don't care." } }
+  { "@table" = "servers.alpha"
+    { "ip" = "10.0.0.1" }
+    { "dc" = "eqdc10" }
+    { } }
+  { "@table" = "servers.beta"
+    { "ip" = "10.0.0.2" }
+    { "dc" = "eqdc10" }
+  { } }
+  { "@table" = "clients"
+    { "data"
+      { "elem" { "elem" = "gamma" } { "elem" = "delta" } }
+      { "elem" { "elem" = "1" } { "elem" = "2" } } }
+    { }
+    { "#comment" = "Line breaks are OK when inside arrays" }
+    { "hosts" { "elem" = "alpha" } { "elem" = "omega" } } }
+
+

--- a/lenses/tests/test_toml.aug
+++ b/lenses/tests/test_toml.aug
@@ -181,6 +181,23 @@ color = \"gray\"\n" =
       { "string" = "gray" } }
   }
 
+(* Test: Toml.entry
+     Empty inline table *)
+test Toml.entry get "name = { }\n" =
+  { "entry" = "name"
+    { "inline_table"
+      {  } } }
+
+(* Test: Toml.entry
+     Inline table *)
+test Toml.entry get "name = { first = \"Tom\", last = \"Preston-Werner\" }\n" =
+  { "entry" = "name"
+    { "inline_table" {}
+      { "entry" = "first"
+        { "string" = "Tom"  } } {}
+      { "entry" = "last"
+        { "string" = "Preston-Werner"  } } {} } }
+
 (* Variable: example
      The example from https://github.com/mojombo/toml *)
 let example = "# This is a TOML document. Boom.

--- a/lenses/tests/test_toml.aug
+++ b/lenses/tests/test_toml.aug
@@ -1,84 +1,154 @@
 module Test_Toml =
 
+(* Test: Toml.norec
+     String value *)
+test Toml.norec get "\"foo\"" = { "string" = "foo" }
+
+(* Test: Toml.norec
+     Integer value *)
+test Toml.norec get "42" = { "integer" = "42" }
+
+(* Test: Toml.norec
+     Positive integer value *)
+test Toml.norec get "+42" = { "integer" = "+42" }
+
+(* Test: Toml.norec
+     Negative integer value *)
+test Toml.norec get "-42" = { "integer" = "-42" }
+
+(* Test: Toml.norec
+     Large integer value *)
+test Toml.norec get "5_349_221" = { "integer" = "5_349_221" }
+
+(* Test: Toml.norec
+     Hexadecimal integer value *)
+test Toml.norec get "0xDEADBEEF" = { "integer" = "0xDEADBEEF" }
+
+(* Test: Toml.norec
+     Octal integer value *)
+test Toml.norec get "0o755" = { "integer" = "0o755" }
+
+(* Test: Toml.norec
+     Binary integer value *)
+test Toml.norec get "0b11010110" = { "integer" = "0b11010110" }
+
+(* Test: Toml.norec
+     Float value *)
+test Toml.norec get "3.14" = { "float" = "3.14" }
+
+(* Test: Toml.norec
+     Positive float value *)
+test Toml.norec get "+3.14" = { "float" = "+3.14" }
+
+(* Test: Toml.norec
+     Negative float value *)
+test Toml.norec get "-3.14" = { "float" = "-3.14" }
+
+(* Test: Toml.norec
+     Complex float value *)
+test Toml.norec get "-3_220.145_223e-34" = { "float" = "-3_220.145_223e-34" }
+
+(* Test: Toml.norec
+     Inf float value *)
+test Toml.norec get "-inf" = { "float" = "-inf" }
+
+(* Test: Toml.norec
+     Nan float value *)
+test Toml.norec get "-nan" = { "float" = "-nan" }
+
+(* Test: Toml.norec
+     Bool value *)
+test Toml.norec get "true" = { "bool" = "true" }
+
+(* Test: Toml.norec
+     Datetime value *)
+test Toml.norec get "1979-05-27T07:32:00Z" =
+  { "datetime" = "1979-05-27T07:32:00Z" }
+test Toml.norec get "1979-05-27 07:32:00.999999" =
+  { "datetime" = "1979-05-27 07:32:00.999999" }
+
+(* Test: Toml.norec 
+     Date value *)
+test Toml.norec get "1979-05-27" =
+  { "date" = "1979-05-27" }
+
+(* Test: Toml.norec 
+     Time value *)
+test Toml.norec get "07:32:00" =
+  { "time" = "07:32:00" }
+
+(* Test: Toml.norec
+     String value with newline *)
+test Toml.norec get "\"bar\nbaz\"" =
+  { "string" = "bar\nbaz" }
+
+(* Test: Toml.norec
+     Multiline value *)
+test Toml.norec get "\"\"\"\nbar\nbaz\n    \"\"\"" =
+  { "string_multi" = "bar\nbaz" }
+
+(* Test: Toml.norec
+     Literal string value *)
+test Toml.norec get "'bar\nbaz'" =
+  { "string_literal" = "bar\nbaz" }
+
+(* Test: Toml.array_norec
+     Empty array *)
+test Toml.array_norec get "[ ]" =
+  { "array" {} }
+
+(* Test: Toml.array_norec
+     Array of strings *)
+test Toml.array_norec get "[ \"foo\", \"bar\" ]" =
+  { "array" {}
+    { "string" = "foo" } {}
+    { "string" = "bar" } {} }
+
+(* Test: Toml.array_norec
+     Array of arrays *)
+test Toml.array_rec get "[ [ \"foo\", [ 42, 43 ] ], \"bar\" ]" =
+  { "array" {}
+    { "array" {}
+      { "string" = "foo" } {}
+      { "array" {}
+        { "integer" = "42" } {}
+        { "integer" = "43" } {} } {} } {}
+    { "string" = "bar" } {} }
+
 (* Test: Toml.lns
      Global parameters *)
 test Toml.lns get "# Globals
 foo = \"bar\"\n" =
   { "#comment" = "Globals" }
-  { "foo" = "bar" }
+  { "entry" = "foo" { "string" = "bar" } }
 
 (* Test: Toml.lns
      Simple section/value *)
 test Toml.lns get "[foo]
 bar = \"baz\"\n" =
-  { "@table" = "foo" { "bar" = "baz" } }
+  { "table" = "foo" { "entry" = "bar" { "string" = "baz" } } }
 
 (* Test: Toml.lns
      Subsections *)
 test Toml.lns get "[foo]
-title = bar
+title = \"bar\"
   [foo.one]
-  hello = world\n" =
-  { "@table" = "foo"
-    { "title" = "bar" } }
-  { "@table" = "foo.one"
-    { "hello" = "world" } }
+  hello = \"world\"\n" =
+  { "table" = "foo"
+    { "entry" = "title" { "string" = "bar" } } }
+  { "table" = "foo.one"
+    { "entry" = "hello" { "string" = "world" } } }
 
 (* Test: Toml.lns
      Nested subsections *)
 test Toml.lns get "[foo]
 [foo.one]
 [foo.one.two]
-bar = baz\n" =
-  { "@table" = "foo" }
-  { "@table" = "foo.one" }
-  { "@table" = "foo.one.two"
-    { "bar" = "baz" } }
-
-(* Test: Toml.lns
-     Integer type *)
-test Toml.lns get "foo = 42
-bar = -17\n" =
-  { "foo" = "42" }
-  { "bar" = "-17" }
-
-(* Test: Toml.lns
-     Float type *)
-test Toml.lns get "foo = 3.1415
-bar = -0.01\n" =
-  { "foo" = "3.1415" }
-  { "bar" = "-0.01" }
-
-(* Test: Toml.lns
-     Boolean type *)
-test Toml.lns get "foo = true
-bar = false\n" =
-  { "foo" = "true" }
-  { "bar" = "false" }
-
-(* Test: Toml.lns
-     Datetime type *)
-test Toml.lns get "foo = 1979-05-27T07:32:00Z\n" =
-  { "foo" = "1979-05-27T07:32:00Z" }
-
-(* Test: Toml.lns
-    Array values *)
-test Toml.lns get "foo = [ \"bar\", 2 ]\n" =
-  { "foo"
-    { "elem" = "bar" }
-    { "elem" = "2" } }
-
-(* Test: Toml.lns
-     Nested arrays *)
-test Toml.lns get "foo = [ \"bar\",
-  [ 1, 2, [\"hello\"]], \"baz\"
-]\n" =
-  { "foo"
-    { "elem" = "bar" }
-    { "elem" { "elem" = "1" }
-          { "elem" = "2" }
-          { "elem" { "elem" = "hello" } } }
-    { "elem" = "baz" } }
+bar = \"baz\"\n" =
+  { "table" = "foo" }
+  { "table" = "foo.one" }
+  { "table" = "foo.one.two"
+    { "entry" = "bar" { "string" = "baz" } } }
 
 (* Test: Toml.lns
      Arrays of tables *)
@@ -92,20 +162,24 @@ sku = 738594937
 name = \"Nail\"
 sku = 284758393
 color = \"gray\"\n" =
-  { "@@table" = "products"
-    { "name" = "Hammer" }
-    { "sku" = "738594937" }
-    { } }
-  { "@@table" = "products" { } }
-  { "@@table" = "products"
-    { "name" = "Nail" }
-    { "sku" = "284758393" }
-    { "color" = "gray" } }
-
-(* Test: Toml.lns
-     Multiline values *)
-test Toml.lns get "foo = \"bar\nbaz\"\n" =
-  { "foo" = "bar\nbaz" }
+  { "@table" = "products"
+    { "entry" = "name"
+      { "string" = "Hammer" } }
+    { "entry" = "sku"
+      { "integer" = "738594937" } }
+    {  }
+  }
+  { "@table" = "products"
+    {  }
+  }
+  { "@table" = "products"
+    { "entry" = "name"
+      { "string" = "Nail" } }
+    { "entry" = "sku"
+      { "integer" = "284758393" } }
+    { "entry" = "color"
+      { "string" = "gray" } }
+  }
 
 (* Variable: example
      The example from https://github.com/mojombo/toml *)
@@ -135,53 +209,98 @@ enabled = true
   [servers.beta]
   ip = \"10.0.0.2\"
   dc = \"eqdc10\"
+  country = \"中国\" # This should be parsed as UTF-8
 
 [clients]
-data = [ [\"gamma\", \"delta\"], [1, 2] ]
+data = [ [\"gamma\", \"delta\"], [1, 2] ] # just an update to make sure parsers support it
 
 # Line breaks are OK when inside arrays
 hosts = [
   \"alpha\",
   \"omega\"
-]\n"
+]
 
+# Products
 
-(* Test: Toml.lns
-     Parse <example> *)
-test Toml.lns get example = 
-  { "#comment" = "This is a TOML document. Boom." }
-  { }
-  { "title" = "TOML Example" }
-  { }
-  { "@table" = "owner"
-    { "name" = "Tom Preston-Werner" }
-    { "organization" = "GitHub" }
-    { "bio" = "GitHub Cofounder & CEO\nLikes tater tots and beer." }
-    { "dob" = "1979-05-27T07:32:00Z" { "#comment" = "First class dates? Why not?" } }
-    { } }
-  { "@table" = "database"
-    { "server" = "192.168.1.1" }
-    { "ports" { "elem" = "8001" } { "elem" = "8001" } { "elem" = "8002" } }
-    { "connection_max" = "5000" }
-    { "enabled" = "true" }
-    { } }
-  { "@table" = "servers"
-    { }
+  [[products]]
+  name = \"Hammer\"
+  sku = 738594937
+
+  [[products]]
+  name = \"Nail\"
+  sku = 284758393
+  color = \"gray\"
+"
+
+test Toml.lns get example =
+  { "#comment" = "This is a TOML document. Boom." } {  }
+  { "entry" = "title"
+    { "string" = "TOML Example" } } {  }
+  { "table" = "owner"
+    { "entry" = "name"
+      { "string" = "Tom Preston-Werner" } }
+    { "entry" = "organization"
+      { "string" = "GitHub" } }
+    { "entry" = "bio"
+      { "string" = "GitHub Cofounder & CEO
+Likes tater tots and beer." }
+    }
+    { "entry" = "dob"
+      { "datetime" = "1979-05-27T07:32:00Z" }
+      { "#comment" = "First class dates? Why not?" } } {  } }
+  { "table" = "database"
+    { "entry" = "server"
+      { "string" = "192.168.1.1" } }
+    { "entry" = "ports"
+      { "array" {  }
+        { "integer" = "8001" } {  }
+        { "integer" = "8001" } {  }
+        { "integer" = "8002" } {  } } }
+    { "entry" = "connection_max"
+      { "integer" = "5000" } }
+    { "entry" = "enabled"
+      { "bool" = "true" } } {  } }
+  { "table" = "servers" {  }
     { "#comment" = "You can indent as you please. Tabs or spaces. TOML don't care." } }
-  { "@table" = "servers.alpha"
-    { "ip" = "10.0.0.1" }
-    { "dc" = "eqdc10" }
-    { } }
-  { "@table" = "servers.beta"
-    { "ip" = "10.0.0.2" }
-    { "dc" = "eqdc10" }
-  { } }
-  { "@table" = "clients"
-    { "data"
-      { "elem" { "elem" = "gamma" } { "elem" = "delta" } }
-      { "elem" { "elem" = "1" } { "elem" = "2" } } }
-    { }
+  { "table" = "servers.alpha"
+    { "entry" = "ip"
+      { "string" = "10.0.0.1" } }
+    { "entry" = "dc"
+      { "string" = "eqdc10" } } {  } }
+  { "table" = "servers.beta"
+    { "entry" = "ip"
+      { "string" = "10.0.0.2" } }
+    { "entry" = "dc"
+      { "string" = "eqdc10" } }
+    { "entry" = "country"
+      { "string" = "中国" }
+      { "#comment" = "This should be parsed as UTF-8" } } {  } }
+  { "table" = "clients"
+    { "entry" = "data"
+      { "array" {  }
+        { "array"
+          { "string" = "gamma" } {  }
+          { "string" = "delta" } } {  }
+        { "array"
+          { "integer" = "1" } {  }
+          { "integer" = "2" } } {  } }
+      { "#comment" = "just an update to make sure parsers support it" } } {  }
     { "#comment" = "Line breaks are OK when inside arrays" }
-    { "hosts" { "elem" = "alpha" } { "elem" = "omega" } } }
-
+    { "entry" = "hosts"
+      { "array" {  }
+        { "string" = "alpha" } {  }
+        { "string" = "omega" } {  } } } {  }
+    { "#comment" = "Products" } {  } }
+  { "@table" = "products"
+    { "entry" = "name"
+      { "string" = "Hammer" } }
+    { "entry" = "sku"
+      { "integer" = "738594937" } } {  } }
+  { "@table" = "products"
+    { "entry" = "name"
+      { "string" = "Nail" } }
+    { "entry" = "sku"
+      { "integer" = "284758393" } }
+    { "entry" = "color"
+      { "string" = "gray" } } }
 

--- a/lenses/toml.aug
+++ b/lenses/toml.aug
@@ -44,7 +44,7 @@ let eol = Util.eol
 (* Group: value entries *)
 
 let bare_re_noquot = (/[^][", \t\r\n]/ - "#")
-let bare_re = (/[^][=,\r]/ - "#")+
+let bare_re = (/[^][,\r=]/ - "#")+
 let no_quot = /[^]["\r\n]*/
 let bare = Quote.do_dquote_opt_nil (store (bare_re_noquot . (bare_re* . bare_re_noquot)?))
 let quoted = Quote.do_dquote (store (no_quot . "#"+ . no_quot))

--- a/lenses/toml.aug
+++ b/lenses/toml.aug
@@ -1,0 +1,95 @@
+(*
+Module: Toml
+  Parses TOML files
+
+Author: Raphael Pinson <raphael.pinson@camptocamp.com>
+
+About: Reference
+  https://github.com/mojombo/toml/blob/master/README.md
+
+About: License
+   This file is licenced under the LGPL v2+, like the rest of Augeas.
+
+About: Lens Usage
+   To be documented
+
+About: Configuration files
+   This lens applies to TOML files.
+
+About: Examples
+   The <Test_Toml> file contains various examples and tests.
+*)
+
+module Toml =
+
+(* Group: base definitions *)
+
+(* View: sep
+     The key/value separator *)
+let sep = IniFile.sep "=" "="
+
+(* View: comment
+     A simple comment *)
+let comment  = IniFile.comment "#" "#"
+
+(* View: empty
+     An empty line *)
+let empty = Util.empty
+
+(* View: eol
+     An end of line *)
+let eol = Util.eol
+
+
+(* Group: value entries *)
+
+let bare_re_noquot = (/[^][", \t\r\n]/ - "#")
+let bare_re = (/[^][=,\r]/ - "#")+
+let no_quot = /[^]["\r\n]*/
+let bare = Quote.do_dquote_opt_nil (store (bare_re_noquot . (bare_re* . bare_re_noquot)?))
+let quoted = Quote.do_dquote (store (no_quot . "#"+ . no_quot))
+
+(* View: array
+     A (potentially recursive) array of values *)
+let rec array =
+     (* Not using seq to avoid counter mess up with reentrancy *)
+     let elem = [ label "elem" . bare ]
+              | [ label "elem" . quoted ]
+              | [ label "elem" . array ]
+  in let comma = del /[ \t\n]*,[ \t\n]*/ ","
+  in del /\[[ \t\n]*/ "["
+   . Build.opt_list elem comma
+   . del /[ \t\n]*\]/ "]"
+
+(* View: entry_gen
+     A generic entry *)
+let entry_gen (sto:lens) = [ Util.indent . key IniFile.entry_re
+                           . sep . Sep.opt_space . sto . (comment|eol) ]
+
+(* View: entry
+     An entry *)
+let entry = entry_gen bare
+          | entry_gen quoted
+          | entry_gen array
+
+(* Group: tables *)
+
+(* View: table_gen
+     A generic table *)
+let table_gen (name:string) (lbrack:string) (rbrack:string) =
+     let title = Util.indent . label name
+               . Util.del_str lbrack
+               . store /[^]\r\n.]+(\.[^]\r\n.]+)*/
+               . Util.del_str rbrack . eol
+  in [ title . (entry|empty|comment)* ]
+
+(* View: table
+     A table or array of tables *)
+let table = table_gen "@table" "[" "]"
+          | table_gen "@@table" "[[" "]]"
+
+(* Group: lens *)
+
+(* View: lns
+     The Toml lens *)
+let lns = (entry | empty | comment)* . table*

--- a/lenses/toml.aug
+++ b/lenses/toml.aug
@@ -50,7 +50,7 @@ let ws = del /[ \t\n]*/ ""
 let space_or_empty = [ del /[ \t\n]+/ " " ]
 
 let comma = Util.del_str "," . (space_or_empty | comment)?
-let lbrace = Util.del_str "{" . comment?
+let lbrace = Util.del_str "{" . (space_or_empty | comment)?
 let rbrace = Util.del_str "}"
 let lbrack = Util.del_str "[" . (space_or_empty | comment)?
 let rbrack = Util.del_str "]"
@@ -113,8 +113,14 @@ let array_norec = array norec
 
 let rec array_rec = array (norec | array_rec)
 
+let entry_base (value:lens) = [ label "entry" . store Rx.word . Sep.space_equal . value ]
+
+let inline_table (value:lens) = [ label "inline_table" . lbrace
+                   . ( (Build.opt_list (entry_base value) comma . space_or_empty? . rbrace)
+                      | rbrace ) ]
+
 let entry = [ label "entry" . Util.indent . store Rx.word . Sep.space_equal
-                        . (norec | array_rec) . (eol | comment) ]
+            . (norec | array_rec | inline_table norec) . (eol | comment) ]
 
 (* Group: tables *)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -217,6 +217,7 @@ lens_tests =			\
   lens-thttpd.sh		\
   lens-tmpfiles.sh		\
   lens-trapperkeeper.sh		\
+  lens-toml.sh		\
   lens-tuned.sh			\
   lens-up2date.sh		\
   lens-updatedb.sh		\


### PR DESCRIPTION
TOML was brought to my attention several times recently: https://github.com/mojombo/toml

The attached patchset covers all the examples provided in the docs.
## CAVEATS

QUOTES! Bare data types need to be clearly identified in order to force quoting only for values that are not integers, floats, booleans or datetimes… Even then, could a user want a quoted boolean? If so, we'll have to put quotes in the values, which is really ugly…

One way to fix this would be to type values strictly using subnodes for examples:

```
{ "foo" = "42" { "type" = "integer" } }
{ "bar" = "baz" { "type" = "string" } }
```

or simply marking them as quoted/bare:

```
{ "foo" = "bar" { "quoted" } }
```

or

```
{ "foo" = "true" { "bare" } }
```
