### PR TITLE
shellvars lens can't handle "expression1 && expression2" or "expression1 || expression2"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -51,7 +51,8 @@
                  @pattern subnode) (Kaarle Ritvanen) (Issue #265)
                  add eval builtin support;
                  add alias builtin support;
-                 allow (almost) any command
+                 allow (almost) any command;
+                 allow && and || after commands (Issue #215)
     * Simplelines: parse OpenBSD's hostname.if(5)
                    files (Jasper Lievisse Adriaanse) (Issue #252)
     * Spacevars: support flags (Issue #279)

--- a/lenses/tests/test_shellvars.aug
+++ b/lenses/tests/test_shellvars.aug
@@ -627,8 +627,46 @@ test Shellvars.lns get "echo foobar 'and this is baz'
 test Shellvars.lns get "echo \"$STRING\" | grep foo\n" =
   { "@command" = "echo"
     { "@arg" = "\"$STRING\"" }
-    { "@command" = "grep"
-      { "@arg" = "foo" } } }
+    { "@pipe"
+      { "@command" = "grep"
+        { "@arg" = "foo" } } } }
+
+(* Test: Shellvars.lns
+     Support && and || after command
+     GH #215 *)
+test Shellvars.lns get "grep -q \"Debian\" /etc/issue && echo moo\n" =
+  { "@command" = "grep"
+    { "@arg" = "-q \"Debian\" /etc/issue" }
+    { "@and"
+      { "@command" = "echo"
+        { "@arg" = "moo" } } } }
+
+test Shellvars.lns get "grep -q \"Debian\" /etc/issue || echo baa\n" =
+  { "@command" = "grep"
+    { "@arg" = "-q \"Debian\" /etc/issue" }
+    { "@or"
+      { "@command" = "echo"
+        { "@arg" = "baa" } } } }
+
+test Shellvars.lns get "grep -q \"Debian\" /etc/issue && DEBIAN=1\n" =
+  { "@command" = "grep"
+    { "@arg" = "-q \"Debian\" /etc/issue" }
+    { "@and"
+      { "DEBIAN" = "1" } } }
+
+test Shellvars.lns get "cat /etc/issue | grep -q \"Debian\" && echo moo || echo baa\n" =
+  { "@command" = "cat"
+    { "@arg" = "/etc/issue" }
+    { "@pipe"
+      { "@command" = "grep"
+        { "@arg" = "-q \"Debian\"" }
+        { "@and"
+          { "@command" = "echo"
+            { "@arg" = "moo" }
+            { "@or"
+              { "@command" = "echo"
+                { "@arg" = "baa" } } } } } } } }
+
 
 (* Local Variables: *)
 (* mode: caml       *)


### PR DESCRIPTION
The shellvars lens fails to handle code like the following:

```
[ ! -z $DEBUG ] && ENABLE_DEBUG="1"
```

or

```
grep -q "Debian" /etc/issue && DEBIAN=1
```

or other variations of this kind of expressions.