### PR TITLE
Multipath: add support for rr_min_io_rq

### DIFF
--- a/lenses/multipath.aug
+++ b/lenses/multipath.aug
@@ -44,7 +44,7 @@ let common_setting =
  |kv "failback" (Rx.integer | /immediate|manual/)
  |kv "rr_weight" /priorities|uniform/
  |kv "no_path_retry" (Rx.integer | /fail|queue/)
- |kv "rr_min_io" Rx.integer
+ |kv /rr_min_io(_rq)?/ Rx.integer
 
 let default_setting =
   kv "polling_interval" Rx.integer

--- a/lenses/tests/test_multipath.aug
+++ b/lenses/tests/test_multipath.aug
@@ -78,6 +78,7 @@ devices {
 		hardware_handler	\"0\"
 		failback		15
 		rr_weight		priorities
+		rr_min_io_rq		75
 		no_path_retry		queue
 	}
 	device {
@@ -159,6 +160,7 @@ test Multipath.lns get conf =
       { "hardware_handler" = "0" }
       { "failback" = "15" }
       { "rr_weight" = "priorities" }
+      { "rr_min_io_rq" = "75" }
       { "no_path_retry" = "queue" } }
     { "device"
       { "vendor" = "COMPAQ  " }


### PR DESCRIPTION
The rr_min_io_rq parameter was added in RHEL 6.2. This change allows for the new parameter in addition to the older rr_min_io.
