### PR TITLE
Chrony: update for chrony 2.0

### DIFF
--- a/lenses/chrony.aug
+++ b/lenses/chrony.aug
@@ -186,7 +186,8 @@ module Chrony =
     let bcast = [ Util.indent . key "broadcast"
                       . space . [ label "interval" . store integer ]
                       . space . store_address
-                      . ( space . [ label "port" . store integer] | eol) ]
+                      . ( space . [ label "port" . store integer ] )?
+                      . eol ]
 
     (* View: fdrift
          fallbackdrift has specific syntax

--- a/lenses/chrony.aug
+++ b/lenses/chrony.aug
@@ -144,14 +144,14 @@ module Chrony =
  * Group: Lenses for parsing out sections
  ************************************************************************)
     (* View: all_flags
-        match all flags using Build.flag_line
+        options without any arguments
     *)
-    let all_flags = Build.flag_line flags
+    let all_flags = [ Util.indent . key flags . eol ]
 
     (* View: kv
         options with only one arg can be directly mapped to key = value
     *)
-    let kv = Build.key_value_line_comment simple_keys space (store no_space) comment
+    let kv = [ Util.indent . key simple_keys . space . (store no_space) . eol ]
 
     (* Property: Options with multiple values
     

--- a/lenses/chrony.aug
+++ b/lenses/chrony.aug
@@ -50,10 +50,10 @@ module Chrony =
     let word       = Rx.word
 
     (* Variable: integer *)
-    let integer    = Rx.integer
+    let integer    = Rx.relinteger
 
     (* Variable: decimal *)
-    let decimal    = Rx.decimal
+    let decimal    = Rx.reldecimal
 
     (* Variable: ip *)
     let ip         = Rx.ip

--- a/lenses/tests/test_chrony.aug
+++ b/lenses/tests/test_chrony.aug
@@ -114,7 +114,6 @@ initstepslew 30 foo.bar.com baz.quz.com
     { "address" = "192.168.100.255" }
     { "port" = "123" }
   }
-  {  }
   { "fallbackdrift"
     { "min" = "16" }
     { "max" = "19" }

--- a/lenses/tests/test_chrony.aug
+++ b/lenses/tests/test_chrony.aug
@@ -23,8 +23,8 @@ server ntp6.example.com maxdelay 2 iburst presend 2
 server ntp7.example.com iburst presend 2 offline
 peer ntpc1.example.com
 stratumweight 0
-driftfile /var/lib/chrony/drift
-rtcsync
+	driftfile /var/lib/chrony/drift
+	rtcsync
 makestep 10 -1
 bindcmdaddress 127.0.0.1
 bindcmdaddress ::1

--- a/lenses/tests/test_chrony.aug
+++ b/lenses/tests/test_chrony.aug
@@ -25,7 +25,7 @@ peer ntpc1.example.com
 stratumweight 0
 driftfile /var/lib/chrony/drift
 rtcsync
-makestep 10 3
+makestep 10 -1
 bindcmdaddress 127.0.0.1
 bindcmdaddress ::1
 local stratum 10
@@ -87,7 +87,7 @@ initstepslew 30 foo.bar.com baz.quz.com
   { "rtcsync" }
   { "makestep"
     { "threshold" = "10" }
-    { "limit" = "3" }
+    { "limit" = "-1" }
   }
   { "bindcmdaddress" = "127.0.0.1" }
   { "bindcmdaddress" = "::1" }

--- a/lenses/tests/test_chrony.aug
+++ b/lenses/tests/test_chrony.aug
@@ -21,7 +21,9 @@ server ntp4.example.com offline polltarget 4
 server ntp5.example.com maxdelay 2 offline
 server ntp6.example.com maxdelay 2 iburst presend 2
 server ntp7.example.com iburst presend 2 offline
+server ntp8.example.com minsamples 8 maxsamples 16 version 3
 peer ntpc1.example.com
+pool pool1.example.com iburst maxsources 3
 stratumweight 0
 	driftfile /var/lib/chrony/drift
 	rtcsync
@@ -32,6 +34,7 @@ local stratum 10
 keyfile /etc/chrony.keys
 commandkey 1
 generatecommandkey
+manual
 noclientlog
 logchange 0.5
 logdir /var/log/chrony
@@ -44,6 +47,11 @@ mailonchange root@localhost 0.5
 maxchange 1000 1 2
 initstepslew 30 foo.bar.com
 initstepslew 30 foo.bar.com baz.quz.com
+refclock SHM 0 refid SHM0 delay 0.1 offset 0.2 noselect
+refclock PPS /dev/pps0 dpoll 2 poll 3 lock SHM0 rate 5 minsamples 8
+smoothtime 400 0.001 leaponly
+tempcomp /sys/class/hwmon/hwmon0/temp2_input 30 26000 0.0 0.000183 0.0
+tempcomp /sys/class/hwmon/hwmon0/temp2_input 30 /etc/chrony.tempcomp
 "
 
   test Chrony.lns get exampleconf =
@@ -81,7 +89,16 @@ initstepslew 30 foo.bar.com baz.quz.com
     { "presend" = "2" }
     { "offline" }
   }
+  { "server" = "ntp8.example.com"
+    { "minsamples" = "8" }
+    { "maxsamples" = "16" }
+    { "version" = "3" }
+  }
   { "peer" = "ntpc1.example.com" }
+  { "pool" = "pool1.example.com"
+    { "iburst" }
+    { "maxsources" = "3" }
+  }
   { "stratumweight" = "0" }
   { "driftfile" = "/var/lib/chrony/drift" }
   { "rtcsync" }
@@ -97,6 +114,7 @@ initstepslew 30 foo.bar.com baz.quz.com
   { "keyfile" = "/etc/chrony.keys" }
   { "commandkey" = "1" }
   { "generatecommandkey" }
+  { "manual" }
   { "noclientlog" }
   { "logchange" = "0.5" }
   { "logdir" = "/var/log/chrony" }
@@ -135,6 +153,41 @@ initstepslew 30 foo.bar.com baz.quz.com
     { "threshold" = "30" }
     { "address" = "foo.bar.com" }
     { "address" = "baz.quz.com" }
+  }
+  { "refclock"
+    { "driver" = "SHM" }
+    { "parameter" = "0" }
+    { "refid" = "SHM0" }
+    { "delay" = "0.1" }
+    { "offset" = "0.2" }
+    { "noselect" }
+  }
+  { "refclock"
+    { "driver" = "PPS" }
+    { "parameter" = "/dev/pps0" }
+    { "dpoll" = "2" }
+    { "poll" = "3" }
+    { "lock" = "SHM0" }
+    { "rate" = "5" }
+    { "minsamples" = "8" }
+  }
+  { "smoothtime"
+    { "maxfreq" = "400" }
+    { "maxwander" = "0.001" }
+    { "leaponly" }
+  }
+  { "tempcomp"
+    { "sensorfile" = "/sys/class/hwmon/hwmon0/temp2_input" }
+    { "interval" = "30" }
+    { "t0" = "26000" }
+    { "k0" = "0.0" }
+    { "k1" = "0.000183" }
+    { "k2" = "0.0" }
+  }
+  { "tempcomp"
+    { "sensorfile" = "/sys/class/hwmon/hwmon0/temp2_input" }
+    { "interval" = "30" }
+    { "pointfile" = "/etc/chrony.tempcomp" }
   }
 
 


### PR DESCRIPTION
In chrony-2.0 was added a new directive to specify a pool of NTP servers
and there are also several new options that can be used with the
server/peer/pool directives.