### PR TITLE
MySQL (incompatible change): handle !include directives in the middle of sections

### DIFF
--- a/lenses/mysql.aug
+++ b/lenses/mysql.aug
@@ -15,12 +15,15 @@ let comment  = IniFile.comment IniFile.comment_re "#"
 let sep      = IniFile.sep IniFile.sep_re IniFile.sep_default
 
 let entry    =
-     let bare = Quote.do_dquote_opt_nil (store /[^#;" \t\r\n]+([ \t]+[^#;" \t\r\n]+)*/)
-  in let quoted = Quote.do_dquote (store /[^"\r\n]*[#;]+[^"\r\n]*/)
-  in [ Util.indent . key IniFile.entry_re . sep . Sep.opt_space . bare . (comment|IniFile.eol) ]
-   | [ Util.indent . key IniFile.entry_re . sep . Sep.opt_space . quoted . (comment|IniFile.eol) ]
-   | [ Util.indent . key IniFile.entry_re . store // .  (comment|IniFile.eol) ]
-   | comment
+  let bare =
+    Quote.do_dquote_opt_nil (store /[^#;" \t\r\n]+([ \t]+[^#;" \t\r\n]+)*/) in
+  let quoted = Quote.do_dquote (store /[^"\r\n]*[#;]+[^"\r\n]*/) in
+  let eol = comment|IniFile.eol in
+  let line (content:lens) = [ Util.indent . content . eol ] in
+    line (key IniFile.entry_re . sep . Sep.opt_space . bare)
+  | line (key IniFile.entry_re . sep . Sep.opt_space . quoted)
+  | line (key IniFile.entry_re . store //)
+  | comment
 
 (************************************************************************
  * sections, led by a "[section]" header
@@ -43,4 +46,3 @@ let filter = (incl "/etc/mysql/my.cnf")
              . (incl "/etc/my.cnf")
 
 let xfm = transform lns filter
-

--- a/lenses/mysql.aug
+++ b/lenses/mysql.aug
@@ -14,6 +14,9 @@ let comment  = IniFile.comment IniFile.comment_re "#"
 
 let sep      = IniFile.sep IniFile.sep_re IniFile.sep_default
 
+(* Like Rx.fspath, but we also disallow characters that start comments *)
+let fspath   = store /[^ \t\r\n#;]+/
+
 let entry    =
   let bare =
     Quote.do_dquote_opt_nil (store /[^#;" \t\r\n]+([ \t]+[^#;" \t\r\n]+)*/) in
@@ -23,6 +26,7 @@ let entry    =
     line (key IniFile.entry_re . sep . Sep.opt_space . bare)
   | line (key IniFile.entry_re . sep . Sep.opt_space . quoted)
   | line (key IniFile.entry_re . store //)
+  | line (key /!include(dir)?/ . Sep.space . fspath)
   | comment
 
 (************************************************************************
@@ -39,7 +43,7 @@ let record  = IniFile.record title entry
 let includedir = Build.key_value_line /!include(dir)?/ Sep.space (store Rx.fspath)
                . (comment|IniFile.empty)*
 
-let lns    = (comment|IniFile.empty)* . (record|includedir)*
+let lns    = (comment|IniFile.empty)* . record*
 
 let filter = (incl "/etc/mysql/my.cnf")
              . (incl "/etc/mysql/conf.d/*.cnf")

--- a/lenses/tests/test_mysql.aug
+++ b/lenses/tests/test_mysql.aug
@@ -274,10 +274,8 @@ key_buffer		= 16M
     {}
     { "#comment" = "* IMPORTANT: Additional settings that can override those from this file!" }
     {}
+    { "!includedir" = "/etc/mysql/conf.d/" }
+    { "!include" = "/etc/mysql/other_conf.d/someconf.cnf" }
+    { "#comment" = "Another comment" }
+    { }
   }
-  { "!includedir" = "/etc/mysql/conf.d/" }
-  { "!include" = "/etc/mysql/other_conf.d/someconf.cnf" }
-  { "#comment" = "Another comment" }
-  { }
-
-


### PR DESCRIPTION
 MySQL (incompatible change): handle !include directives in the middle…

CentOS 6.6 (at least) ships with a mysql.conf that has a !include directive
in the middle of a section. To accomodate that, we pull !include directives
into the sections in which they appear rather than having htem end the
section. That's the incompatible change: these directives now appear
underneath /target/!include rather than at /!include

Fixes https://github.com/hercules-team/augeas/issues/113