### PR TITLE
known_hosts lens doesn't handle aliases

### DIFF
--- a/lenses/known_hosts.aug
+++ b/lenses/known_hosts.aug
@@ -5,8 +5,7 @@ Module: Known_Hosts
 Author: Raphaël Pinson <raphink@gmail.com>
 
 About: Reference
-  This lens ensures that conf files included in ActiveMQ /FuseMQ are properly
-  handled by Augeas.
+  This lens manages OpenSSH's known_hosts files. See `man 8 sshd` for reference.
 
 About: License
   This file is licenced under the LGPL v2+, like the rest of Augeas.

--- a/lenses/known_hosts.aug
+++ b/lenses/known_hosts.aug
@@ -29,17 +29,35 @@ module Known_Hosts =
 
 autoload xfm
 
+
+(* View: marker
+  The marker is optional, but if it is present then it must be one of
+  “@cert-authority”, to indicate that the line contains a certification
+  authority (CA) key, or “@revoked”, to indicate that the key contained
+  on the line is revoked and must not ever be accepted.
+  Only one marker should be used on a key line.
+*)
+let marker = [ key /@(revoked|cert-authority)/ . Sep.space ]
+
+
+(* View: type
+  Bits, exponent, and modulus are taken directly from the RSA host key;
+  they can be obtained, for example, from /etc/ssh/ssh_host_key.pub.
+  The optional comment field continues to the end of the line, and is not used.
+*)
+let type = [ label "type" . store Rx.neg1 ]
+
+
 (* View: entry
      A known_hosts entry *)
 let entry =
-  let alias = [ label "alias" . store Rx.neg1 ]
-  in [ Util.indent . seq "entry" . store Rx.neg1
+     let alias = [ label "alias" . store Rx.neg1 ]
+  in let key = [ label "key" . store Rx.neg1 ]
+  in [ Util.indent . seq "entry" . marker?
+     . store Rx.neg1
      . (Sep.comma . Build.opt_list alias Sep.comma)?
-     . Sep.space
-     . [ label "type" . store Rx.no_spaces ]
-     . Sep.space
-     . [ label "key" . store Rx.no_spaces ]
-     . Util.eol ]
+     . Sep.space . type . Sep.space . key
+     . Util.comment_or_eol ]
 
 (* View: lns
      The known_hosts lens *)

--- a/lenses/tests/test_known_hosts.aug
+++ b/lenses/tests/test_known_hosts.aug
@@ -8,15 +8,41 @@ module Test_Known_Hosts =
 (* Test: Known_Hosts.lns
      Simple get test *)
 test Known_Hosts.lns get "# A comment
-foo.example.com,foo,bar ecdsa-sha2-nistp256 AAABBBDKDFX=
+foo.example.com,foo ecdsa-sha2-nistp256 AAABBBDKDFX=
+bar.example.com,bar ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN9NJSjDZh4+K6WBS16iX7ZndnwbGsaEbLwHlCEhZmef
 |1|FhUqf1kMlRWNfK6InQSAmXiNiSY=|jwbKFwD4ipl6D0k6OoshmW7xOao= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIvNOU8OedkWalFmoFcJWP3nasnCLx6M78F9y0rzTQtplggNd0dvR0A4SQOBfHInmk5dH6YGGcpT3PM3cJBR7rI=\n" =
   { "#comment" = "A comment" }
   { "1" = "foo.example.com"
     { "alias" = "foo" }
-    { "alias" = "bar" }
     { "type" = "ecdsa-sha2-nistp256" }
     { "key" = "AAABBBDKDFX=" } }
-  { "2" = "|1|FhUqf1kMlRWNfK6InQSAmXiNiSY=|jwbKFwD4ipl6D0k6OoshmW7xOao="
+  { "2" = "bar.example.com"
+    { "alias" = "bar" }
+    { "type" = "ssh-ed25519" }
+    { "key" = "AAAAC3NzaC1lZDI1NTE5AAAAIN9NJSjDZh4+K6WBS16iX7ZndnwbGsaEbLwHlCEhZmef" } }
+  { "3" = "|1|FhUqf1kMlRWNfK6InQSAmXiNiSY=|jwbKFwD4ipl6D0k6OoshmW7xOao="
     { "type" = "ecdsa-sha2-nistp256" }
     { "key" = "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIvNOU8OedkWalFmoFcJWP3nasnCLx6M78F9y0rzTQtplggNd0dvR0A4SQOBfHInmk5dH6YGGcpT3PM3cJBR7rI=" } }
 
+(* Test: Known_Hosts.lns
+      Markers *)
+test Known_Hosts.lns get "@revoked * ssh-rsa AAAAB5W
+@cert-authority *.mydomain.org,*.mydomain.com ssh-rsa AAAAB5W\n" =
+  { "1" = "*"
+    { "@revoked" }
+    { "type" = "ssh-rsa" }
+    { "key" = "AAAAB5W" } }
+  { "2" = "*.mydomain.org"
+    { "@cert-authority" }
+    { "alias" = "*.mydomain.com" }
+    { "type" = "ssh-rsa" }
+    { "key" = "AAAAB5W" } }
+
+(* Test: Known_Hosts.lns
+      Eol comment *)
+test Known_Hosts.lns get "@revoked * ssh-rsa AAAAB5W # this is revoked\n" =
+  { "1" = "*"
+    { "@revoked" }
+    { "type" = "ssh-rsa" }
+    { "key" = "AAAAB5W" }
+    { "#comment" = "this is revoked" } }


### PR DESCRIPTION
The new `known_hosts` lens doesn't handle host aliases as demonstrated by this adjusted test case: https://gist.github.com/jasperla/0af79e173b70553638ad
