### PR TITLE
PageKite: Allow more fine-grained control of 'service_on' entries

### DIFF
--- a/lenses/tests/test_pagekite.aug
+++ b/lenses/tests/test_pagekite.aug
@@ -64,21 +64,27 @@ test Pagekite.lns get conf_service =
   {  }
   { "service_on"
     { "1"
-      { "source" = "raw/22:@kitename" }
-      { "destination" = "localhost:22" }
+      { "protocol" = "raw/22" }
+      { "kitename" = "@kitename" }
+      { "backend_host" = "localhost" }
+      { "backend_port" = "22" }
       { "secret" = "@kitesecret" }
     }
   }
   { "service_on"
     { "2"
-      { "source" = "http:192.168.0.1" }
-      { "destination" = "127.0.0.1:80" }
+      { "protocol" = "http" }
+      { "kitename" = "192.168.0.1" }
+      { "backend_host" = "127.0.0.1" }
+      { "backend_port" = "80" }
     }
   }
   { "service_on"
     { "3"
-      { "source" = "https:yourhostname,fqdn" }
-      { "destination" = "127.0.0.1:443" }
+      { "protocol" = "https" }
+      { "kitename" = "yourhostname,fqdn" }
+      { "backend_host" = "127.0.0.1" }
+      { "backend_port" = "443" }
     }
   }
 


### PR DESCRIPTION
The definition of a pagekite 'service_on' entry is now more detailed.

Instead of the current parameters 'source' and 'destination', the new lens now allows these parameters (in addition to 'secret'): protocol, kitename, backend_host, backend_port