### PR TITLE
Dnsmasq: add structure to 'address' and 'server' options

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,8 @@
     * Dhcpd: stmt_string quoted blocks no longer store quote marks
              (incompatible change),
              many changes to support more record types (Robert Drake)
+    * Dnsmasq: Parse the structure of the 'address' and 'server' options
+               (incompatible change) (Kaarle Ritvanen)
     * Known_Hosts: New lens for SSH known hosts files
     * Group: NIS support
     * Grub: handle "foreground" option, RHBZ#1059383

--- a/lenses/dnsmasq.aug
+++ b/lenses/dnsmasq.aug
@@ -17,26 +17,42 @@ module Dnsmasq =
  *                           USEFUL PRIMITIVES
  *************************************************************************)
 
-let eol        = Util.eol
-let spc        = Util.del_ws_spc
-let comment    = Util.comment
-let empty      = Util.empty
+let eol          = Util.eol
+let spc          = Util.del_ws_spc
+let comment      = Util.comment
+let empty        = Util.empty
 
-let sep_eq     = del /=/ "="
-let sto_to_eol = store /([^ \t\n].*[^ \t\n]|[^ \t\n])/
+let sep_eq       = Sep.equal
+let sto_to_eol   = store /([^ \t\n].*[^ \t\n]|[^ \t\n])/
+
+let slash        = Util.del_str "/"
+let sto_no_slash = store /([^\/ \t\n]+)/
+let domains      = slash . [ label "domain" . sto_no_slash . slash ]+
 
 (************************************************************************
- *                               ENTRIES
+ *                            SIMPLE ENTRIES
  *************************************************************************)
 
-let entry_re   = /[A-Za-z0-9._-]+/
+let entry_re   = Rx.word - /(address|server)/
 let entry      = [ key entry_re . (sep_eq . sto_to_eol)? . eol ]
+
+(************************************************************************
+ *                          STRUCTURED ENTRIES
+ *************************************************************************)
+
+let address       = [ key "address" . sep_eq . domains . sto_no_slash . eol ]
+
+let server        =
+     let port     = [ Build.xchgs "#" "port" . store Rx.integer ]
+  in let source   = [ Build.xchgs "@" "source" . store /[^#\/ \t\n]+/ . port? ]
+  in let srv_spec = store /(#|([^#@\/ \t\n]+))/ . port? . source?
+  in [ key "server" . sep_eq . domains? . srv_spec? . eol ]
 
 (************************************************************************
  *                                LENS
  *************************************************************************)
 
-let lns = (comment|empty|entry) *
+let lns = (comment|empty|address|server|entry) *
 
 let filter            = incl "/etc/dnsmasq.conf"
                       . incl "/etc/dnsmasq.d/*"

--- a/lenses/tests/test_dnsmasq.aug
+++ b/lenses/tests/test_dnsmasq.aug
@@ -6,6 +6,16 @@ let conf = "# Configuration file for dnsmasq.
 
 conf-dir=/etc/dnsmasq.d
 selfmx
+
+address=/foo.com/bar.net/10.1.2.3
+
+server=10.4.5.6#1234
+server=/bar.com/foo.net/10.7.8.9
+server=/foo.org/bar.org/10.3.2.1@eth0#5678
+server=/baz.org/#
+server=/baz.net/#@eth1
+server=10.6.5.4#1234@eth0#5678
+server=/qux.com/qux.net/
 "
 
 test Dnsmasq.lns get conf =
@@ -15,3 +25,40 @@ test Dnsmasq.lns get conf =
   {}
   { "conf-dir" = "/etc/dnsmasq.d" }
   { "selfmx" }
+  {}
+  { "address" = "10.1.2.3"
+    { "domain" = "foo.com" }
+    { "domain" = "bar.net" }
+  }
+  {}
+  { "server" = "10.4.5.6"
+    { "port" = "1234" }
+  }
+  { "server" = "10.7.8.9"
+    { "domain" = "bar.com" }
+    { "domain" = "foo.net" }
+  }
+  { "server" = "10.3.2.1"
+    { "domain" = "foo.org" }
+    { "domain" = "bar.org" }
+    { "source" = "eth0"
+      { "port" = "5678" }
+    }
+  }
+  { "server" = "#"
+    { "domain" = "baz.org" }
+  }
+  { "server" = "#"
+    { "domain" = "baz.net" }
+    { "source" = "eth1" }
+  }
+  { "server" = "10.6.5.4"
+    { "port" = "1234" }
+    { "source" = "eth0"
+      { "port" = "5678" }
+    }
+  }
+  { "server"
+    { "domain" = "qux.com" }
+    { "domain" = "qux.net" }
+  }


### PR DESCRIPTION
This is a backwards incompatible change.