### PR TITLE
NagiosCfg lens broken for /etc/nagios.cfg on CentOS 6 due to spaces

### DIFF
--- a/lenses/nagioscfg.aug
+++ b/lenses/nagioscfg.aug
@@ -26,7 +26,7 @@ autoload xfm
 let param_def =
      let space_in  = /[^ \t\n][^\n=]*[^ \t\n]|[^ \t\n]/
   in key /[A-Za-z0-9_]+/
-   . Sep.space_equal
+   . Sep.opt_space . Sep.equal . Sep.opt_space
    . store space_in
 
 (* View: macro_def


### PR DESCRIPTION
Hi,

I can't get the NagiosCfg lens to work with Nagios on CentOS 6, I believe because of 16c5c80772c9da2f3a2b6f36ae7801da50a15652 .
This change introduces spaces surrounding the equal sign, e.g.:

```
# Before
key=value
# After
key = value
```

...and Nagios doesn't like this syntax:

```
Error in configuration file '/etc/nagios/nagios.cfg' - Line 1350 (UNKNOWN VARIABLE)
   Error processing main config file!
```

Line 1350 being:

```
cfg_dir = /etc/nagios/static
```

Changing it manual to `cfg_dir=/etc/nagios/static` makes Nagios happy.

I'm using Nagios v3.5.1 on CentOS 6, and Augeas v1.0.0. I also tried with the latest version of the lens from this repo but it's the same thing. It has also been reported by [someone else on the mailing list](https://www.mail-archive.com/augeas-devel@redhat.com/msg05209.html).

I'm not sure what the right solution is if spaces are needed for other Nagios config files (`commands.cfg`, `resource.cfg`), perhaps we need 2 separate lenses?

Cheers,

Nico
