### PR TITLE
xml.aug: Support for external entities

### DIFF
--- a/lenses/tests/test_xml.aug
+++ b/lenses/tests/test_xml.aug
@@ -96,6 +96,23 @@ test Xml.doctype get "<!DOCTYPE foo [
     }
   }
 
+(* Test: Xml.doctype
+   This is an example of a !DOCTYPE tag with !ELEMENT children tags and
+   external entities. *)
+test Xml.doctype get "<!DOCTYPE foo [
+<!ELEMENT bar SYSTEM \"foo\">
+<!ELEMENT baz PUBLIC \"bar\">
+]>" =
+
+  { "!DOCTYPE" = "foo"
+    { "!ELEMENT" = "bar"
+      { "SYSTEM" = "foo" }
+    }
+    { "!ELEMENT" = "baz"
+      { "PUBLIC" = "bar" }
+    }
+  }
+
 (* Group: Attributes *)
 
 (* Variable: att_def1 *)

--- a/lenses/xml.aug
+++ b/lenses/xml.aug
@@ -65,7 +65,8 @@ let att_type      = /CDATA|ID|IDREF|IDREFS|ENTITY|ENTITIES|NMTOKEN|NMTOKENS/ |
 
 let id_def        = [ sep_spc . key /PUBLIC/ .
                       [ label "#literal" . sep_spc . sto_dquote ]* ] |
-                    [ sep_spc . key /SYSTEM/ . sep_spc . sto_dquote ]
+                    [ sep_spc . key /SYSTEM/ . sep_spc . sto_dquote ] |
+                    [ sep_spc . label "#decl" . sto_dquote ]*
 
 let notation_def  = decl_def /!NOTATION/ id_def
 
@@ -78,7 +79,7 @@ let att_def       = counter "att_id" .
 
 let att_list_def = decl_def /!ATTLIST/ att_def
 
-let entity_def    = decl_def /!ENTITY/ ([sep_spc . label "#decl" . sto_dquote ])
+let entity_def    = decl_def /!ENTITY/ id_def
 
 let decl_def_item = elem_def | entity_def | att_list_def | notation_def
 


### PR DESCRIPTION
Currently the Xml.lns fails parsing an external entity defined in the DOCTYPE
due to the "entity_def" lacking support for the optional "SYSTEM" and "PUBLIC"
attributes of the entity element[1].

[1] http://www.w3.org/TR/2006/REC-xml11-20060816/#sec-external-ent

Close #142 