### PR TITLE
Improvements to Jaas lens

### DIFF
--- a/lenses/jaas.aug
+++ b/lenses/jaas.aug
@@ -1,5 +1,7 @@
 (* Module Jaas *)
 (* Author: Simon Vocella <voxsim@gmail.com> *)
+(* Updated by: Steve Shipway <steve@steveshipway.org> *)
+(* Changes: allow comments within Modules, allow optionless flags, allow options without linebreaks, allow naked true/false options *)
 
 module Jaas =
 
@@ -9,17 +11,17 @@ let space_equal = del (/[ \t]*/ . "=" . /[ \t]*/) (" = ")
 let lbrace = del (/[ \t\n]*/ . "{") "{"
 let rbrace = del ("};") "};"
 let word = /[A-Za-z0-9_.-]+/
+let endflag = del ( /[ \t]*;/ ) ( ";" )
 
 let value_re =
         let value_squote = /'[^\n']*'/
-        in let value_squote_2 = /'[^\n']*';/
         in let value_dquote = /"[^\n"]*"/
-        in let value_dquote_2 = /"[^\n"]*";/
-        in value_squote | value_squote_2 | value_dquote | value_dquote_2
+        in let value_tf = /(true|false)/
+        in value_squote | value_dquote | value_tf
 
-let moduleOption = [Util.del_opt_ws "" . key word . space_equal . (store value_re . Util.comment_or_eol)]
-let flag = [label "flag" . (store word . Util.eol) . moduleOption*]
-let loginModuleClass = [Util.del_opt_ws "" . label "loginModuleClass" . (store word . Util.del_ws_spc) . flag]
+let moduleOption = [ ( Util.del_opt_ws "" . key word . space_equal . (store value_re . Util.del_opt_ws "") | Util.empty | Util.comment_c_style | Util.comment_multiline  )]
+let flag = [label "flag" . (store word . Util.del_opt_ws " " ) . moduleOption* . endflag ]
+let loginModuleClass = [( Util.del_opt_ws "" . label "loginModuleClass" . (store word . Util.del_ws_spc) .  flag  | Util.empty | Util.comment_c_style | Util.comment_multiline ) ]
 
 let content = (Util.empty | Util.comment_c_style | Util.comment_multiline | loginModuleClass)*
 let loginModule = [Util.del_opt_ws "" . label "login" . (store word . lbrace) . (content . rbrace)]


### PR DESCRIPTION
Add flexibility to Jaas lens.  Allow comments within Modules, optionless flags, options without intervening linebreaks, and true/false option values without quotes.  All of these are valid syntax in the Shibboleth file, and prevent our live file from parsing correctly.

The existing lens still has problems with comments within comments, but this is fairly rare.