### PR TITLE
Fixes #194 - Allow multiple interfaces in redis bind command

### DIFF
--- a/lenses/redis.aug
+++ b/lenses/redis.aug
@@ -54,7 +54,7 @@ redis-server.
 *)
 let standard_entry =
      let reserved_k = "save" | "rename-command" | "slaveof"
-                    | "client-output-buffer-limit"
+                    | "bind" | "client-output-buffer-limit"
   in let entry_noempty = [ indent . key k . del_ws_spc
                          . Quote.do_quote_opt_nil (store v) . eol ]
   in let entry_empty = [ indent . key (k - reserved_k) . del_ws_spc
@@ -81,6 +81,12 @@ port number. The same rules as standard_entry apply for quoting, comments and
 whitespaces.
 *)
 let slaveof_entry = [ indent . key slaveof . del_ws_spc . ip . del_ws_spc . port . eol ]
+
+(* View: bind_entry
+The "bind" entry can be passed one or several ip addresses
+*)
+let bind = /bind/
+let bind_entry = [ indent . key bind . [ label "ip" . del_ws_spc . store Rx.ip ]+ . eol ]
 
 let renamecmd = /rename-command/
 let from = [ label "from" . Quote.do_quote_opt_nil (store Rx.word) ]
@@ -112,6 +118,7 @@ let entry = standard_entry
           | save_entry
 	  | renamecmd_entry
 	  | slaveof_entry
+	  | bind_entry
 	  | client_output_buffer_limit_entry
 
 (* View: lns

--- a/lenses/redis.aug
+++ b/lenses/redis.aug
@@ -55,7 +55,7 @@ redis-server.
 let standard_entry =
      let reserved_k = "save" | "rename-command" | "slaveof"
                     | "bind" | "client-output-buffer-limit"
-  in let entry_noempty = [ indent . key (k -reserved_k) . del_ws_spc
+  in let entry_noempty = [ indent . key (k - reserved_k) . del_ws_spc
                          . Quote.do_quote_opt_nil (store v) . eol ]
   in let entry_empty = [ indent . key (k - reserved_k) . del_ws_spc
                          . dquote . store "" . dquote . eol ]

--- a/lenses/redis.aug
+++ b/lenses/redis.aug
@@ -55,7 +55,7 @@ redis-server.
 let standard_entry =
      let reserved_k = "save" | "rename-command" | "slaveof"
                     | "bind" | "client-output-buffer-limit"
-  in let entry_noempty = [ indent . key k . del_ws_spc
+  in let entry_noempty = [ indent . key (k -reserved_k) . del_ws_spc
                          . Quote.do_quote_opt_nil (store v) . eol ]
   in let entry_empty = [ indent . key (k - reserved_k) . del_ws_spc
                          . dquote . store "" . dquote . eol ]

--- a/lenses/redis.aug
+++ b/lenses/redis.aug
@@ -86,7 +86,7 @@ let slaveof_entry = [ indent . key slaveof . del_ws_spc . ip . del_ws_spc . port
 The "bind" entry can be passed one or several ip addresses
 *)
 let bind = /bind/
-let bind_entry = [ indent . key bind . [ seq "bind_ip" . del_ws_spc . store Rx.ip ]+ . eol ]
+let bind_entry = [ indent . key bind . [ seq "bind_ip" . del_ws_spc . Quote.do_quote_opt_nil (store Rx.ip) ]+ . eol ]
 
 let renamecmd = /rename-command/
 let from = [ label "from" . Quote.do_quote_opt_nil (store Rx.word) ]

--- a/lenses/redis.aug
+++ b/lenses/redis.aug
@@ -86,7 +86,7 @@ let slaveof_entry = [ indent . key slaveof . del_ws_spc . ip . del_ws_spc . port
 The "bind" entry can be passed one or several ip addresses
 *)
 let bind = /bind/
-let bind_entry = [ indent . key bind . [ label "ip" . del_ws_spc . store Rx.ip ]+ . eol ]
+let bind_entry = [ indent . key bind . [ seq "bind_ip" . del_ws_spc . store Rx.ip ]+ . eol ]
 
 let renamecmd = /rename-command/
 let from = [ label "from" . Quote.do_quote_opt_nil (store Rx.word) ]

--- a/lenses/tests/test_redis.aug
+++ b/lenses/tests/test_redis.aug
@@ -184,7 +184,7 @@ test Redis.lns get "notify-keyspace-events \"\"\n" =
 
 (* Test: Redis.lns
      Multiple bind IP addresses (GH issue #194) *)
-test Redis.lns get "bind 127.0.0.1 ::1 192.168.1.1\n" =
+test Redis.lns get "bind 127.0.0.1 \"::1\" 192.168.1.1\n" =
   { "bind"
   { "1" = "127.0.0.1" }
   { "2" = "::1" }

--- a/lenses/tests/test_redis.aug
+++ b/lenses/tests/test_redis.aug
@@ -150,7 +150,9 @@ test Redis.lns get redis_conf =
   { "#comment" = "If you want you can bind a single interface, if the bind option is not" }
   { "#comment" = "specified all the interfaces will listen for incoming connections." }
   { }
-  { "bind" = "127.0.0.1" }
+  { "bind"
+  { "1" = "127.0.0.1" }
+  }
   { }
   { "#comment" = "Note: you can disable saving at all commenting all the \"save\" lines." }
   { }
@@ -179,3 +181,12 @@ test Redis.lns get redis_conf =
      Empty value (GH issue #115) *)
 test Redis.lns get "notify-keyspace-events \"\"\n" =
   { "notify-keyspace-events" = "" }
+
+(* Test: Redis.lns
+     Multiple bind IP addresses (GH issue #194) *)
+test Redis.lns get "bind 127.0.0.1 \"::1\" 192.168.1.1\n" =
+  { "bind"
+  { "1" = "127.0.0.1" }
+  { "2" = "::1" }
+  { "3" = "192.168.1.1" }
+  }

--- a/lenses/tests/test_redis.aug
+++ b/lenses/tests/test_redis.aug
@@ -184,7 +184,7 @@ test Redis.lns get "notify-keyspace-events \"\"\n" =
 
 (* Test: Redis.lns
      Multiple bind IP addresses (GH issue #194) *)
-test Redis.lns get "bind 127.0.0.1 \"::1\" 192.168.1.1\n" =
+test Redis.lns get "bind 127.0.0.1 ::1 192.168.1.1\n" =
   { "bind"
   { "1" = "127.0.0.1" }
   { "2" = "::1" }


### PR DESCRIPTION
I added the tests from mfournier, and tried to fix the tests following the help from lutter... It is important to keep in mind that you would now set bind interfaces with /files/etc/redis.conf/bind/1 instead of /files/etc/redis.conf/bind which some people might be using happily with just one interface, so this might break for some people. 

Also, I admit I'm not too sure of the difference between /files/etc/redis.conf/bind/1 and /files/etc/redis.conf/bind[1] - I failed at getting the latter version to work.
