### PR TITLE
Systemd: parse environment variables where only value is quoted

### DIFF
--- a/lenses/systemd.aug
+++ b/lenses/systemd.aug
@@ -132,9 +132,11 @@ let entry_env =
      let envkv (env_val:lens) = key env_key . Util.del_str "=" . env_val
      (* bare has no spaces, and is optionally quoted *)
   in let bare = Quote.do_quote_opt (envkv (store /[^#'" \t\n]*[^#'" \t\n\\]/)?)
+  in let bare_dqval = envkv (store /"[^#" \t\n]*[^#" \t\n\\]"/)
+  in let bare_sqval = envkv (store /'[^#' \t\n]*[^#' \t\n\\]'/)
      (* quoted has at least one space, and must be quoted *)
   in let quoted = Quote.do_quote (envkv (store /[^#"'\n]*[ \t]+[^#"'\n]*/))
-  in let envkv_quoted = [ bare ] | [ quoted ]
+  in let envkv_quoted = [ bare ] | [ bare_dqval ] | [ bare_sqval ] | [ quoted ]
   in entry_fn entry_env_kw ( Build.opt_list envkv_quoted value_sep )
 
 

--- a/lenses/tests/test_systemd.aug
+++ b/lenses/tests/test_systemd.aug
@@ -204,6 +204,8 @@ Environment=LANG= LANGUAGE= LC_CTYPE= LC_NUMERIC= LC_TIME= LC_COLLATE= LC_MONETA
 Environment=LANG=C\
 FOO=BAR
 Environment=\"LANG=foo bar\" FOO=BAR
+Environment=OPTIONS=\"-LS0-6d\"
+Environment=OPTIONS='-LS0-6d'
 "
 (* Test: Systemd.lns *)
 test Systemd.lns get env =
@@ -238,6 +240,12 @@ test Systemd.lns get env =
     { "Environment"
       { "LANG" = "foo bar" }
       { "FOO" = "BAR" }
+    }
+    { "Environment"
+      { "OPTIONS" = "\"-LS0-6d\"" }
+    }
+    { "Environment"
+      { "OPTIONS" = "'-LS0-6d'" }
     }
   }
 


### PR DESCRIPTION
Fixes regression introduced in 5226ae7, which added support to parse fully
quoted "NAME=value" environment vars.  To support both, this commit stores
the quotes in the value if it's only the value quoted.

Fixes RHBZ#1138508

---

@raphink would you mind double checking this, to make sure I haven't missed a better way to support both without putting quotes in the stored value?  I think any other solution introduces ambiguities in the put direction.
