### PR TITLE
Added config.d files to the nginx lens filter

### DIFF
--- a/lenses/nginx.aug
+++ b/lenses/nginx.aug
@@ -58,6 +58,7 @@ let lns = ( Util.comment | Util.empty | simple | block )*
 
 (* Variable: filter *)
 let filter = incl "/etc/nginx/nginx.conf"
+           . incl "/etc/nginx/conf.d/*.conf"
            . incl "/usr/portage/www-servers/nginx/files/nginx.conf"
 
 let xfm = transform lns filter


### PR DESCRIPTION
Used by systems running Red Hat or a variant.

Once merged, I'll open up an issue to address parse errors with the default nginx config files.
