### PR TITLE
* src/augrun.c: remove unused "filename" argument from dump-xml command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@
     * Add seq to vim syntax highlight (Robert Drake)
     * Update augtool.1 man page with new commands and --span, RHBZ#1100077
     * augtool autocomplete includes command aliases, RHBZ#1100184
+    * Remove unused "filename" argument from dump-xml command, RHBZ#1100106
   - Lens changes/additions
     * AptPreferences: Support spaces in origin fields
     * Chrony: New lens to parse /etc/chrony.conf

--- a/man/augtool.1
+++ b/man/augtool.1
@@ -266,11 +266,10 @@ the \s-1FILE\s0 will be excluded from the \s-1LENS. FILE\s0 may contain wildcard
 .SS "\s-1READ COMMANDS\s0"
 .IX Subsection "READ COMMANDS"
 The following commands are used to retrieve data from the Augeas tree.
-.IP "\fBdump-xml\fR \fI[<\s-1PATH\s0>]\fR \fI[<\s-1FILENAME\s0>]\fR" 4
-.IX Item "dump-xml [<PATH>] [<FILENAME>]"
+.IP "\fBdump-xml\fR \fI[<\s-1PATH\s0>]\fR" 4
+.IX Item "dump-xml [<PATH>]"
 Print entries in the tree as \s-1XML.\s0 If \s-1PATH\s0 is given, printing starts there,
-otherwise the whole tree is printed. If \s-1FILENAME\s0 is given, the \s-1XML\s0 is saved
-to the given file.
+otherwise the whole tree is printed.
 .IP "\fBget\fR <\s-1PATH\s0>" 4
 .IX Item "get <PATH>"
 Print the value associated with \s-1PATH\s0

--- a/man/augtool.pod
+++ b/man/augtool.pod
@@ -165,11 +165,10 @@ The following commands are used to retrieve data from the Augeas tree.
 
 =over 4
 
-=item B<dump-xml> I<[E<lt>PATHE<gt>]> I<[E<lt>FILENAMEE<gt>]>
+=item B<dump-xml> I<[E<lt>PATHE<gt>]>
 
 Print entries in the tree as XML. If PATH is given, printing starts there,
-otherwise the whole tree is printed. If FILENAME is given, the XML is saved
-to the given file.
+otherwise the whole tree is printed.
 
 =item B<get> E<lt>PATHE<gt>
 

--- a/src/augrun.c
+++ b/src/augrun.c
@@ -937,21 +937,16 @@ static const struct command_def cmd_print_def = {
 
 static void cmd_dump_xml(struct command *cmd) {
     const char *path = arg_value(cmd, "path");
-    const char *filename = arg_value(cmd, "filename");
     xmlNodePtr xmldoc;
     int r;
 
     r = aug_to_xml(cmd->aug, path, &xmldoc, 0);
     if (r < 0)
         ERR_REPORT(cmd, AUG_ECMDRUN,
-                   "XML export of path %s to file %s failed", path, filename);
+                   "XML export of path %s failed", path);
 
     xmlElemDump(stdout, NULL, xmldoc);
     printf("\n");
-
-    if (filename != NULL) {
-        printf("Saving to %s\n", filename);
-    }
 
     xmlFreeNode(xmldoc);
 }
@@ -959,8 +954,6 @@ static void cmd_dump_xml(struct command *cmd) {
 static const struct command_opt_def cmd_dump_xml_opts[] = {
     { .type = CMD_PATH, .name = "path", .optional = true,
       .help = "print this subtree" },
-    { .type = CMD_NONE, .name = "filename", .optional = true,
-      .help = "save to this file" },
     CMD_OPT_DEF_LAST
 };
 
@@ -969,7 +962,7 @@ static const struct command_def cmd_dump_xml_def = {
     .opts = cmd_dump_xml_opts,
     .handler = cmd_dump_xml,
     .synopsis = "print a subtree as XML",
-    .help = "Export entries in the tree as XML. If PATH is given, printing starts there,\n otherwise the whole tree is printed. If FILENAME is given, the XML is saved\n to the given file."
+    .help = "Export entries in the tree as XML. If PATH is given, printing starts there,\n otherwise the whole tree is printed."
 };
 
 static void cmd_transform(struct command *cmd) {


### PR DESCRIPTION
Fixes RHBZ#1100106

As mentioned on https://www.redhat.com/archives/augeas-devel/2014-June/msg00000.html, this does nothing at the moment and I'd prefer to simply remove it rather than implement it.  (It'd be the only command with this option.)
