### PR TITLE
RFC: Add a 'region' lens to make controlling spacing easier

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -93,6 +93,21 @@ struct dict *make_dict(char *key, struct skel *skel, struct dict *subdict) {
     return NULL;
 }
 
+static char *size_as_key(size_t key) {
+    char *s = NULL;
+
+    xasprintf(&s, "%zx", key);
+    return s;
+}
+
+struct dict *make_dictz(size_t key, struct skel *skel, struct dict *subdict) {
+    char *s = size_as_key(key);
+
+    if (s == NULL)
+        return NULL;
+    return make_dict(s, skel, subdict);
+}
+
 void free_dict(struct dict *dict) {
     if (dict == NULL)
         return;
@@ -213,7 +228,17 @@ void dict_lookup(const char *key, struct dict *dict,
     }
 }
 
+void dict_lookupz(size_t key, struct dict *dict,
+                  struct skel **skel, struct dict **subdict) {
+    char *s = size_as_key(key);
 
+    if (s == NULL) {
+        *skel = NULL;
+        *subdict = NULL;
+        return;
+    }
+    dict_lookup(s, dict, skel, subdict);
+}
 
 /*
  * Local variables:

--- a/src/internal.h
+++ b/src/internal.h
@@ -376,8 +376,9 @@ struct tree {
     char        *label;      /* Last component of PATH */
     struct tree *children;   /* List of children through NEXT */
     char        *value;
-    int          dirty;
+    size_t       pos;
     struct span *span;
+    int          dirty;
 };
 
 /* The opaque structure used to represent path expressions. API's

--- a/src/jmt.c
+++ b/src/jmt.c
@@ -759,6 +759,7 @@ build_nullable(struct jmt_parse *parse, ind_t pos,
                                    lens->children[i], lvl+1);
             break;
         case L_SUBTREE:
+        case L_REGION:
         case L_SQUARE:
             build_nullable(parse, pos, visitor, lens->child, lvl+1);
             break;
@@ -1217,6 +1218,7 @@ static void print_grammar(struct jmt *jmt, struct lens *lens) {
             print_grammar(jmt, lens->children[i]);
         break;
     case L_SUBTREE:
+    case L_REGION:
         print_lens_symbol(stdout, jmt, lens->child);
         printf("\n");
         print_grammar(jmt, lens->child);
@@ -1280,6 +1282,7 @@ static void index_lenses(struct jmt *jmt, struct lens *lens) {
             index_lenses(jmt, lens->children[i]);
         break;
     case L_SUBTREE:
+    case L_REGION:
     case L_STAR:
     case L_MAYBE:
     case L_SQUARE:
@@ -1475,6 +1478,7 @@ static void conv_rhs(struct jmt *jmt, ind_t l) {
         conv_union(jmt, lens, &s, &e, &f);
         break;
     case L_SUBTREE:
+    case L_REGION:
         conv(jmt, lens->child, &s, &e, &f);
         break;
     case L_STAR:

--- a/src/lens.h
+++ b/src/lens.h
@@ -39,6 +39,7 @@ enum lens_tag {
     L_CONCAT,
     L_UNION,
     L_SUBTREE,
+    L_REGION,
     L_STAR,
     L_MAYBE,
     L_REC,
@@ -94,7 +95,8 @@ struct lens {
             struct string *string; /* L_VALUE, L_LABEL, L_SEQ, L_COUNTER */
         };
         /* Combinators */
-        struct lens *child;         /* L_SUBTREE, L_STAR, L_MAYBE, L_SQUARE */
+        struct lens *child;         /* L_SUBTREE, L_STAR, L_MAYBE,
+                                       L_SQUARE, L_REGION */
         struct {                    /* L_UNION, L_CONCAT */
             unsigned int nchildren;
             struct lens **children;
@@ -134,6 +136,7 @@ struct value *lns_make_union(struct info *, struct lens *, struct lens *,
 struct value *lns_make_concat(struct info *, struct lens *, struct lens *,
                               int check);
 struct value *lns_make_subtree(struct info *, struct lens *);
+struct value *lns_make_region(struct info *, struct lens *);
 struct value *lns_make_star(struct info *, struct lens *,
                             int check);
 struct value *lns_make_plus(struct info *, struct lens *,
@@ -165,7 +168,7 @@ struct skel {
         char        *text;    /* L_DEL */
         struct skel *skels;   /* L_CONCAT, L_STAR */
     };
-    /* Also tag == L_SUBTREE, with no data in the union */
+    /* Also tag == L_SUBTREE || tag == L_REGION, with no data in the union */
 };
 
 struct lns_error {
@@ -178,8 +181,12 @@ struct lns_error {
 };
 
 struct dict *make_dict(char *key, struct skel *skel, struct dict *subdict);
+struct dict *make_dictz(size_t key, struct skel *skel, struct dict *subdict);
+
 void dict_lookup(const char *key, struct dict *dict,
                  struct skel **skel, struct dict **subdict);
+void dict_lookupz(size_t key, struct dict *dict,
+                  struct skel **skel, struct dict **subdict);
 int dict_append(struct dict **dict, struct dict *d2);
 void free_skel(struct skel *skel);
 void free_dict(struct dict *dict);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -107,7 +107,7 @@ ARROW  ->
                return REGEXP;
   }
 
-  [|*?+()=:;\.\[\]{}-]    return yytext[0];
+  [|*?+()=:;\.\[\]{}<>-]    return yytext[0];
 
   module        return KW_MODULE;
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -264,6 +264,8 @@ aexp: qid
       { $$ = $2; }
     | '[' exp ']'
       { $$ = make_unop(A_BRACKET, $2, &@$); }
+    | '<' exp '>'
+      { $$ = make_unop(A_REGION, $2, &@$); }
     | '(' ')'
       { $$ = make_unit_term(&@$); }
 
@@ -524,7 +526,7 @@ static struct term *make_binop(enum term_tag tag,
 
 static struct term *make_unop(enum term_tag tag, struct term *exp,
                              struct info *locp) {
-  assert(tag == A_BRACKET);
+  assert(tag == A_BRACKET || tag == A_REGION);
   struct term *term = make_term_locp(tag, locp);
   term->brexp = exp;
   return term;

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -49,6 +49,7 @@ enum term_tag {
     A_VALUE,
     A_IDENT,
     A_BRACKET,
+    A_REGION,
     A_FUNC,
     A_REP,
     A_TEST
@@ -87,7 +88,7 @@ struct term {
             struct term *right;
         };
         struct value    *value;         /* A_VALUE */
-        struct term     *brexp;         /* A_BRACKET */
+        struct term     *brexp;         /* A_BRACKET, A_REGION */
         struct string   *ident;         /* A_IDENT */
         struct {                        /* A_REP */
             enum quant_tag quant;

--- a/tests/modules/pass_region.aug
+++ b/tests/modules/pass_region.aug
@@ -1,0 +1,64 @@
+module Pass_Region =
+
+(* Some basic lenses that we will combine in a number of ways *)
+let eol = del "\n" "\n"
+let indent = del /[ _]*/ "_"  (* Create spaces as '_' *)
+let entry = key /a/ . del "=" "=" . store /[sx]*/
+
+(* indent outside the subtree for entry *)
+let outside = indent . [ entry ] . eol
+(* indent inside the subtree for entry *)
+let inside = [ indent . entry ] . eol
+
+(* The test text is set up so that the number of 's' indicate how many
+   spaces of indent we had *)
+let text = "a=\n a=s\n  a=ss\n"
+
+(* All these lenses produce the exact same tree, with or without < .. > *)
+test (outside*) get text =
+  { "a" = "" }
+  { "a" = "s" }
+  { "a" = "ss" }
+
+test (inside*) get text =
+  { "a" = "" }
+  { "a" = "s" }
+  { "a" = "ss" }
+
+test (< outside >*) get text =
+  { "a" = "" }
+  { "a" = "s" }
+  { "a" = "ss" }
+
+test (< inside >*) get text =
+  { "a" = "" }
+  { "a" = "s" }
+  { "a" = "ss" }
+
+(* They behave slightly differently when we insert in the middle,
+   depending on whether we use < .. > or not *)
+let text_new_middle = "a=\n_a=sx\n a=s\n  a=ss\n"
+let text_new_end = "a=\n a=sx\n  a=s\n_a=ss\n"
+
+test (outside*) put text after insa "a" "/a[1]"; set "/a[2]" "sx" =
+  text_new_end
+
+test (inside*) put text after insa "a" "/a[1]"; set "/a[2]" "sx" =
+  text_new_end
+
+test (< outside >*) put text after insa "a" "/a[1]"; set "/a[2]" "sx" =
+  text_new_middle
+
+test (< inside >*) put text after insa "a" "/a[1]"; set "/a[2]" "sx" =
+  text_new_middle
+
+(* Delete an entry in the middle *)
+let text_rm_shift = "a=\n a=ss\n"
+let text_rm_noshift = "a=\n  a=ss\n"
+test (outside*) put text after rm "/a[2]" = text_rm_shift
+
+test (inside*) put text after  rm "/a[2]" = text_rm_shift
+
+test (< outside >*) put text after rm "/a[2]" = text_rm_noshift
+
+test (< inside >*) put text after rm "/a[2]" = text_rm_noshift


### PR DESCRIPTION
This is not meant to be committed yet, but I would really appreciate feedback based on people's experimenting with these patches.

So far, how deleted text is handled when entries are added to or removed
from the tree is tightly bound up with how the tree was structured,
because the subtree combinator [ .. ] controlled both: construction of new
tree nodes and glomming deleted stuff together.

In addition, the [ .. ] does the glomming based on the key of the tree node
it constructs, so that deleting a node from hte middle of a number of nodes
with the same key had the weird effect that entries tended to 'shift up'.

The region combinator tries to address this, in that all it does is
demarcate how deleted stuff should be glommed, and it does that based on
the position in the input file, not on the value of a key.

Syntactically, this is written as < l >, though other syntax, like 'region
l', or '<< l >>' might be better.

It would be great if this could also be used to indent new things the same
as surrounding stuff, i.e. if we have a lens < l >* and we add en entry in
the middle of it, if that would automatically mean that the new entry gets
the indentation of one of the surrounding lines - that's not implemented
yet.

I would really like to see and hear how this does or does not address some
of the spacing/indentation problems that people have been having, ideally
demonstrated by a simple test.