### PR TITLE
Fix passwd lens for @nisdefault on OpenBSD

### DIFF
--- a/lenses/passwd.aug
+++ b/lenses/passwd.aug
@@ -91,7 +91,7 @@ let nisentry =
 let nisdefault =
   let overrides =
         colon
-      . [ label "password" . store word?    . colon ]
+      . [ label "password" . sto_to_col?    . colon ]
       . [ label "uid"      . store integer? . colon ]
       . [ label "gid"      . store integer? . colon ]
       . [ label "name"     . sto_to_col?    . colon ]

--- a/lenses/tests/test_passwd.aug
+++ b/lenses/tests/test_passwd.aug
@@ -45,12 +45,21 @@ test Passwd.lns get "+\n" =
 
 test Passwd.lns get "+::::::/sbin/nologin\n" =
   { "@nisdefault"
-    { "password" = "" }
+    { "password" }
     { "uid" = "" }
     { "gid" = "" }
     { "name" }
     { "home" }
     { "shell" = "/sbin/nologin" } }
+
+test Passwd.lns get "+:*:0:0:::\n" =
+  { "@nisdefault"
+    { "password" = "*" }
+    { "uid" = "0" }
+    { "gid" = "0" }
+    { "name" }
+    { "home" }
+    { "shell" } }
 
 (* NIS entries with overrides, ticket #339 *)
 test Passwd.lns get "+@bob:::::/home/bob:/bin/bash\n" =


### PR DESCRIPTION
Following `passwd(5)` on OpenBSD results in an `/etc/passwd` NIS entry like:

```
+:*:0:0:::
```

Passwd lens barfs on the '*' password. Change to match how normal entries are
matched.