### PR TITLE
comma-separated lists in nagios configs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,7 +21,9 @@
                 handle hex IDs and hyphens, as present in rt_dsfield, RHBZ#1063961
     * Keepalived: Add more virtual/real server settings and checks, RHBZ#1064388
     * Krb5: permit braces in values when not in sub-section, RHBZ#1066419
-    * NagiosConfig and NagiosObjects: Fix documentation (Simon Sehier)
+    * NagiosCfg: Parse authorized_* and allowed_hosts values
+                 as lists (GH issue #117)
+    * NagiosCfg and NagiosObjects: Fix documentation (Simon Sehier)
     * NetworkManager: Use the Quote module, support # in values (no eol comments)
     * Pam: Add partial support for arguments enclosed in [] (Vincent Brillault)
     * Redis: Allow empty quoted values (GH issue #115)

--- a/lenses/nagioscfg.aug
+++ b/lenses/nagioscfg.aug
@@ -21,13 +21,30 @@ autoload xfm
 (************************************************************************
  * Group: Utility variables/functions
  ************************************************************************)
-(* View: param_def
-    define a field *)
-let param_def =
+
+(* Variable: list_param_re
+    A list of parameters parsed as lists *)
+let list_param_re = /authorized_for_[A-Za-z0-9_]+/
+                  | "allowed_hosts"
+
+(* View: simple_param
+    A simple key/value parameter *)
+let simple_param =
      let space_in  = /[^ \t\n][^\n=]*[^ \t\n]|[^ \t\n]/
-  in key /[A-Za-z0-9_]+/
+  in key (/[A-Za-z][A-Za-z0-9_]*/ - list_param_re)
    . Sep.space_equal
    . store space_in
+
+(* View: list_param
+    A list parameter *)
+let list_param =
+     let elem = [ seq "list" . store Rx.word ]
+  in counter "list" . key list_param_re
+   . Sep.space_equal . Build.opt_list elem Sep.comma
+
+(* View: param_def
+    define a field *)
+let param_def = simple_param | list_param
 
 (* View: macro_def
     Macro line, as used in resource.cfg *)

--- a/lenses/tests/test_nagioscfg.aug
+++ b/lenses/tests/test_nagioscfg.aug
@@ -87,3 +87,14 @@ test NagiosCfg.lns get "$USER1$=/usr/local/libexec/nagios\n" =
 
 test NagiosCfg.lns get "$USER3$=somepassword\n" =
   { "$USER3$" = "somepassword" }
+
+(* Test: NagiosCfg.lns
+     Parse authorized_* values as lists *)
+test NagiosCfg.lns get "authorized_for_system_information=nagiosadmin,theboss
+authorized_for_system_commands=nagiosadmin
+allowed_hosts=127.0.0.1,10.0.0.1\n" =
+  { "authorized_for_system_information" { "1" = "nagiosadmin" }
+                                        { "2" = "theboss" } }
+  { "authorized_for_system_commands" { "1" = "nagiosadmin" } }
+  { "allowed_hosts" { "1" = "127.0.0.1" }
+                    { "2" = "10.0.0.1" } }


### PR DESCRIPTION
Augeas Team,

We'd like to request the implementation of a useful feature: comma-separated lists in nagios config files (currently handled by nagioscfg.aug); for example,

```
key=val1,val2,...,valn
```

would be parsed into n subnodes in augeas' abstract syntax tree. Please let us know how likely (or how soon) this feature will be implemented.

Thanks for considering...
