### PR TITLE
Fixes "server" entries in upstream blocks

### DIFF
--- a/lenses/nginx.aug
+++ b/lenses/nginx.aug
@@ -42,7 +42,7 @@ let block_re_all = block_re | "if" | "location" | "geo" | "map"
 (* View: simple
      A simple entry *)
 let simple =
-     let kw = Rx.word - block_re_all
+     let kw = Rx.word - block_re_all | "server"
   in let sto = store /[^ \t\n;][^;]*/ . Sep.semicolon
   in [ Util.indent . key kw . Sep.space . sto . (Util.eol|Util.comment_eol) ]
 

--- a/lenses/tests/test_nginx.aug
+++ b/lenses/tests/test_nginx.aug
@@ -175,9 +175,14 @@ test lns get "split_clients \"${remote_addr}AAA\" $variable { }\n" =
     { "#variable" = "$variable" } }
 
 (* upstream block *)
-test lns get "upstream backend { }\n" =
+test lns get "upstream backend {
+  server server1.example.com;
+  server server2.example.com;
+}\n" =
  { "upstream"
-    { "#name" = "backend" } }
+    { "#name" = "backend" }
+    { "server" = "server1.example.com" }
+    { "server" = "server2.example.com" } }
 
 (* GH #179 - recursive blocks *)
 let http = "http {


### PR DESCRIPTION
The "server" keyword was reserved for blocks and therefore excluded
from normal entries. This commit adds "server" as a valid entry.