### PR TITLE
Add /etc/puppetlabs/mcollective to mcollective lens

### DIFF
--- a/lenses/mcollective.aug
+++ b/lenses/mcollective.aug
@@ -35,5 +35,7 @@ let lns = Simplevars.lns
 
 let filter = incl "/etc/mcollective/client.cfg"
            . incl "/etc/mcollective/server.cfg"
+           . incl "/etc/puppetlabs/mcollective/client.cfg"
+           . incl "/etc/puppetlabs/mcollective/server.cfg"
 
 let xfm = transform lns filter


### PR DESCRIPTION
In the latest release of Puppet, the mcollective paths have been updated
to reflect the documentation at
https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md

This commit adds server.cfg and client.cfg in
/etc/puppetlabs/mcollective to the mcollective filter.