### PR TITLE
Support for negated command alias in /etc/sudoers - fixes #262

### DIFF
--- a/lenses/sudoers.aug
+++ b/lenses/sudoers.aug
@@ -82,15 +82,46 @@ let sep_col  = sep_cont_opt_build ":"
 (* Variable: sep_dquote *)
 let sep_dquote   = Util.del_str "\""
 
+(************************************************************************
+ * View: default_type
+ *   Type definition for <defaults>
+ *
+ *   Definition:
+ *     > Default_Type ::= 'Defaults' |
+ *     >                  'Defaults' '@' Host_List |
+ *     >                  'Defaults' ':' User_List |
+ *     >                  'Defaults' '!' Cmnd_List |
+ *     >                  'Defaults' '>' Runas_List
+ *************************************************************************)
+let default_type     =
+  let value = store /[@:!>][^ \t\n\\]+/ in
+  [ label "type" . value ]
+
+(************************************************************************
+ * View: del_negate
+ *   Delete an even number of '!' signs
+ *************************************************************************)
+let del_negate = del /(!!)*/ ""
+
+(************************************************************************
+ * View: negate_node
+ *   Negation of boolean values for <defaults>. Accept one optional '!'
+ *   and produce a 'negate' node if there is one.
+ *************************************************************************)
+let negate_node = [ del "!" "!" . label "negate" ]
+
+let negate_or_value (key:lens) (value:lens) =
+  [ del_negate . (negate_node . key | key . value) ]
 
 (* Group: Stores *)
 
 (* Variable: sto_to_com_cmnd
 sto_to_com_cmnd does not begin or end with a space *)
-let sto_to_com_cmnd =
-      let alias = /!?/ . Rx.word - /(NO)?(PASSWD|EXEC|SETENV)/
-   in let non_alias = /(!?[\/a-z]([^,:#()\n\\]|\\\\[=:,\\])*[^,=:#() \t\n\\])|[^,=:#() \t\n\\]/
-   in store (alias | non_alias)
+
+let sto_to_com_cmnd = del_negate . negate_node? . (
+      let alias = Rx.word - /(NO)?(PASSWD|EXEC|SETENV)/
+     in let non_alias = /[\/a-z]([^,:#()\n\\]|\\\\[=:,\\])*[^,=:#() \t\n\\]|[^,=:#() \t\n\\]/
+   in store (alias | non_alias))
 
 (* Variable: sto_to_com
 
@@ -255,36 +286,6 @@ let alias = user_alias | runas_alias | host_alias | cmnd_alias
  * Group:                          DEFAULTS
  *************************************************************************)
 
-(************************************************************************
- * View: default_type
- *   Type definition for <defaults>
- *
- *   Definition:
- *     > Default_Type ::= 'Defaults' |
- *     >                  'Defaults' '@' Host_List |
- *     >                  'Defaults' ':' User_List |
- *     >                  'Defaults' '!' Cmnd_List |
- *     >                  'Defaults' '>' Runas_List
- *************************************************************************)
-let default_type     =
-  let value = store /[@:!>][^ \t\n\\]+/ in
-  [ label "type" . value ]
-
-(************************************************************************
- * View: del_negate
- *   Delete an even number of '!' signs
- *************************************************************************)
-let del_negate = del /(!!)*/ ""
-
-(************************************************************************
- * View: negate_node
- *   Negation of boolean values for <defaults>. Accept one optional '!'
- *   and produce a 'negate' node if there is one.
- *************************************************************************)
-let negate_node = [ del "!" "!" . label "negate" ]
-
-let negate_or_value (key:lens) (value:lens) =
-  [ del_negate . (negate_node . key | key . value) ]
 
 (************************************************************************
  * View: parameter_flag

--- a/lenses/sudoers.aug
+++ b/lenses/sudoers.aug
@@ -88,7 +88,7 @@ let sep_dquote   = Util.del_str "\""
 (* Variable: sto_to_com_cmnd
 sto_to_com_cmnd does not begin or end with a space *)
 let sto_to_com_cmnd =
-      let alias = Rx.word - /(NO)?(PASSWD|EXEC|SETENV)/
+      let alias = /!?/ . Rx.word - /(NO)?(PASSWD|EXEC|SETENV)/
    in let non_alias = /(!?[\/a-z]([^,:#()\n\\]|\\\\[=:,\\])*[^,=:#() \t\n\\])|[^,=:#() \t\n\\]/
    in store (alias | non_alias)
 

--- a/lenses/tests/test_sudoers.aug
+++ b/lenses/tests/test_sudoers.aug
@@ -326,3 +326,16 @@ test Sudoers.spec get "group+user somehost = ALL\n" =
       { "command" = "ALL" }
     }
   }
+
+(* Test: Sudoers.spec
+     https://github.com/hercules-team/augeas/issues/262:  Sudoers lens doesn't suppot `!` for command aliases *)
+test Sudoers.spec get "%opssudoers ALL=(ALL) ALL, !BANNED\n" = 
+  { "spec"
+    { "user" = "%opssudoers" }
+    { "host_group"
+      { "host" = "ALL" }
+      { "command" = "ALL"
+        { "runas_user" = "ALL" } }
+      { "command" = "!BANNED" }
+    }
+  }

--- a/lenses/tests/test_sudoers.aug
+++ b/lenses/tests/test_sudoers.aug
@@ -183,7 +183,8 @@ www-data +biglab=(rpinson)NOEXEC: ICAL \
 	  { "host_group"
 	      { "host" = "ALPHA" }
 	      { "command" = "/usr/bin/su [!-]*" }
-	      { "command" = "!/usr/bin/su *root*" } } }
+	      { "command" = "/usr/bin/su *root*" 
+                  { "negate" } } } }
       {}
       { "spec"
           { "user"    = "@my\ admin\ group" }
@@ -328,14 +329,29 @@ test Sudoers.spec get "group+user somehost = ALL\n" =
   }
 
 (* Test: Sudoers.spec
-     https://github.com/hercules-team/augeas/issues/262:  Sudoers lens doesn't suppot `!` for command aliases *)
-test Sudoers.spec get "%opssudoers ALL=(ALL) ALL, !BANNED\n" = 
+     GH #262:  Sudoers lens doesn't support `!` for command aliases *)
+test Sudoers.spec get "%opssudoers ALL=(ALL) ALL, !!!BANNED\n" = 
   { "spec"
     { "user" = "%opssudoers" }
     { "host_group"
       { "host" = "ALL" }
       { "command" = "ALL"
         { "runas_user" = "ALL" } }
-      { "command" = "!BANNED" }
+      { "command" = "BANNED"
+        { "negate" } }
+    }
+  }
+
+(* Test: Sudoers.spec
+     Handle multiple `!` properly in commands *)
+test Sudoers.spec get "%opssudoers ALL=(ALL) ALL, !!!/bin/mount\n" =
+  { "spec"
+    { "user" = "%opssudoers" }
+    { "host_group"
+      { "host" = "ALL" }
+      { "command" = "ALL"
+        { "runas_user" = "ALL" } }
+      { "command" = "/bin/mount"
+        { "negate" } }
     }
   }


### PR DESCRIPTION
Hi there,

This fixes the sudoers lens to support negating command alias groups like this:
```
 %sportshorseracingopssudoers ALL=(ALL) ALL, !DISALLOWED
```

Which currently fails if the command alias appears _after_ a comma.

An additional unit test has been added to support this fix which is also documented at https://fedorahosted.org/augeas/ticket/346 (along with a patch which was a useful confirmation that the fix I'd come up with was correct)

How does this look?  Would be great to get this fixed once and for all.

Thanks,
Geoff