### PR TITLE
inifiles with trailing comments are broken

### DIFF
--- a/lenses/tests/test_inifile.aug
+++ b/lenses/tests/test_inifile.aug
@@ -54,7 +54,7 @@ test_ace = value_with_trailing_comment #
           { "test_ace" = "value with spaces" }
 	  { "#comment"  = "comment with colon" }
           { "test_ace" = "value_with_trailing_comment"
-             { "#comment" } }
+             {} }
 	  {} }
 
   test lns_ace put conf_ace after
@@ -377,7 +377,7 @@ ticket_243 = \"value1;value2#value3\" # end of line comment
     { "test_ace" = "value with spaces" }
     { "#comment" = "comment with colon" }
     { "test_ace" = "value_with_trailing_comment"
-      { "#comment" } }
+      {} }
     {  }
   }
 
@@ -395,7 +395,7 @@ ticket_243 = \"value1;value2#value3\" # end of line comment
     { "test_ace" = "value with spaces" }
     { "#comment" = "comment with colon" }
     { "test_ace" = "value_with_trailing_comment"
-      { "#comment" } }
+      {} }
     {  }
   }
   


### PR DESCRIPTION
This is a pullrequest with failing tests but not with functionality fix.

In version 0.10 empty comments after values in inifiles worked fine.
After the upgrade the augeas started to crash with the following error on these:

```
$  augparse test_inifile.aug                                                                                          * master 1c89f56
test_inifile.aug:47.2-58.7:exception thrown in test
test_inifile.aug:47.7-.27:exception: Get did not match entire input
    Lens: /usr/share/augeas/lenses/dist/inifile.aug:497.25-.43:
    Error encountered at 8:0 (135 characters into string)
    <paces"\n; comment with colon\n|=|test_ace = value_with_traili>

    Tree generated so far:
    /#comment = "comment with sharp"
/(none)
/section1
/section1/test_ace[1] = "value"
/section1/test_ace[1]/#comment = "end of line comment"
/section1/test_ace[2]
/section1/test_ace[3] = "value with spaces"
/section1/#comment = "comment with colon"


Syntax error in lens definition
Failed to load test_inifile.aug
```

I'm using augeas-tools, augeas-lenses and libaugeas0 1.2.0-0ubuntu1 from Ubuntu 14.04

I'd happy to create not only a test for that but also a fix but atm I can't quite understand how to debug this into getting it fixed.
