### PR TITLE
CentOs 6.5 basic install errors reading several configs

### DIFF
--- a/lenses/authorized_keys.aug
+++ b/lenses/authorized_keys.aug
@@ -33,7 +33,9 @@ let option =
   in let flag_re = "cert-authority" | "no-agent-forwarding"
                  | "no-port-forwarding" | "no-pty" | "no-user-rc"
                  | "no-X11-forwarding"
-  in let option_value = Util.del_str "\"" . store /[^\n"]+/ . Util.del_str "\""
+  in let option_value = Util.del_str "\""
+                      . store /((\\\\")?[^\\\n"]*)+/
+                      . Util.del_str "\""
   in Build.key_value kv_re Sep.equal option_value
    | Build.flag flag_re
 

--- a/lenses/tests/test_authorized_keys.aug
+++ b/lenses/tests/test_authorized_keys.aug
@@ -115,3 +115,14 @@ test Authorized_Keys.lns get options =
     }
     { "type" = "ssh-dsa" }
   }
+
+(* Test: Authorized_keys.lns
+     GH 165 *)
+test Authorized_keys.lns get "command=\"echo 'Please login as the user \\\"blaauser\\\" rather than the user \\\"root\\\".';echo;sleep 10\" ssh-rsa DEADBEEF== username1\n" =
+  { "key" = "DEADBEEF=="
+    { "options"
+      { "command" = "echo 'Please login as the user \\\"blaauser\\\" rather than the user \\\"root\\\".';echo;sleep 10" }
+    }
+    { "type" = "ssh-rsa" }
+    { "comment" = "username1" }
+  }


### PR DESCRIPTION
<pre>
# augtool print /augeas//error
/augeas/files/etc/sysconfig/iptables.save/error = "parse_failed"
/augeas/files/etc/sysconfig/iptables.save/error/pos = "64"
/augeas/files/etc/sysconfig/iptables.save/error/line = "2"
/augeas/files/etc/sysconfig/iptables.save/error/char = "0"
/augeas/files/etc/sysconfig/iptables.save/error/lens = "/usr/share/augeas/lenses/dist/shellvars.aug:163.12-.99:"
/augeas/files/etc/sysconfig/iptables.save/error/message = "Syntax error"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-431.29.2.el6.x86_64.conf/error = "parse_failed"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-431.29.2.el6.x86_64.conf/error/pos = "307"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-431.29.2.el6.x86_64.conf/error/line = "6"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-431.29.2.el6.x86_64.conf/error/char = "0"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-431.29.2.el6.x86_64.conf/error/lens = "/usr/share/augeas/lenses/dist/ldso.aug:31.10-.55:"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-431.29.2.el6.x86_64.conf/error/message = "Iterated lens matched less than it should"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-358.el6.x86_64.conf/error = "parse_failed"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-358.el6.x86_64.conf/error/pos = "307"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-358.el6.x86_64.conf/error/line = "6"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-358.el6.x86_64.conf/error/char = "0"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-358.el6.x86_64.conf/error/lens = "/usr/share/augeas/lenses/dist/ldso.aug:31.10-.55:"
/augeas/files/etc/ld.so.conf.d/kernel-2.6.32-358.el6.x86_64.conf/error/message = "Iterated lens matched less than it should"
/augeas/files/root/.ssh/authorized_keys/error = "parse_failed"
/augeas/files/root/.ssh/authorized_keys/error/pos = "0"
/augeas/files/root/.ssh/authorized_keys/error/line = "1"
/augeas/files/root/.ssh/authorized_keys/error/char = "0"
/augeas/files/root/.ssh/authorized_keys/error/lens = "/usr/share/augeas/lenses/dist/authorized_keys.aug:64.10-.56:"
/augeas/files/root/.ssh/authorized_keys/error/message = "Iterated lens matched less than it should"
</pre>
---
<pre>
cat /etc/sysconfig/iptables.save 
# Generated by iptables-save v1.4.7 on Mon Oct 13 18:23:43 2014
*filter
:INPUT ACCEPT [1:52]
:FORWARD ACCEPT [0:0]
:OUTPUT ACCEPT [1:628]
:SSHD_IN - [0:0]
-A INPUT -s 10.0.0.0/8 -p tcp -m multiport --dports 80 -m comment --comment "010 accpet  ssh incoming requests from 10  to sshd in chain" -m state --state NEW -j ACCEPT 
-A SSHD_IN -s 10.0.0.0/8 -p tcp -m comment --comment "002 accpet  ssh incoming requests from 10  to sshd in chain" -j ACCEPT 
-A SSHD_IN -s 10.0.0.0/8 -p tcp -m comment --comment "003 accpet  ssh incoming requests from 68.87.107.203  to sshd in chain" -j ACCEPT 
COMMIT
# Completed on Mon Oct 13 18:23:43 2014
</pre>
---
<pre>
cat /etc/ld.so.conf.d/kernel-2.6.32-431.29.2.el6.x86_64.conf 
# This directive teaches ldconfig to search in nosegneg subdirectories
# and cache the DSOs there with extra bit 1 set in their hwcap match
# fields.  In Xen guest kernels, the vDSO tells the dynamic linker to
# search in nosegneg subdirectories and to match this extra hwcap bit
# in the ld.so.cache file.
hwcap 1 nosegneg
</pre>
---
<pre>
cat /etc/ld.so.conf.d/kernel-2.6.32-358.el6.x86_64.conf 
# This directive teaches ldconfig to search in nosegneg subdirectories
# and cache the DSOs there with extra bit 1 set in their hwcap match
# fields.  In Xen guest kernels, the vDSO tells the dynamic linker to
# search in nosegneg subdirectories and to match this extra hwcap bit
# in the ld.so.cache file.
hwcap 1 nosegneg
</pre>
---
<pre>
cat /root/.ssh/authorized_keys 
no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command="echo 'Please login as the user \"blaauser\" rather than the user \"root\".';echo;sleep 10" ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA+PWfTW2Qaa6fPk771g3ToEMhtUzkC0hxo0hOEQuXnN9Z/TJO02RgxMHIqmFS4+w2CfgBVUtRnax2chiW6CFGXPeZ98UwLO+CukFGYC7x3cIlbzYJS4kKKzfhtQvylPE8vw/cvNlY0umBbu+V3VNxQl6MT5/ubHp7uTtWdFFlPDGqpQOk8w4YOjRpab/8iauFoQmDQWoIeoqBIAT4OICvvz/eqyVwuwVPTikVc7/LgkZSKMQZmnAWhkpjq0+pZ21wOpfBFincQNP0PJ6epY5cQ6ZsejcGr6x9DOGmVtlXP1oAlTRHDzLf16aXw3yU1jWNBKpo2TRbf1s5fPOflucQfw== username1
</pre>
---

thats all.
