### PR TITLE
Httpd: type checking fails

### DIFF
--- a/lenses/httpd.aug
+++ b/lenses/httpd.aug
@@ -86,13 +86,13 @@ let directive = [ indent . label "directive" . store word .
 let section (body:lens) =
     let eol_comment = Util.comment_generic /[ \t\n]*#[ \t]*/ "# " in
     let inner = (sep_spc . argv arg_sec)? . sep_osp .
-             dels ">" . (eol|eol_comment) . (body . (body|comment)*)? .
+             dels ">" . (eol|eol_comment) . (body . (body|empty|comment)*)? .
              indent . dels "</" in
     let kword = key word in
     let dword = del word "a" in
         [ indent . dels "<" . square kword inner dword . del ">" ">" . eol ]
 
-let rec content = section (content|directive|empty)
+let rec content = section (content|directive)
 
 let lns = (content|directive|comment|empty)*
 

--- a/lenses/httpd.aug
+++ b/lenses/httpd.aug
@@ -59,7 +59,7 @@ let empty               = Util.empty_dos
 let indent              = Util.indent
 
 (* borrowed from shellvars.aug *)
-let char_arg_dir  = /[^ '"\t\r\n]|\\\\"|\\\\'/
+let char_arg_dir  = /[^\\ '"\t\r\n]|\\\\"|\\\\'/
 let char_arg_sec  = /[^ '"\t\r\n>]|\\\\"|\\\\'/
 let cdot = /\\\\./
 let cl = /\\\\\n/

--- a/lenses/tests/test_httpd.aug
+++ b/lenses/tests/test_httpd.aug
@@ -1,5 +1,11 @@
 module Test_httpd =
 
+(* Check that we can iterate on directive *)
+let _ = Httpd.directive+
+
+(* Check that we can do a non iterative section *)
+let __ = Httpd.section Httpd.directive
+
 (* directives testing *)
 let d1 = "ServerRoot \"/etc/apache2\"\n"
 test Httpd.directive get d1 =


### PR DESCRIPTION
If I add the line
```augeas
  let _ = section (directive|empty)
```
into `httpd.aug` right before the `let rec content` to force some lens type checking for the base case of the recursion, I get the following error:

```
Syntax error in lens definition
/homes/lutter/code/augeas/lenses/httpd.aug:96.0-.33:Failed to compile _
/homes/lutter/code/augeas/lenses/httpd.aug:89.52-.67:exception: ambiguous iterat
ion
      Iterated regexp: /(([ \t]*)([a-zA-Z][a-zA-Z0-9._-]*)(((([ \t]+|[ \t]*\\\\\
r?\n[ \t]*))((((([^ '"\t\r\n]|\\\\"|\\\\')+)|(((")(((([^"\\\r\n])|(\\\\.))|(\\\\
\n))*))(")))|(((')(((([^'\\\r\n])|(\\\\.))|(\\\\\n))*))('))))(((([ \t]+|[ \t]*\\\\\r?\n[ \t]*))((((([^ '"\t\r\n]|\\\\"|\\\\')+)|(((")(((([^"\\\r\n])|(\\\\.))|(\\\\\n))*))(")))|(((')(((([^'\\\r\n])|(\\\\.))|(\\\\\n))*))(')))))*))?)([ \t]*\r?\n))|(([ \t]*#?[ \t]*)(\r?\n))|(([ \t]*#[ \t]*)(([^ \t\r\n].*[^ \t\r\n]|[^ \t\r\n]))([ \t]*\r?\n))/
      'A\\\n\\'\\\nA\n' can be split into
      'A\\\n\\'\\\n|=|A\n'

     and
      'A\\\n\\'\\\nA\n|=|'

    Iterated lens: /homes/lutter/code/augeas/lenses/httpd.aug:89.52-.65:
```