### PR TITLE
integrate two patches from FreeBSD ports

### DIFF
--- a/lenses/shellvars.aug
+++ b/lenses/shellvars.aug
@@ -247,6 +247,7 @@ module Shellvars =
                      . incl "/etc/lintianrc"
                      . incl "/etc/lsb-release"
                      . incl "/etc/os-release"
+                     . incl "/etc/periodic.conf"
                      . incl "/etc/popularity-contest.conf"
                      . incl "/etc/rc.conf"
                      . incl "/etc/rc.conf.local"

--- a/lenses/sysctl.aug
+++ b/lenses/sysctl.aug
@@ -23,7 +23,8 @@ module Sysctl =
 autoload xfm
 
 (* Variable: filter *)
-let filter = incl "/etc/sysctl.conf"
+let filter = incl "/boot/loader.conf"
+           . incl "/etc/sysctl.conf"
            . incl "/etc/sysctl.d/*"
            . excl "/etc/sysctl.d/README"
            . excl "/etc/sysctl.d/README.sysctl"


### PR DESCRIPTION
- /boot/loader.conf can be parsed with the sysctl lens
- /etc/perodic.conf can be parsed with the shellvars lens

Variations of these patches are floating around in the FreeBSD ports tree for quite some time, lastly updated in freebsd/freebsd-ports@a378156b, but I'd really like to get these upstreamed. 