### PR TITLE
Shellvars: Allow (almost) any command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -45,6 +45,7 @@
                  @pattern subnode) (Kaarle Ritvanen) (Issue #265)
                  add eval builtin support;
                  add alias builtin support;
+                 allow (almost) any command
     * Simplelines: parse OpenBSD's hostname.if(5)
                    files (Jasper Lievisse Adriaanse) (Issue #252)
     * Tmpfiles: new lens to parse systemd's tempfiles.d configuration

--- a/lenses/shellvars.aug
+++ b/lenses/shellvars.aug
@@ -116,6 +116,11 @@ module Shellvars =
                                             . ( action "&&" "@and" | action "||" "@or" )*
     in Util.indent . label "@condition" . (cond "[" "]" | cond "[[" "]]")
 
+  let command =
+       let reserved_key = /exit|shift|return|ulimit|unset|export|source|\.|if|for|select|while|until|then|else|fi|done|case|eval|alias/
+    in let word = /[A-Za-z0-9_.-\/]+/
+    in Util.indent . label "@command" . store (word - reserved_key)
+     . [ Sep.space . label "@arg" . sto_to_semicol]?
 
 (************************************************************************
  * Group:                 CONDITIONALS AND LOOPS
@@ -185,6 +190,7 @@ module Shellvars =
         | entry_eol_item condition
         | entry_eol_item eval
         | entry_eol_item alias
+        | entry_eol_item command
 
   let entry_noeol =
     let entry_item (item:lens) = [ item ] in
@@ -197,6 +203,7 @@ module Shellvars =
         | entry_item condition
         | entry_item eval
         | entry_item alias
+        | entry_item command
 
   let rec rec_entry =
     let entry = comment | entry_eol | rec_entry in

--- a/lenses/tests/test_shellvars.aug
+++ b/lenses/tests/test_shellvars.aug
@@ -609,7 +609,17 @@ esac\n" =
   { "@condition" = "-f $FILENAME"
     { "type" = "[" }
     { "@and" = "do this" }
-    { "@or" = "or that" }
+    { "@or" = "or that" } }
+
+(* Test: Shellvars.lns
+     Parse (almost) any command *)
+test Shellvars.lns get "echo foobar 'and this is baz'
+/usr/local/bin/myscript.sh with args\n" =
+  { "@command" = "echo"
+    { "@arg" = "foobar 'and this is baz'" }
+  }
+  { "@command" = "/usr/local/bin/myscript.sh"
+    { "@arg" = "with args" }
   }
 
 (* Local Variables: *)

--- a/lenses/tests/test_shellvars.aug
+++ b/lenses/tests/test_shellvars.aug
@@ -622,6 +622,14 @@ test Shellvars.lns get "echo foobar 'and this is baz'
     { "@arg" = "with args" }
   }
 
+(* Test: Shellvars.lns
+     Support pipes in commands *)
+test Shellvars.lns get "echo \"$STRING\" | grep foo\n" =
+  { "@command" = "echo"
+    { "@arg" = "\"$STRING\"" }
+    { "@command" = "grep"
+      { "@arg" = "foo" } } }
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)


### PR DESCRIPTION
This PR intends to parse more shellvar files by trying to parse most commands.

E.g.:

```shell
$ cat /usr/local/bin/sh2js 
#!/bin/sh
cd /opt/shjs-0.6/
./sh2js.pl $@

$ augtool -I lenses/ --noautoload -t "Shellvars.lns incl /usr/local/bin/sh2js" print /files
/files
/files/usr
/files/usr/local
/files/usr/local/bin
/files/usr/local/bin/sh2js
/files/usr/local/bin/sh2js/#comment = "!/bin/sh"
/files/usr/local/bin/sh2js/@command[1] = "cd"
/files/usr/local/bin/sh2js/@command[1]/@arg = "/opt/shjs-0.6/"
/files/usr/local/bin/sh2js/@command[2] = "./sh2js.pl"
/files/usr/local/bin/sh2js/@command[2]/@arg = "$@"
```