### PR TITLE
Shellvars: fix insertion at top of file that starts with blank lines

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@
   - Lens changes/additions
     * Dnsmasq: Parse the structure of the 'address' and 'server' options
                (incompatible change) (Kaarle Ritvanen)
+    * Shellvars: make insertion at the beginning of a file that starts with
+                 blank lines work; the new lens will remove blank lines
+                 from the beginning of a file as soon as lines are added to
+                 or removed from it (GH issue #202)
     * Sudoers: allow '+' in user/groupnames (Andreas Grüninger)
 
 1.3.0 - 2014-11-07

--- a/lenses/shellvars.aug
+++ b/lenses/shellvars.aug
@@ -13,6 +13,9 @@ About: Lens Usage
 module Shellvars =
   autoload xfm
 
+  (* Delete a blank line, rather than mapping it *)
+  let del_empty = del (Util.empty_generic_re . "\n") "\n"
+
   let empty   = Util.empty
   let empty_part_re = Util.empty_generic_re . /\n+/
   let eol = del (/[ \t]+|[ \t]*[;\n]/ . empty_part_re*) "\n"
@@ -186,9 +189,9 @@ module Shellvars =
       | case entry entry_noeol
       | function entry
 
-  let lns_norec = empty* . (comment | entry_eol) *
+  let lns_norec = del_empty* . (comment | entry_eol) *
 
-  let lns = empty* . (comment | entry_eol | rec_entry) *
+  let lns = del_empty* . (comment | entry_eol | rec_entry) *
 
   let sc_incl (n:string) = (incl ("/etc/sysconfig/" . n))
   let sc_excl (n:string) = (excl ("/etc/sysconfig/" . n))

--- a/lenses/tests/test_shellvars.aug
+++ b/lenses/tests/test_shellvars.aug
@@ -406,7 +406,6 @@ esac\n" =
 
   (* Empty comment before entries *)
   test Shellvars.lns get "# \nfoo=bar\n" =
-  { }
   { "foo" = "bar" }
 
   (* Empty comment after entries *)
@@ -507,6 +506,31 @@ fi\n" =
   test lns get "export MALLOC_PERTURB_=$(($RANDOM % 255 + 1))\n" =
     { "MALLOC_PERTURB_" = "$(($RANDOM % 255 + 1))"
       { "export" } }
+
+  (*
+   * Github issue 202
+   *)
+  let starts_with_blank = "\n  \nVAR=value\n"
+
+  test lns get starts_with_blank = { "VAR" = "value" }
+
+  (* It is now possible to insert at the beginning of a file
+   * that starts with blank lines *)
+  test lns put starts_with_blank after
+    insb "#comment" "/*[1]";
+    set "/#comment[1]" "a comment" =
+    " # a comment\nVAR=value\n"
+
+  (* Modifications of the file lose the blank lines though *)
+  test lns put starts_with_blank after
+    set "/VAR2" "abc" = "VAR=value\nVAR2=abc\n"
+
+  test lns put starts_with_blank after
+    rm "/VAR";
+    set "/VAR2" "abc" = "VAR2=abc\n"
+
+  test lns put starts_with_blank after
+    rm "/VAR"         = ""
 
 (* Local Variables: *)
 (* mode: caml       *)


### PR DESCRIPTION
Possible blank lines at the start of a file were mapped with Util.empty
which produces empty 'hidden' nodes (nodes with NULL label and value)

This causes problem when a user inserts something before these nodes, for
example with "insert 'foo' before /*[1]". Even though the nodes that
Util.empty produces are generally hidden from the user, they are still in
the tree and /*[1] selects such a node. The resulting tree has a hidden
node in the middle, something that Shellvars.lns does not allow and
therefore putting this tree fails. This is really hard to understand for
users as the tree they see with 'print' is indistinguishable from one that
doesn't have these hidden nodes.

To fix this, the changed lens simply deletes the blank lines at the
beginning of the file without creating any tree nodes. This makes the above
insertion work at the cost of losing these blank lines as soon as anything
is inserted into or deleted from the file.

Fixes https://github.com/hercules-team/augeas/issues/202