### PR TITLE
Fixes and Improvements to Jaas lens

### DIFF
--- a/lenses/jaas.aug
+++ b/lenses/jaas.aug
@@ -1,16 +1,20 @@
 (* Module Jaas *)
 (* Author: Simon Vocella <voxsim@gmail.com> *)
 (* Updated by: Steve Shipway <steve@steveshipway.org> *)
-(* Changes: allow comments within Modules, allow optionless flags, allow options without linebreaks, allow naked true/false options *)
+(* Changes: allow comments within Modules, allow optionless flags,  *)
+(* allow options without linebreaks, allow naked true/false options *)
+(* Note: requires latest Util.aug for multiline comments to work    *)
+
 
 module Jaas =
 
 autoload xfm
 
 let space_equal = del (/[ \t]*/ . "=" . /[ \t]*/) (" = ")
-let lbrace = del (/[ \t\n]*/ . "{") "{"
-let rbrace = del ("};") "};"
+let lbrace = del (/[ \t\n]*\{[ \t]*\n/) " {\n"
+let rbrace = del (/[ \t]*}[ \t]*;/) " };"
 let word = /[A-Za-z0-9_.-]+/
+let wsnl = del (/[ \t\n]+/) ("\n")
 let endflag = del ( /[ \t]*;/ ) ( ";" )
 
 let value_re =
@@ -19,12 +23,14 @@ let value_re =
         in let value_tf = /(true|false)/
         in value_squote | value_dquote | value_tf
 
-let moduleOption = [ ( Util.del_opt_ws "" . key word . space_equal . (store value_re . Util.del_opt_ws "") | Util.empty | Util.comment_c_style | Util.comment_multiline  )]
-let flag = [label "flag" . (store word . Util.del_opt_ws " " ) . moduleOption* . endflag ]
-let loginModuleClass = [( Util.del_opt_ws "" . label "loginModuleClass" . (store word . Util.del_ws_spc) .  flag  | Util.empty | Util.comment_c_style | Util.comment_multiline ) ]
+let moduleOption = [  wsnl . key word . space_equal . (store value_re) ]
+let moduleSuffix = ( moduleOption  | Util.eol . Util.comment_c_style | Util.comment_multiline  )
+let flag = [ Util.del_ws_spc . label "flag" . (store word) . moduleSuffix* . endflag ]
+let loginModuleClass = [( Util.del_opt_ws "" . label "loginModuleClass" . (store word) . flag ) ]
 
 let content = (Util.empty | Util.comment_c_style | Util.comment_multiline | loginModuleClass)*
 let loginModule = [Util.del_opt_ws "" . label "login" . (store word . lbrace) . (content . rbrace)]
+
 let lns = (Util.empty | Util.comment_c_style | Util.comment_multiline | loginModule)*
 let filter = incl "/opt/shibboleth-idp/conf/login.config"
 let xfm = transform lns filter

--- a/lenses/jaas.aug
+++ b/lenses/jaas.aug
@@ -1,5 +1,7 @@
 (* Module Jaas *)
 (* Author: Simon Vocella <voxsim@gmail.com> *)
+(* Updated by: Steve Shipway <steve@steveshipway.org> *)
+(* Changes: allow comments within Modules, allow optionless flags, allow options without linebreaks, allow naked true/false options *)
 
 module Jaas =
 
@@ -9,17 +11,17 @@ let space_equal = del (/[ \t]*/ . "=" . /[ \t]*/) (" = ")
 let lbrace = del (/[ \t\n]*/ . "{") "{"
 let rbrace = del ("};") "};"
 let word = /[A-Za-z0-9_.-]+/
+let endflag = del ( /[ \t]*;/ ) ( ";" )
 
 let value_re =
         let value_squote = /'[^\n']*'/
-        in let value_squote_2 = /'[^\n']*';/
         in let value_dquote = /"[^\n"]*"/
-        in let value_dquote_2 = /"[^\n"]*";/
-        in value_squote | value_squote_2 | value_dquote | value_dquote_2
+        in let value_tf = /(true|false)/
+        in value_squote | value_dquote | value_tf
 
-let moduleOption = [Util.del_opt_ws "" . key word . space_equal . (store value_re . Util.comment_or_eol)]
-let flag = [label "flag" . (store word . Util.eol) . moduleOption*]
-let loginModuleClass = [Util.del_opt_ws "" . label "loginModuleClass" . (store word . Util.del_ws_spc) . flag]
+let moduleOption = [ ( Util.del_opt_ws "" . key word . space_equal . (store value_re . Util.del_opt_ws "") | Util.empty | Util.comment_c_style | Util.comment_multiline  )]
+let flag = [label "flag" . (store word . Util.del_opt_ws " " ) . moduleOption* . endflag ]
+let loginModuleClass = [( Util.del_opt_ws "" . label "loginModuleClass" . (store word . Util.del_ws_spc) .  flag  | Util.empty | Util.comment_c_style | Util.comment_multiline ) ]
 
 let content = (Util.empty | Util.comment_c_style | Util.comment_multiline | loginModuleClass)*
 let loginModule = [Util.del_opt_ws "" . label "login" . (store word . lbrace) . (content . rbrace)]

--- a/lenses/jaas.aug
+++ b/lenses/jaas.aug
@@ -1,10 +1,10 @@
 (* Module Jaas *)
-(* Author: Simon Vocella <voxsim@gmail.com> *)
+(* Original Author: Simon Vocella <voxsim@gmail.com> *)
 (* Updated by: Steve Shipway <steve@steveshipway.org> *)
 (* Changes: allow comments within Modules, allow optionless flags,  *)
 (* allow options without linebreaks, allow naked true/false options *)
+(* Trailing ';' terminator should not be included in option value   *)
 (* Note: requires latest Util.aug for multiline comments to work    *)
-
 
 module Jaas =
 

--- a/lenses/tests/test_jaas.aug
+++ b/lenses/tests/test_jaas.aug
@@ -54,7 +54,18 @@ ShibUserPassAuth {
       serviceCredential = \"ldappassword\"
       ssl = \"false\"
       userField = \"uid\"
+      // Example comment within definition
       subtreeSearch = \"true\";
+};
+
+NetAccountAuth {
+   // Test of optionless flag
+   nz.ac.auckland.jaas.Krb5LoginModule required;
+};
+
+com.sun.security.jgss.krb5.initiate {
+   // Test of omitted linebreaks and naked boolean
+   com.sun.security.auth.module.Krb5LoginModule required useTicketCache=true;
 };"
 
 test Jaas.lns get conf =
@@ -78,7 +89,6 @@ test Jaas.lns get conf =
   {  }
   {  }
   { "login" = "ShibUserPassAuth"
-    {  }
     {  }
     { "#comment" = "Example LDAP authentication" }
     { "#comment" = "See: https://wiki.shibboleth.net/confluence/display/SHIB2/IdPAuthUserPass" }
@@ -106,7 +116,29 @@ test Jaas.lns get conf =
         { "serviceCredential" = "\"ldappassword\"" }
         { "ssl" = "\"false\"" }
         { "userField" = "\"uid\"" }
-        { "subtreeSearch" = "\"true\";" }
+        { "#comment" = "Example comment within definition" }
+        { "subtreeSearch" = "\"true\"" }
       }
     }
+    {  }
+  }
+  {  }
+  {  }
+  { "login" = "NetAccountAuth"
+    { "#comment" = "Test of optionless flag" }
+    { "loginModuleClass" = "nz.ac.auckland.jaas.Krb5LoginModule"
+      { "flag" = "required" }
+    }
+    {  }
+  }
+  {  }
+  {  }
+  { "login" = "com.sun.security.jgss.krb5.initiate"
+    { "#comment" = "Test of omitted linebreaks and naked boolean" }
+    { "loginModuleClass" = "com.sun.security.auth.module.Krb5LoginModule"
+      { "flag" = "required"
+        { "useTicketCache" = "true" }
+      }
+    }
+    {  }
   }


### PR DESCRIPTION
Tested against augparse successfully.  Requires latest Util.aug to function correctly.

This corrects an error in the existing jaas.aug lens (terminating ; was included in option value), plus adds support for several other syntactically valid formatting options (comments within option lists, options on the same line, uncommented boolean values, flags without options)

An updated test script tests for the newly supported syntax combinations, and corrects for the semicolon error.

This replaces my previous pull request which did not take into account other changes in the Util.pm and the test script.