### PR TITLE
Add support for setting script-security

### DIFF
--- a/lenses/openvpn.aug
+++ b/lenses/openvpn.aug
@@ -63,6 +63,7 @@ let empty   = Util.empty
  *   - mute => num
  *   - ns-cert-type => "server"
  *   - resolv-retry => "infinite"
+ *   - script-security => [0-3] (execve|system)?
  *************************************************************************)
 
 let single_ip  = "local"

--- a/lenses/tests/test_openvpn.aug
+++ b/lenses/tests/test_openvpn.aug
@@ -48,6 +48,7 @@ log-append  openvpn.log
 verb 3
 mute 20
 management 10.0.5.20 1193 /etc/openvpn/mpass
+script-security 3 system
 "
 
 test OpenVPN.lns get server_conf =
@@ -116,6 +117,7 @@ test OpenVPN.lns get server_conf =
       { "server"  = "10.0.5.20" }
       { "port"	  = "1193" }
       { "pwfile"  = "/etc/openvpn/mpass" } }
+  { "script-security" = "3 system" }
 
 
 


### PR DESCRIPTION
Setting script security is especially needed when using learn-address, which we can already set via augeas but is useless without script-security.
