### PR TITLE
Rsyslog: Improve property filter parsing.

### DIFF
--- a/lenses/rsyslog.aug
+++ b/lenses/rsyslog.aug
@@ -48,7 +48,7 @@ let entry = [ label "entry" . Syslog.selectors . Syslog.sep_tab .
 (* View: prop_filter
    Parses property-based filters, which start with ":" and the property name *)
 let prop_filter =
-     let sep = Sep.comma . Util.del_ws_spc
+     let sep = Sep.comma . Util.del_opt_ws " "
   in let prop_name = [ Util.del_str ":" . label "property" . store Rx.word ]
   in let prop_oper = [ label "operation" . store /[A-Za-z!-]+/ ]
   in let prop_val  = [ label "value" . Quote.do_dquote (store /[^\n"]*/) ]

--- a/lenses/syslog.aug
+++ b/lenses/syslog.aug
@@ -198,10 +198,15 @@ module Syslog =
 	 *)
 	let logprogram = pipe . [ label "program" . store /[^ \t\n][^\n]+[^ \t\n]/ ]
 
-	(* View: action
-	 an action is either a file, a host, users, or a program
+	(* View: discard
+	 discards matching messages
 	 *)
-        let action = (file | loghost | users | logprogram)
+	let discard = [ label "discard" . Util.del_str "~" ]
+
+	(* View: action
+	 an action is either a file, a host, users, a program, or discard
+	 *)
+        let action = (file | loghost | users | logprogram | discard)
 
 	(* Group: Entry *)
 

--- a/lenses/tests/test_rsyslog.aug
+++ b/lenses/tests/test_rsyslog.aug
@@ -140,3 +140,11 @@ test Rsyslog.lns get ":msg, !contains, \"error\" /var/log/noterror.log\n" =
     { "value" = "error" }
     { "action"
       { "file" = "/var/log/noterror.log" } } }
+
+test Rsyslog.lns get ":msg,!contains,\"garbage\" ~\n" =
+  { "filter"
+    { "property" = "msg" }
+    { "operation" = "!contains" }
+    { "value" = "garbage" }
+    { "action"
+      { "discard" } } }

--- a/lenses/tests/test_syslog.aug
+++ b/lenses/tests/test_syslog.aug
@@ -212,6 +212,12 @@ daemon.info                                     /var/log/cvsupd.log
 	  set "/entry[1]/action/file" "/foo"
 	  = "*.* /foo\n"
 
+	(* changing file to discard *)
+	test Syslog.lns put "*.* /var\n" after
+	  rm "/entry[1]/action/file" ;
+	  set "/entry[1]/action/discard" ""
+	  = "*.* ~\n"
+
 	(* removing entry *)
 	test Syslog.lns put "*.* /var\n" after
 	  rm "/entry[1]"


### PR DESCRIPTION
 - Treat whitespace after commas as optional.
 - Recognize '~' as a valid syslog action (discard).