### PR TITLE
Sysconfig: accept leading whitespace before variables

### DIFF
--- a/lenses/sysconfig.aug
+++ b/lenses/sysconfig.aug
@@ -46,8 +46,10 @@ module Sysconfig =
     let word = char* . "\"" . char* in
     Quote.do_squote (store word+)
 
-  let export = Shellvars.export
-  let kv (value:lens) = [ export? . key key_re . eq . value . comment_or_eol ]
+  let kv (value:lens) =
+    let export = Shellvars.export in
+    let indent = Util.del_opt_ws "" in
+    [ indent . export? . key key_re . eq . value . comment_or_eol ]
 
   let assign =
     let nothing = del /(""|'')?/ "" . value "" in

--- a/lenses/tests/test_sysconfig.aug
+++ b/lenses/tests/test_sysconfig.aug
@@ -148,6 +148,15 @@ unset ONBOOT    #   We do not want this var
   test lns get "#MOUNTD_NFS_V3\n#\n" =
     { "#comment" = "MOUNTD_NFS_V3" }
 
+  (* Handle leading whitespace at the beginning of a line correctly *)
+  test lns get " var=value\n" = { "var" = "value" }
+
+  test lns put " var=value\n" after set "/var" "val2" = " var=val2\n"
+
+  test lns get "\t \tvar=value\n" = { "var" = "value" }
+
+  test lns get "  export var=value\n" = { "var" = "value" { "export" } }
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)


### PR DESCRIPTION
Make sure we allow '  var=value' and similar entries in files

Fixes part of https://bugzilla.redhat.com/show_bug.cgi?id=761246