### PR TITLE
Add support for /etc/master.passwd

### DIFF
--- a/lenses/group.aug
+++ b/lenses/group.aug
@@ -22,8 +22,7 @@ let colon      = Sep.colon
 let comma      = Sep.comma
 
 let sto_to_spc = store Rx.space_in
-let sto_to_col  = store /[^:\n]+/
-let sto_to_eol = store /([^ \t\n].*[^ \t\n]|[^ \t\n])/
+let sto_to_col = Passwd.sto_to_col
 
 let word    = Rx.word
 let password = /[A-Za-z0-9_.!*-]*/
@@ -43,8 +42,8 @@ let entry     = Build.key_value_line word colon params
 let nisdefault =
   let overrides =
         colon
-      . [ label "password" . store word?    . colon ]
-      . [ label "gid"      . store integer? . colon ]
+      . [ label "password" . store password? . colon ]
+      . [ label "gid"      . store integer?  . colon ]
       . user_list? in
   [ dels "+" . label "@nisdefault" . overrides? . eol ]
 

--- a/lenses/masterpasswd.aug
+++ b/lenses/masterpasswd.aug
@@ -1,0 +1,148 @@
+(*
+ Module: MasterPasswd
+ Parses /etc/master.passwd
+
+ Author: Matt Dainty <matt@bodgit-n-scarper.com>
+
+ About: Reference
+        - man 5 master.passwd
+
+ Each line in the master.passwd file represents a single user record, whose
+ colon-separated attributes correspond to the members of the passwd struct
+
+*)
+
+module MasterPasswd =
+
+   autoload xfm
+
+(************************************************************************
+ * Group:                    USEFUL PRIMITIVES
+ *************************************************************************)
+
+(* Group: Comments and empty lines *)
+
+let eol        = Util.eol
+let comment    = Util.comment
+let empty      = Util.empty
+let dels       = Util.del_str
+
+let word       = Rx.word
+let integer    = Rx.integer
+
+let colon      = Sep.colon
+
+let sto_to_eol = Passwd.sto_to_eol
+let sto_to_col = Passwd.sto_to_col
+(* Store an empty string if nothing matches *)
+let sto_to_col_or_empty = Passwd.sto_to_col_or_empty
+
+(************************************************************************
+ * Group:                        ENTRIES
+ *************************************************************************)
+
+let username    = /[_.A-Za-z0-9][-_.A-Za-z0-9]*\$?/
+
+(* View: password
+        pw_passwd *)
+let password    = [ label "password"    . sto_to_col?   . colon ]
+
+(* View: uid
+        pw_uid *)
+let uid         = [ label "uid"         . store integer . colon ]
+
+(* View: gid
+        pw_gid *)
+let gid         = [ label "gid"         . store integer . colon ]
+
+(* View: class
+        pw_class *)
+let class       = [ label "class"       . sto_to_col? . colon ]
+
+(* View: change
+        pw_change *)
+let change_date = [ label "change_date" . store integer? . colon ]
+
+(* View: expire
+        pw_expire *)
+let expire_date = [ label "expire_date" . store integer? . colon ]
+
+(* View: name
+        pw_gecos; the user's full name *)
+let name        = [ label "name"        . sto_to_col? . colon ]
+
+(* View: home
+        pw_dir *)
+let home        = [ label "home"        . sto_to_col?   . colon ]
+
+(* View: shell
+        pw_shell *)
+let shell       = [ label "shell"       . sto_to_eol? ]
+
+(* View: entry
+        struct passwd *)
+let entry       = [ key username
+                . colon
+                . password
+                . uid
+                . gid
+                . class
+                . change_date
+                . expire_date
+                . name
+                . home
+                . shell
+                . eol ]
+
+(* NIS entries *)
+let niscommon   =  [ label "password"    . sto_to_col ]?    . colon
+               . [ label "uid"         . store integer ]? . colon
+               . [ label "gid"         . store integer ]? . colon
+               . [ label "class"       . sto_to_col ]?    . colon
+               . [ label "change_date" . store integer ]? . colon
+               . [ label "expire_date" . store integer ]? . colon
+               . [ label "name"        . sto_to_col ]?    . colon
+               . [ label "home"        . sto_to_col ]?    . colon
+               . [ label "shell"       . sto_to_eol ]?
+
+let nisentry =
+  let overrides =
+        colon
+      . niscommon in
+  [ dels "+@" . label "@nis" . store username . overrides . eol ]
+
+let nisuserplus =
+  let overrides =
+        colon
+      . niscommon in
+  [ dels "+" . label "@+nisuser" . store username . overrides . eol ]
+
+let nisuserminus =
+  let overrides =
+        colon
+      . niscommon in
+  [ dels "-" . label "@-nisuser" . store username . overrides . eol ]
+
+let nisdefault =
+  let overrides =
+        colon
+      . [ label "password"    . sto_to_col_or_empty . colon ]
+      . [ label "uid"         . store integer? . colon ]
+      . [ label "gid"         . store integer? . colon ]
+      . [ label "class"       . sto_to_col?    . colon ]
+      . [ label "change_date" . store integer? . colon ]
+      . [ label "expire_date" . store integer? . colon ]
+      . [ label "name"        . sto_to_col?    . colon ]
+      . [ label "home"        . sto_to_col?    . colon ]
+      . [ label "shell"       . sto_to_eol? ] in
+  [ dels "+" . label "@nisdefault" . overrides? . eol ]
+
+(************************************************************************
+ *                                LENS
+ *************************************************************************)
+
+let lns        = (comment|empty|entry|nisentry|nisdefault|nisuserplus|nisuserminus) *
+
+let filter     = incl "/etc/master.passwd"
+
+let xfm        = transform lns filter

--- a/lenses/tests/test_group.aug
+++ b/lenses/tests/test_group.aug
@@ -47,3 +47,8 @@ test Group.lns get "+:::\n" =
   { "@nisdefault"
     { "password" = "" }
     { "gid" = "" } }
+
+test Group.lns get "+:*::\n" = 
+  { "@nisdefault"
+    { "password" = "*" }
+    { "gid" = "" } }

--- a/lenses/tests/test_masterpasswd.aug
+++ b/lenses/tests/test_masterpasswd.aug
@@ -1,0 +1,125 @@
+module Test_MasterPasswd =
+
+let conf = "root:*:0:0:daemon:0:0:Charlie &:/root:/bin/ksh
+sshd:*:27:27::0:0:sshd privsep:/var/empty:/sbin/nologin
+_portmap:*:28:28::0:0:portmap:/var/empty:/sbin/nologin
+test:x:1000:1000:ldap:1434329080:1434933880:Test User,,,:/home/test:/bin/bash
+"
+
+test MasterPasswd.lns get conf =
+   { "root"
+     { "password" = "*" }
+     { "uid" = "0" }
+     { "gid" = "0" }
+     { "class" = "daemon" }
+     { "change_date" = "0" }
+     { "expire_date" = "0" }
+     { "name" = "Charlie &" }
+     { "home" = "/root" }
+     { "shell" = "/bin/ksh" } }
+   { "sshd"
+     { "password" = "*" }
+     { "uid" = "27" }
+     { "gid" = "27" }
+     { "class" }
+     { "change_date" = "0" }
+     { "expire_date" = "0" }
+     { "name" = "sshd privsep" }
+     { "home" = "/var/empty" }
+     { "shell" = "/sbin/nologin" } }
+   { "_portmap"
+     { "password" = "*" }
+     { "uid" = "28" }
+     { "gid" = "28" }
+     { "class" }
+     { "change_date" = "0" }
+     { "expire_date" = "0" }
+     { "name" = "portmap" }
+     { "home" = "/var/empty" }
+     { "shell" = "/sbin/nologin" } }
+   { "test"
+     { "password" = "x" }
+     { "uid" = "1000" }
+     { "gid" = "1000" }
+     { "class" = "ldap" }
+     { "change_date" = "1434329080" }
+     { "expire_date" = "1434933880" }
+     { "name" = "Test User,,," }
+     { "home" = "/home/test" }
+     { "shell" = "/bin/bash" } }
+
+(* Popular on Solaris *)
+test MasterPasswd.lns get "+@some-nis-group:::::::::\n" =
+  { "@nis" = "some-nis-group" }
+
+test MasterPasswd.lns get "+\n" =
+  { "@nisdefault" }
+
+test MasterPasswd.lns get "+:::::::::\n" =
+  { "@nisdefault"
+      { "password" = "" }
+      { "uid" = "" }
+      { "gid" = "" }
+      { "class" }
+      { "change_date" = "" }
+      { "expire_date" = "" }
+      { "name" }
+      { "home" }
+      { "shell" } }
+
+test MasterPasswd.lns get "+:::::::::/sbin/nologin\n" =
+  { "@nisdefault"
+    { "password" = "" }
+    { "uid" = "" }
+    { "gid" = "" }
+    { "class" }
+    { "change_date" = "" }
+    { "expire_date" = "" }
+    { "name" }
+    { "home" }
+    { "shell" = "/sbin/nologin" } }
+
+test MasterPasswd.lns get "+:*:::ldap:::::\n" =
+  { "@nisdefault"
+    { "password" = "*" }
+    { "uid" = "" }
+    { "gid" = "" }
+    { "class" = "ldap" }
+    { "change_date" = "" }
+    { "expire_date" = "" }
+    { "name" }
+    { "home" }
+    { "shell" } }
+
+(* NIS entries with overrides, ticket #339 *)
+test MasterPasswd.lns get "+@bob::::::::/home/bob:/bin/bash\n" =
+ { "@nis" = "bob"
+   { "home" = "/home/bob" }
+   { "shell" = "/bin/bash" } }
+
+(* NIS user entries *)
+test MasterPasswd.lns get "+bob:::::::::\n" =
+ { "@+nisuser" = "bob" }
+
+test MasterPasswd.lns get "+bob:::::::User Comment:/home/bob:/bin/bash\n" =
+ { "@+nisuser" = "bob"
+   { "name" = "User Comment" }
+   { "home" = "/home/bob" }
+   { "shell" = "/bin/bash" } }
+
+test MasterPasswd.lns put "+bob:::::::::\n" after
+  set "@+nisuser" "alice"
+= "+alice:::::::::\n"
+
+test MasterPasswd.lns put "+bob:::::::::\n" after
+  set "@+nisuser/name" "User Comment";
+  set "@+nisuser/home" "/home/bob";
+  set "@+nisuser/shell" "/bin/bash"
+= "+bob:::::::User Comment:/home/bob:/bin/bash\n"
+
+test MasterPasswd.lns get "-bob:::::::::\n" =
+ { "@-nisuser" = "bob" }
+
+test MasterPasswd.lns put "-bob:::::::::\n" after
+  set "@-nisuser" "alice"
+= "-alice:::::::::\n"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -110,6 +110,7 @@ lens_tests =			\
   lens-lvm.sh			\
   lens-mailscanner.sh   \
   lens-mailscanner_rules.sh	\
+  lens-masterpasswd.sh	\
   lens-mcollective.sh 	\
   lens-mdadm_conf.sh	\
   lens-memcached.sh		\


### PR DESCRIPTION
Found on OpenBSD and possibly other BSD's.

Also update /etc/group lens with support for NIS map with an overridden and
disabled password, i.e. `+:*::`