### PR TITLE
Allow '+' in groupnames

### DIFF
--- a/lenses/sudoers.aug
+++ b/lenses/sudoers.aug
@@ -105,7 +105,7 @@ let sto_to_com_host = store /[^,=:#() \t\n\\]+/
 Escaped spaces and NIS domains and allowed*)
 let sto_to_com_user =
       let nis_re = /([A-Z]([-A-Z0-9]|(\\\\[ \t]))*+\\\\\\\\)/
-   in let user_re = /[%+@a-z]([-A-Za-z0-9._]|(\\\\[ \t]))*/
+   in let user_re = /[%+@a-z]([-A-Za-z0-9._+]|(\\\\[ \t]))*/
    in let alias_re = /[A-Z_]+/
    in store ((nis_re? . user_re) | alias_re)
 

--- a/lenses/tests/test_sudoers.aug
+++ b/lenses/tests/test_sudoers.aug
@@ -315,3 +315,14 @@ test Sudoers.spec get "%GrOup ALL = (ALL) ALL\n" =
         { "runas_user" = "ALL" } }
     }
   }
+
+(* Test: Sudoers.spec
+     allow + in user-/groupnames *)
+test Sudoers.spec get "group+user somehost = ALL\n" =
+  { "spec"
+    { "user" = "group+user" }
+    { "host_group"
+      { "host" = "somehost" }
+      { "command" = "ALL" }
+    }
+  }


### PR DESCRIPTION
Samba users may use '+' as separator between group- and username e.g. from Active Directory