### PR TITLE
Add passwd lens support for nis [+-]username syntax

### DIFF
--- a/lenses/passwd.aug
+++ b/lenses/passwd.aug
@@ -28,7 +28,7 @@ let comment    = Util.comment
 let empty      = Util.empty
 let dels       = Util.del_str
 
-let word       = Rx.word
+let word       = /[_.A-Za-z0-9][-\@_.A-Za-z0-9]*\$?/
 let integer    = Rx.integer
 
 let colon      = Sep.colon
@@ -88,6 +88,28 @@ let nisentry =
       . [ label "shell"    . sto_to_eol ]? in
   [ dels "+@" . label "@nis" . store word . overrides . eol ]
 
+let nisuserplus =
+  let overrides =
+        colon
+      . [ label "password" . store word ]?    . colon
+      . [ label "uid"      . store integer ]? . colon
+      . [ label "gid"      . store integer ]? . colon
+      . [ label "name"     . sto_to_col ]?    . colon
+      . [ label "home"     . sto_to_col ]?    . colon
+      . [ label "shell"    . sto_to_eol ]? in
+  [ dels "+" . label "@+nisuser" . store word . overrides . eol ]
+
+let nisuserminus =
+  let overrides =
+        colon
+      . [ label "password" . store word ]?    . colon
+      . [ label "uid"      . store integer ]? . colon
+      . [ label "gid"      . store integer ]? . colon
+      . [ label "name"     . sto_to_col ]?    . colon
+      . [ label "home"     . sto_to_col ]?    . colon
+      . [ label "shell"    . sto_to_eol ]? in
+  [ dels "-" . label "@-nisuser" . store word . overrides . eol ]
+
 let nisdefault =
   let overrides =
         colon
@@ -103,7 +125,7 @@ let nisdefault =
  *                                LENS
  *************************************************************************)
 
-let lns        = (comment|empty|entry|nisentry|nisdefault) *
+let lns        = (comment|empty|entry|nisentry|nisdefault|nisuserplus|nisuserminus) *
 
 let filter     = incl "/etc/passwd"
 

--- a/lenses/passwd.aug
+++ b/lenses/passwd.aug
@@ -28,7 +28,7 @@ let comment    = Util.comment
 let empty      = Util.empty
 let dels       = Util.del_str
 
-let word       = /[_.A-Za-z0-9][-\@_.A-Za-z0-9]*\$?/
+let word       = Rx.word
 let integer    = Rx.integer
 
 let colon      = Sep.colon
@@ -39,6 +39,8 @@ let sto_to_col = store /[^:\r\n]+/
 (************************************************************************
  * Group:                        ENTRIES
  *************************************************************************)
+
+let username  = /[_.A-Za-z0-9][-_.A-Za-z0-9]*\$?/
 
 (* View: password
         pw_passwd *)
@@ -66,7 +68,7 @@ let shell     = [ label "shell"    . sto_to_eol? ]
 
 (* View: entry
         struct passwd *)
-let entry     = [ key word
+let entry     = [ key username
                 . colon
                 . password
                 . uid
@@ -76,39 +78,31 @@ let entry     = [ key word
                 . shell
                 . eol ]
 
-(* A NIS entry has nothing bar the +@:::::: bits. *)
+(* NIS entries *)
+let niscommon =  [ label "password" . sto_to_col ]?    . colon
+               . [ label "uid"      . store integer ]? . colon
+               . [ label "gid"      . store integer ]? . colon
+               . [ label "name"     . sto_to_col ]?    . colon
+               . [ label "home"     . sto_to_col ]?    . colon
+               . [ label "shell"    . sto_to_eol ]?
+
 let nisentry =
   let overrides =
         colon
-      . [ label "password" . sto_to_col ]?   . colon
-      . [ label "uid"      . store integer ]? . colon
-      . [ label "gid"      . store integer ]? . colon
-      . [ label "name"     . sto_to_col ]?   . colon
-      . [ label "home"     . sto_to_col ]?  . colon
-      . [ label "shell"    . sto_to_eol ]? in
-  [ dels "+@" . label "@nis" . store word . overrides . eol ]
+      . niscommon in
+  [ dels "+@" . label "@nis" . store username . overrides . eol ]
 
 let nisuserplus =
   let overrides =
         colon
-      . [ label "password" . store word ]?    . colon
-      . [ label "uid"      . store integer ]? . colon
-      . [ label "gid"      . store integer ]? . colon
-      . [ label "name"     . sto_to_col ]?    . colon
-      . [ label "home"     . sto_to_col ]?    . colon
-      . [ label "shell"    . sto_to_eol ]? in
-  [ dels "+" . label "@+nisuser" . store word . overrides . eol ]
+      . niscommon in
+  [ dels "+" . label "@+nisuser" . store username . overrides . eol ]
 
 let nisuserminus =
   let overrides =
         colon
-      . [ label "password" . store word ]?    . colon
-      . [ label "uid"      . store integer ]? . colon
-      . [ label "gid"      . store integer ]? . colon
-      . [ label "name"     . sto_to_col ]?    . colon
-      . [ label "home"     . sto_to_col ]?    . colon
-      . [ label "shell"    . sto_to_eol ]? in
-  [ dels "-" . label "@-nisuser" . store word . overrides . eol ]
+      . niscommon in
+  [ dels "-" . label "@-nisuser" . store username . overrides . eol ]
 
 let nisdefault =
   let overrides =

--- a/lenses/tests/test_passwd.aug
+++ b/lenses/tests/test_passwd.aug
@@ -57,3 +57,30 @@ test Passwd.lns get "+@bob:::::/home/bob:/bin/bash\n" =
  { "@nis" = "bob"
    { "home" = "/home/bob" }
    { "shell" = "/bin/bash" } }
+
+(* NIS user entries *)
+test Passwd.lns get "+bob::::::\n" =
+ { "@+nisuser" = "bob" }
+
+test Passwd.lns get "+bob::::User Comment:/home/bob:/bin/bash\n" =
+ { "@+nisuser" = "bob"
+   { "name" = "User Comment" }
+   { "home" = "/home/bob" }
+   { "shell" = "/bin/bash" } }
+
+test Passwd.lns put "+bob::::::\n" after
+  set "@+nisuser" "alice"
+= "+alice::::::\n"
+
+test Passwd.lns put "+bob::::::\n" after
+  set "@+nisuser/name" "User Comment";
+  set "@+nisuser/home" "/home/bob";
+  set "@+nisuser/shell" "/bin/bash"
+= "+bob::::User Comment:/home/bob:/bin/bash\n"
+
+test Passwd.lns get "-bob::::::\n" =
+ { "@-nisuser" = "bob" }
+
+test Passwd.lns put "-bob::::::\n" after
+  set "@-nisuser" "alice"
+= "-alice::::::\n"


### PR DESCRIPTION
The /etc/passwd file can contain nis users with the syntax [+-]username for the pruprose of including or excluding specific accounts.

Importing of particular users' accounts can be restricted by using the prefix "+" with a username.

root:x:0:0:root user:/home/root:/bin/bash
+bob::::::
+alice::::Alice:/home/alice:/bin/bash

Certain users' accounts can be excluded from being imported by using the "-" prefix with a username.

root:x:0:0:root user:/home/root:/bin/bash
-bob::::::
+

The string that can copmrise a valid username has been updated to cover a range slightly larger that the definitions in POSIX (http://pubs.opengroup.org/onlinepubs/9699919799/ , section 3.431), is_valid_name() in chkname.c in shadow-utils and the NAME_REGEX definition in distributions where defined. Rx.word was too broad and did not allow for the -username syntax.