### PR TITLE
Fix ubuntu bug 1302638

### DIFF
--- a/lenses/krb5.aug
+++ b/lenses/krb5.aug
@@ -22,6 +22,7 @@ let closebr = del /[ \t]*\}/ "}"
 *)
 
 let realm_re = /[A-Z][.a-zA-Z0-9-]*/
+let realm_anycase_re = /[A-Za-z][.a-zA-Z0-9-]*/
 let app_re = /[a-z][a-zA-Z0-9_]*/
 let name_re = /[.a-zA-Z0-9_-]+/
 
@@ -91,7 +92,7 @@ let realms =
                    (subsec_entry name_re eq comment)* . closebr . eol ] in
   let v4subsec = [ indent . key /host|plain/ . eq_openbr .
                    (subsec_entry name_re eq comment)* . closebr . eol ] in
-  let realm = [ indent . label "realm" . store realm_re .
+  let realm = [ indent . label "realm" . store (realm_re|realm_anycase_re) .
                   eq_openbr . (option|subsec|(v4_name_convert v4subsec))* .
                   closebr . eol ] in
     record "realms" (realm|comment)

--- a/lenses/krb5.aug
+++ b/lenses/krb5.aug
@@ -85,7 +85,7 @@ let appdefaults =
 let realms =
   let simple_option = /kdc|admin_server|database_module|default_domain/
       |/v4_realm|auth_to_local(_names)?|master_kdc|kpasswd_server/
-      |/admin_server|ticket_lifetime|pkinit_anchors/ in
+      |/admin_server|ticket_lifetime|pkinit_anchors|krb524_server/ in
   let subsec_option = /v4_instance_convert/ in
   let option = subsec_entry simple_option eq comment in
   let subsec = [ indent . key subsec_option . eq_openbr .

--- a/lenses/tests/test_krb5.aug
+++ b/lenses/tests/test_krb5.aug
@@ -96,8 +96,10 @@ module Test_krb5 =
                 kdc = krb5auth1.stanford.edu
                 kdc = krb5auth2.stanford.edu
                 kdc = krb5auth3.stanford.edu
+		master_kdc = krb5auth1.stanford.edu
                 admin_server = krb5-admin.stanford.edu
                 default_domain = stanford.edu
+		krb524_server = krb524.stanford.edu
         }
 
 [instancemapping]
@@ -369,8 +371,10 @@ test Krb5.lns get fermi_str =
       { "kdc" = "krb5auth1.stanford.edu" }
       { "kdc" = "krb5auth2.stanford.edu" }
       { "kdc" = "krb5auth3.stanford.edu" }
+      { "master_kdc" = "krb5auth1.stanford.edu" }
       { "admin_server" = "krb5-admin.stanford.edu" }
       { "default_domain" = "stanford.edu" }
+      { "krb524_server" = "krb524.stanford.edu" }
     }
     { } }
   { "instancemapping"

--- a/lenses/tests/test_krb5.aug
+++ b/lenses/tests/test_krb5.aug
@@ -92,6 +92,13 @@ module Test_krb5 =
                         }
                 }
 	}
+        stanford.edu = {
+                kdc = krb5auth1.stanford.edu
+                kdc = krb5auth2.stanford.edu
+                kdc = krb5auth3.stanford.edu
+                admin_server = krb5-admin.stanford.edu
+                default_domain = stanford.edu
+        }
 
 [instancemapping]
  afs = {
@@ -357,6 +364,13 @@ test Krb5.lns get fermi_str =
           { "rcmd" = "host" }
         }
       }
+    }
+    { "realm" = "stanford.edu"
+      { "kdc" = "krb5auth1.stanford.edu" }
+      { "kdc" = "krb5auth2.stanford.edu" }
+      { "kdc" = "krb5auth3.stanford.edu" }
+      { "admin_server" = "krb5-admin.stanford.edu" }
+      { "default_domain" = "stanford.edu" }
     }
     { } }
   { "instancemapping"

--- a/src/parser.y
+++ b/src/parser.y
@@ -19,6 +19,11 @@
 
 #define YYDEBUG 1
 
+  /*
+    Work around 'undefined reference to YYID' - j.bokma@rug.nl 20140409
+   */
+#define YYID(n) (n)
+
 int augl_parse_file(struct augeas *aug, const char *name, struct term **term);
 
 typedef void *yyscan_t;


### PR DESCRIPTION
Opening this PR as requested by Raphaël Pinson in https://bugs.launchpad.net/ubuntu/+source/augeas/+bug/1302638
This is my first time doing that, so if I'm doing it wrong, please correct me.

When building, at the linking stage I run into this issue: https://github.com/hercules-team/augeas/issues/88
My topic branch `fix-YYID_undefined_reference' trivially works around that. I should 've bisected the tree, but haven't the time. I suspect it may actually be an autotools issue?

This fix-ubuntu-bug-1302638 makes the krb5.aug lens process lower case realms in the [realms] section, but not in the [appdefaults]. So there are still valid krb5.conf that the lense will not parse. This seems to be by design: in order to be able to label an entry 'app' or 'realm' in the appdefaults section.
I see only ways out of this situation that break backward compatibility.

Thanks for reviewing!
Jurjen