### PR TITLE
Add MySQL Sandbox config location

### DIFF
--- a/lenses/mysql.aug
+++ b/lenses/mysql.aug
@@ -41,6 +41,7 @@ let lns    = (comment|IniFile.empty)* . (record|includedir)*
 let filter = (incl "/etc/mysql/my.cnf")
              . (incl "/etc/mysql/conf.d/*.cnf")
              . (incl "/etc/my.cnf")
+             . (incl (Sys.getenv("HOME") . "/sandboxes/*/my.sandbox.cnf"))
 
 let xfm = transform lns filter
 


### PR DESCRIPTION
By default MySQL Sandbox ( http://mysqlsandbox.net/ ) puts configs in ~/sandboxes/<sandbox_name>/my.sandbox.cnf
