### PR TITLE
Add rpm default paths to postgresql.aug

### DIFF
--- a/lenses/postgresql.aug
+++ b/lenses/postgresql.aug
@@ -69,7 +69,9 @@ let entry = entry_gen number
 let lns = (Util.empty | Util.comment | entry)*
 
 (* Variable: filter *)
-let filter = incl "/etc/postgresql/*/*/postgresql.conf"
+let filter = (incl "/var/lib/pgsql/data/postgresql.conf" .
+              incl "/var/lib/pgsql/*/data/postgresql.conf" .
+              incl "/etc/postgresql/*/*/postgresql.conf" )
 
 let xfm = transform lns filter
 


### PR DESCRIPTION
As of Postgres 9.4, postgresql.conf is stored in the database cluster's
data directory

See:
http://www.postgresql.org/docs/9.4/static/runtime-config-file-locations.html