### PR TITLE
Parse all device.map files under /boot

### DIFF
--- a/lenses/device_map.aug
+++ b/lenses/device_map.aug
@@ -21,7 +21,7 @@ module Device_map =
 
   let lns = ( empty | comment | map ) *
 
-  let xfm = transform lns (incl "/boot/grub/device.map")
+  let xfm = transform lns (incl "/boot/*/device.map")
 
 (* Local Variables: *)
 (* mode: caml *)


### PR DESCRIPTION
The device_map.aug lense is capable of parsing device.map files from grub and grub2 environments (the format is identical). However, some distributions (such as SUSE) place grub2 device.map files in /boot/grub2 instead of /boot/grub. This patch causes the lense to find this file under any /boot subdirectory. 

(This wildcard approach seems more appropriate than adding /boot/grub2/device.map to the incl list, but either one works.)
