### PR TITLE
pam: partial support of arguments enclosed in [ .. ]

### DIFF
--- a/lenses/pam.aug
+++ b/lenses/pam.aug
@@ -30,9 +30,9 @@ module Pam =
   (* Allowed types *)
   let types = /(auth|session|account|password)/i
 
-  (* This isn't entirely right: arguments enclosed in [ .. ] are allowed   *)
-  (* and should be parsed as one                                           *)
-  let argument = /[^#\n \t]+/
+  (* This isn't entirely right: arguments enclosed in [ .. ] can contain  *)
+  (* a ']' if escaped with a '\' and can be on multiple lines ('\')       *)
+  let argument = /(\[[^]#\n]+\]|[^[#\n \t][^#\n \t]*)/
 
   let comment = Util.comment
   let comment_or_eol = Util.comment_or_eol

--- a/lenses/tests/test_pam.aug
+++ b/lenses/tests/test_pam.aug
@@ -41,6 +41,14 @@ session    optional     pam_keyinit.so force revoke
       { "module" = "pam_gnome_keyring.so" }
     }
 
+  test Pam.lns get "session    optional    pam_motd.so [motd=/etc/bad example]\n" =
+    { "1"
+      { "type" = "session" }
+      { "control" = "optional" }
+      { "module" = "pam_motd.so" }
+      { "argument" = "[motd=/etc/bad example]" }
+    }
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)


### PR DESCRIPTION
Pam.conf(5) manual page states 'module-arguments are a space separated list
of tokens that can be used to modify the specific behavior of the given PAM.
Such arguments will be documented for each individual module. Note, if you
wish to include spaces in an argument, you should surround that argument with
square brackets.', but such arguments are not supported by the pam lenses, as
expressed in the comments 'This isn't entirely right: arguments enclosed in
[ .. ] are allowed and should be parsed as one'.

This commit add basic support of such arguments via the regex:
'/([[^]#\n]+]|[^[#\n \t][^#\n \t]*)/'

It is only a partial support as some corner cases are not covered:
- Multi line arguments (lines ending with '\')
- Arguments containing a '[' (escaped via '\')
