### PR TITLE
Limits lens: Allowing comments at end of line

### DIFF
--- a/lenses/limits.aug
+++ b/lenses/limits.aug
@@ -14,6 +14,7 @@ module Limits =
  *************************************************************************)
 
 let eol        = Util.eol
+let comment_or_eol = Util.comment_or_eol
 let spc        = Util.del_ws_spc
 let comment    = Util.comment
 let empty      = Util.empty
@@ -56,7 +57,7 @@ let value      = [ label "value" . store /[A-Za-z0-9_.\/-]+/ ]
 let entry      = [ domain . spc
                  . type   . spc
                  . item   . spc
-                 . value  . eol ]
+                 . value  . comment_or_eol ]
 
 (************************************************************************
  *                                LENS


### PR DESCRIPTION
Here is my proposal for changing limits.aug lens to allow comments at the end of the line, which are no problem for the OS and heavily used in the limits.conf on our systems. Without that change you get a parse error.