### PR TITLE
exports: add bracket support to the supported machine name formats.

### DIFF
--- a/lenses/exports.aug
+++ b/lenses/exports.aug
@@ -76,7 +76,7 @@ About: Limitations
 module Exports =
   autoload xfm
 
-  let client_re = /[a-zA-Z0-9.@*?\/:-]+/
+  let client_re = /[][a-zA-Z0-9.@*?\/:-]+/
 
   let eol = Util.eol
   let lbracket  = Util.del_str "("

--- a/lenses/tests/test_exports.aug
+++ b/lenses/tests/test_exports.aug
@@ -1,4 +1,4 @@
-module Test_exports = 
+module Test_exports =
 
 let s = "/local 172.31.0.0/16(rw,sync) \t
 
@@ -9,6 +9,7 @@ let s = "/local 172.31.0.0/16(rw,sync) \t
 /local3 some-host(rw,sync)
 /local3 an-other-host(rw,sync)
 /local4 2000:123:456::/64(rw)
+/local5 somehost-[01](rw)
 "
 
 test Exports.lns get s =
@@ -46,4 +47,7 @@ test Exports.lns get s =
           { "option" = "sync" } } }
   { "dir" = "/local4"
       { "client" = "2000:123:456::/64"
+          { "option" = "rw" } } }
+  { "dir" = "/local5"
+      { "client" = "somehost-[01]"
           { "option" = "rw" } } }


### PR DESCRIPTION
Hi,

This patch add support for character class lists within [square brackets].

Thanks!