### PR TITLE
xml.aug: Allow nmotoken rather than plain word after !DOCTYPE

### DIFF
--- a/lenses/tests/test_xml.aug
+++ b/lenses/tests/test_xml.aug
@@ -74,9 +74,9 @@ test Xml.decl_def_item get
    !DOCTYPE tags are mapped in "!DOCTYPE" nodes.
    The associated system attribute is mapped in a "SYSTEM" subnode. *)
 test Xml.doctype get
- "<!DOCTYPE greeting SYSTEM \"hello.dtd\">" =
+ "<!DOCTYPE greeting:foo SYSTEM \"hello.dtd\">" =
 
-  { "!DOCTYPE" = "greeting"
+  { "!DOCTYPE" = "greeting:foo"
     { "SYSTEM" = "hello.dtd" }
   }
 

--- a/lenses/xml.aug
+++ b/lenses/xml.aug
@@ -53,7 +53,7 @@ let decl          = [ label "#decl" . sep_spc .
                       store /[^> \t\n\r]|[^> \t\n\r][^>\t\n\r]*[^> \t\n\r]/ ]
 
 let decl_def (r:regexp) (b:lens) = [ dels "<" . key r .
-                                     sep_spc . store word .
+                                     sep_spc . store nmtoken .
                                      b . sep_osp . del_end_simple ]
 
 let elem_def      = decl_def /!ELEMENT/ decl


### PR DESCRIPTION
Currently, the lens only accepts a word after the `!DOCTYPE` keyword.

A - valid - doctype can have the following form :

``` xml
<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
```

making the xml file invalid with the current lens. This commits aims for the lens
to accept nmtoken rather than strict word after the `!DOCTYPE` keyword.

Close #143 
