### PR TITLE
Error loading /etc/apache2/envvars with Shellvars lense

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,7 +25,9 @@
     * NetworkManager: Use the Quote module, support # in values (no eol comments)
     * Pam: Add partial support for arguments enclosed in [] (Vincent Brillault)
     * Redis: Allow empty quoted values (GH issue #115)
-    * Shellvars: handle case statements with same-line ';;', RHBZ#1033799
+    * Shellvars: Handle case statements with same-line ';;', RHBZ#1033799
+                 Allow any kind of quoted values in block
+                 conditions (GH issue #118)
     * Sshd: Allow all types of entries in Match groups (GH issue #75)
     * Sssd: Allow ; for comments
     * Squid: Support configuration files for squid 3 (Mykola Nikishov)

--- a/lenses/shellvars.aug
+++ b/lenses/shellvars.aug
@@ -41,13 +41,22 @@ module Shellvars =
   let dbquot = /``[^` \t\n;]+``/
   let dollar_assign = /\$\([^\)#\n]*\)/
 
-  let sto_to_semicol = store /[^#; \t\n][^#;\n]+[^#; \t\n]|[^#; \t\n]+/
+  let anyquot = (dquot|squot)+ | bquot | dbquot | dollar_assign
+
+  let to_semicol_re = /[^#; \t\n][^#;\n]+[^#; \t\n]|[^#; \t\n]+/
+  let sto_to_semicol = store to_semicol_re
+
+  let sto_to_semicol_quot =
+       let no_semicol_re = /[^"'#;\n]/
+    in let no_semicol_spc_re = /[^"'#; \t\n]/
+    in let multi_chars = no_semicol_spc_re . (no_semicol_re|anyquot)+ . no_semicol_spc_re
+    in store (no_semicol_spc_re | multi_chars)
 
   (* Array values of the form '(val1 val2 val3)'. We do not handle empty *)
   (* arrays here because of typechecking headaches. Instead, they are    *)
   (* treated as a simple value                                           *)
   let array =
-    let array_value = store (char+ | (dquot | squot)+ | bquot | dbquot | dollar_assign) in
+    let array_value = store (char+ | anyquot) in
     del /\([ \t]*/ "(" . counter "values" .
       [ seq "values" . array_value ] .
       [ del /[ \t\n]+/ " " . seq "values" . array_value ] *
@@ -57,8 +66,7 @@ module Shellvars =
   (* but fairly close.                                                *)
   let simple_value =
     let empty_array = /\([ \t]*\)/ in
-      store (char* | (dquot | squot)+
-            | bquot | dbquot | dollar_assign | empty_array)
+      store (char* | anyquot | empty_array)
 
   let export = [ key "export" . Util.del_ws_spc ]
   let kv = Util.indent . export? . key key_re
@@ -101,7 +109,7 @@ module Shellvars =
   let generic_cond_start (start_kw:string) (lbl:string)
                          (then_kw:string) (contents:lens) =
       keyword_label start_kw lbl . Sep.space
-      . sto_to_semicol . semicol_eol
+      . sto_to_semicol_quot . semicol_eol
       . keyword then_kw . eol
       . contents
 

--- a/lenses/tests/test_shellvars.aug
+++ b/lenses/tests/test_shellvars.aug
@@ -470,6 +470,20 @@ esac\n" =
       { "@case_entry" = "1"
         { "TestVar" = "\"test1\"" } } }
 
+(* Test: Shellvars.lns
+     Support `##` bashism in conditions (GH issue #118) *)
+test Shellvars.lns get "if [ \"${APACHE_CONFDIR##/etc/apache2-}\" != \"${APACHE_CONFDIR}\" ] ; then
+    SUFFIX=\"-${APACHE_CONFDIR##/etc/apache2-}\"
+else
+    SUFFIX=
+fi\n" =
+  { "@if" = "[ \"${APACHE_CONFDIR##/etc/apache2-}\" != \"${APACHE_CONFDIR}\" ]"
+    { "SUFFIX" = "\"-${APACHE_CONFDIR##/etc/apache2-}\"" }
+    { "@else"
+      { "SUFFIX" = "" }
+    }
+  }
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)


### PR DESCRIPTION
When trying to load Debian wheezy's default /etc/apache2/envvars with Shellvars lense, I get:

```
# augtool -t 'Shellvars incl /etc/apache2/envvars' -A -L
augtool> print
/augeas
/augeas/root = "/"
/augeas/context = "/files"
/augeas/variables
/augeas/version = "1.2.0"
/augeas/version/save
/augeas/version/save/mode[1] = "backup"
/augeas/version/save/mode[2] = "newfile"
/augeas/version/save/mode[3] = "noop"
/augeas/version/save/mode[4] = "overwrite"
/augeas/version/defvar
/augeas/version/defvar/expr
/augeas/version/pathx
/augeas/version/pathx/functions
/augeas/version/pathx/functions/count
/augeas/version/pathx/functions/glob
/augeas/version/pathx/functions/label
/augeas/version/pathx/functions/last
/augeas/version/pathx/functions/position
/augeas/version/pathx/functions/regexp
/augeas/save = "overwrite"
/augeas/span = "disable"
/augeas/load
/augeas/load/Shellvars
/augeas/load/Shellvars/lens = "Shellvars.lns"
/augeas/load/Shellvars/incl = "/etc/apache2/envvars"
/augeas/files
/augeas/files/etc
/augeas/files/etc/apache2
/augeas/files/etc/apache2/envvars
/augeas/files/etc/apache2/envvars/path = "/files/etc/apache2/envvars"
/augeas/files/etc/apache2/envvars/mtime = "1396598308"
/augeas/files/etc/apache2/envvars/lens = "Shellvars.lns"
/augeas/files/etc/apache2/envvars/lens/info = "/usr/share/augeas/lenses/dist/shellvars.aug:167.12-.99:"
/augeas/files/etc/apache2/envvars/error = "parse_failed"
/augeas/files/etc/apache2/envvars/error/pos = "179"
/augeas/files/etc/apache2/envvars/error/line = "7"
/augeas/files/etc/apache2/envvars/error/char = "22"
/augeas/files/etc/apache2/envvars/error/lens = "/usr/share/augeas/lenses/dist/shellvars.aug:167.12-.99:"
/augeas/files/etc/apache2/envvars/error/message = "Syntax error"
/files
```

File is:

```
# envvars - default environment variables for apache2ctl

# this won't be correct after changing uid
unset HOME

# for supporting multiple apache2 instances
if [ "${APACHE_CONFDIR##/etc/apache2-}" != "${APACHE_CONFDIR}" ] ; then
    SUFFIX="-${APACHE_CONFDIR##/etc/apache2-}"
else
    SUFFIX=
fi

# Since there is no sane way to get the parsed apache2 config in scripts, some
# settings are defined via environment variables and then used in apache2ctl,
# /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
export APACHE_RUN_USER=www-data
export APACHE_RUN_GROUP=www-data
export APACHE_PID_FILE=/var/run/apache2$SUFFIX.pid
export APACHE_RUN_DIR=/var/run/apache2$SUFFIX
export APACHE_LOCK_DIR=/var/lock/apache2$SUFFIX
# Only /var/log/apache2 is handled by /etc/logrotate.d/apache2.
export APACHE_LOG_DIR=/var/log/apache2$SUFFIX

## The locale used by some modules like mod_dav
export LANG=C
## Uncomment the following line to use the system default locale instead:
#. /etc/default/locale

export LANG

## The command to get the status for 'apache2ctl status'.
## Some packages providing 'www-browser' need '--dump' instead of '-dump'.
#export APACHE_LYNX='www-browser -dump'
```

Is it supposed to work ?
