### PR TITLE
Httpd: error parsing comments

### DIFF
--- a/lenses/httpd.aug
+++ b/lenses/httpd.aug
@@ -84,9 +84,10 @@ let directive = [ indent . label "directive" . store word .
                   (sep_spc . argv arg_dir)? . eol ]
 
 let section (body:lens) =
-    let eol_comment = Util.comment_generic /[ \t\n]*#[ \t]*/ "# " in
+    (* opt_eol includes empty lines *)
+    let opt_eol = del /([ \t]*#?\r?\n)*/ "\n" in
     let inner = (sep_spc . argv arg_sec)? . sep_osp .
-             dels ">" . (eol|eol_comment) . (body . (body|empty|comment)*)? .
+             dels ">" . opt_eol . ((body|comment) . (body|empty|comment)*)? .
              indent . dels "</" in
     let kword = key word in
     let dword = del word "a" in

--- a/lenses/tests/test_httpd.aug
+++ b/lenses/tests/test_httpd.aug
@@ -410,3 +410,48 @@ test Httpd.lns get versioncheck =
       }
     }
   }
+
+
+(* GH #220 *)
+let double_comment = "<IfDefine Foo>
+##
+## Comment
+##
+</IfDefine>\n"
+
+test Httpd.lns get double_comment =
+  { "IfDefine"
+    { "arg" = "Foo" }
+    { "#comment" = "#" }
+    { "#comment" = "# Comment" }
+    { "#comment" = "#" }
+  }
+
+let single_comment = "<IfDefine Foo>
+#
+## Comment
+##
+</IfDefine>\n"
+
+test Httpd.lns get single_comment =
+  { "IfDefine"
+    { "arg" = "Foo" }
+    { "#comment" = "# Comment" }
+    { "#comment" = "#" }
+  }
+
+let single_empty = "<IfDefine Foo>
+#
+
+</IfDefine>\n"
+test Httpd.lns get single_empty =
+  { "IfDefine"
+    { "arg" = "Foo" }
+  }
+
+let eol_empty = "<IfDefine Foo> #
+</IfDefine>\n"
+test Httpd.lns get eol_empty =
+  { "IfDefine"
+    { "arg" = "Foo" }
+  }


### PR DESCRIPTION
The latest httpd.aug seems to have some issues handling comments. For example:

```
<IfDefine Foo>
##
## Comment
##
</IfDefine>
```

results in

```
/augeas/files/usr/apache/conf/ssl.conf/error = "parse_failed"
/augeas/files/usr/apache/conf/ssl.conf/error/pos = "18"
/augeas/files/usr/apache/conf/ssl.conf/error/line = "3"
/augeas/files/usr/apache/conf/ssl.conf/error/char = "0"
/augeas/files/usr/apache/conf/ssl.conf/error/lens = "/path/to/augeas-1.3.0/share/augeas/lenses/dist/httpd.aug:97.10-.44:"
/augeas/files/usr/apache/conf/ssl.conf/error/message = "Syntax error"
```

However (note the single deleted '#' char),

```
<IfDefine Foo>
#
## Comment
##
</IfDefine>
```

parses successfully. This problem doesn't occur in the 1.2.0 release.