### PR TITLE
Update cgconfig lens, comments at the end of the line break cgconfig

### DIFF
--- a/lenses/cgconfig.aug
+++ b/lenses/cgconfig.aug
@@ -23,8 +23,9 @@ module Cgconfig =
 
    let indent  = Util.indent
    let eol     = Util.eol
-   let comment = Util.comment
+   let comment = eol . Util.comment_eol
    let empty   = Util.empty
+   let optional_eol = del /[ \t]*\n*/ "\n"
 
    let id        = /[a-zA-Z0-9_\/.-]+/
    let name      = /[^#= \n\t{}\/]+/
@@ -42,7 +43,7 @@ module Cgconfig =
  ******************************************)
 
    let key_value (key_rx:regexp) (val_rx:regexp) =
-     [ indent . key key_rx . eq . store val_rx
+     [ optional_eol . indent . key key_rx . eq . store val_rx
          . indent . Util.del_str ";" ]
 
    (* Function to deal with bracketted entries *)


### PR DESCRIPTION
Hi,

Currently cgconfig write comments at the end of the line.

``` bash
$ augtool
augtool> set /files/etc/cgconfig.conf/mount/blkio /cgroup/blkio
augtool> set /files/etc/cgconfig.conf/mount/#comment 'Managed by puppet:openshift_origin'
augtool> save
Saved 1 file(s)

$ cat /etc/cgconfig.conf
mount {blkio=/cgroup/blkio; # Managed by puppet:openshift_origin
}
```

It breaks the cgconfig service, because only line starting with ’#’ is considered a comment line and is ignored.

``` bash
$ /etc/init.d/cgconfig restart
Stopping cgconfig service:                                 [  OK  ]
Starting cgconfig service: error at line number 2 at #:syntax error
Error: failed to parse file /etc/cgconfig.conf
/sbin/cgconfigparser; error loading /etc/cgconfig.conf: Have multiple paths for the same namespace
Failed to parse /etc/cgconfig.conf                         [FAIL]
```

With this PR, the generated cgconfig.conf looks like this:

``` bash
$ cat /etc/cgconfig.conf
mount {
blkio=/cgroup/blkio;
 # Managed by puppet:openshift_origin
}
```

And the cgconfig service works

``` bash
$ /etc/init.d/cgconfig restart
Stopping cgconfig service:                                 [  OK  ]
Starting cgconfig service:                                 [  OK  ]
```

This issue was detected here:
https://github.com/openshift/puppet-openshift_origin/issues/301
