### PR TITLE
Fix for readline add_history with interactive mode

### DIFF
--- a/src/augtool.c
+++ b/src/augtool.c
@@ -404,7 +404,7 @@ static int run_command(const char *line) {
     int result;
 
     result = aug_srun(aug, stdout, line);
-    if (isatty(fileno(rl_instream)))
+    if (isatty(fileno(stdin)))
         add_history(line);
     return result;
 }
@@ -468,10 +468,12 @@ static int main_loop(void) {
                 echo_commands = true;
 
                 // reopen in stream
-                if ((rl_instream = fopen("/dev/tty", "r")) == NULL) {
+                fclose(stdin);
+                if ((stdin = fopen("/dev/tty", "r")) == NULL) {
                     perror("Failed to open terminal for reading");
                     return -1;
                 }
+                rl_instream = stdin;
 
                 // reopen stdout and stream to a tty if originally silenced or
                 // not connected to a tty, for full interactive mode

--- a/src/augtool.c
+++ b/src/augtool.c
@@ -404,7 +404,7 @@ static int run_command(const char *line) {
     int result;
 
     result = aug_srun(aug, stdout, line);
-    if (isatty(fileno(stdin)))
+    if (isatty(fileno(rl_instream)))
         add_history(line);
     return result;
 }


### PR DESCRIPTION
If you use interactive mode, augtool never adds anything to history that
you type once the input becomes a normal tty.

This is because it was checking stdin, which as far as the system is
concerned is still !isatty().  I'm not sure of the better way to fix
this.  An freopen stdin with /dev/tty might be good, but just changing
the add_history check to use rl_instream seems to work fine as long as
it doesn't cause unintended effects.