### PR TITLE
reprepro_uploader lens doesn't support groups

### DIFF
--- a/lenses/reprepro_uploaders.aug
+++ b/lenses/reprepro_uploaders.aug
@@ -179,10 +179,13 @@ let allow =
 (* View: group
    A group declaration *)
 let group =
-    [ key "group" . Sep.space
-  . store Rx.word . Sep.space
-  . [ key "add" . Sep.space
-    . store Rx.word . Util.eol ] ]
+     let add = [ key "add" . Sep.space
+             . store Rx.word ]
+  in let contains = [ key "contains" . Sep.space
+                    . store Rx.word ]
+  in [ key "group" . Sep.space
+     . store Rx.word . Sep.space
+     . (add | contains) . Util.eol ]
 
 (* View: entry
    An entry is either an <allow> statement

--- a/lenses/reprepro_uploaders.aug
+++ b/lenses/reprepro_uploaders.aug
@@ -9,7 +9,6 @@ About: Reference
 
 About: License
    This file is licenced under the LGPL v2+, like the rest of Augeas.
-
 About: Lens Usage
    See <lns>.
 
@@ -129,6 +128,16 @@ let by_key =
                   . store (Rx.word - "any") ] in
     value "key" . (any_key | named_key)
 
+(* View: by_group
+   Authenticate packages by a groupname.
+
+   > $reprepro/allow[1]/by/group = "groupname"
+
+ *)
+let by_group = value "group"
+             . [ key "group" . Sep.space
+             . store Rx.word ]
+
 (* View: by
    <by> statements define who is allowed to upload.
    It can be simple keywords, like "anybody" or "unsigned",
@@ -143,7 +152,7 @@ let by_key =
 let by =
     [ key "by" . Sep.space
          . ( store ("anybody"|"unsigned")
-           | by_key ) ]
+           | by_key | by_group ) ]
 
 (* View: entry
    An entry is an allow statement, e.g.:

--- a/lenses/reprepro_uploaders.aug
+++ b/lenses/reprepro_uploaders.aug
@@ -184,9 +184,10 @@ let group =
   in let contains = [ key "contains" . Sep.space
                     . store Rx.word ]
   in let empty = [ key "empty" ]
+  in let unused = [ key "unused" ]
   in [ key "group" . Sep.space
      . store Rx.word . Sep.space
-     . (add | contains | empty) . Util.eol ]
+     . (add | contains | empty | unused) . Util.eol ]
 
 (* View: entry
    An entry is either an <allow> statement

--- a/lenses/reprepro_uploaders.aug
+++ b/lenses/reprepro_uploaders.aug
@@ -183,9 +183,10 @@ let group =
              . store Rx.word ]
   in let contains = [ key "contains" . Sep.space
                     . store Rx.word ]
+  in let empty = [ key "empty" ]
   in [ key "group" . Sep.space
      . store Rx.word . Sep.space
-     . (add | contains) . Util.eol ]
+     . (add | contains | empty) . Util.eol ]
 
 (* View: entry
    An entry is either an <allow> statement

--- a/lenses/reprepro_uploaders.aug
+++ b/lenses/reprepro_uploaders.aug
@@ -154,8 +154,8 @@ let by =
          . ( store ("anybody"|"unsigned")
            | by_key | by_group ) ]
 
-(* View: entry
-   An entry is an allow statement, e.g.:
+(* View: allow
+   An allow entry, e.g.:
 
    > $reprepro/allow[1]
    > $reprepro/allow[1]/and[1]
@@ -171,10 +171,24 @@ let by =
    > $reprepro/allow[1]/by/key = "ABCD1234"
 
  *)
-let entry =
+let allow =
     [ key "allow" . Sep.space
   . condition_list . Sep.space
   . by . Util.eol ]
+
+(* View: group
+   A group declaration *)
+let group =
+    [ key "group" . Sep.space
+  . store Rx.word . Sep.space
+  . [ key "add" . Sep.space
+    . store Rx.word . Util.eol ] ]
+
+(* View: entry
+   An entry is either an <allow> statement
+   or a <group> definition.
+ *)
+let entry = allow | group
 
 (* View: lns
    The lens is made of <Util.empty>, <Util.comment> and <entry> lines *)

--- a/lenses/tests/test_reprepro_uploaders.aug
+++ b/lenses/tests/test_reprepro_uploaders.aug
@@ -152,3 +152,9 @@ test Reprepro_Uploaders.lns get "group groupname add key-id\n" =
 test Reprepro_Uploaders.lns get "group groupname contains group2\n" =
   { "group" = "groupname"
     { "contains" = "group2" } }
+
+(* Test: Reprepro_Uploaders.lns
+     Empty group, GH #283 *)
+test Reprepro_Uploaders.lns get "group groupname empty\n" =
+  { "group" = "groupname"
+    { "empty" } }

--- a/lenses/tests/test_reprepro_uploaders.aug
+++ b/lenses/tests/test_reprepro_uploaders.aug
@@ -133,3 +133,11 @@ test Reprepro_Uploaders.lns get conf =
             { "or" = "source" { "not" } { "or" = "*melanie*" } { "or" = "katya" } } }
     { "by" = "key"
       { "key" = "any" } } }
+
+(* Test: Reprepro_Uploaders.lns
+     Support group conditions, GH #283 *)
+test Reprepro_Uploaders.lns get "allow sections 'desktop/*' by group groupname\n" =
+  { "allow"
+    { "and" { "or" = "sections" { "or" = "desktop/*" } } }
+    { "by" = "group" { "group" = "groupname" } } }
+

--- a/lenses/tests/test_reprepro_uploaders.aug
+++ b/lenses/tests/test_reprepro_uploaders.aug
@@ -158,3 +158,9 @@ test Reprepro_Uploaders.lns get "group groupname contains group2\n" =
 test Reprepro_Uploaders.lns get "group groupname empty\n" =
   { "group" = "groupname"
     { "empty" } }
+
+(* Test: Reprepro_Uploaders.lns
+     Unused group, GH #283 *)
+test Reprepro_Uploaders.lns get "group groupname unused\n" =
+  { "group" = "groupname"
+    { "unused" } }

--- a/lenses/tests/test_reprepro_uploaders.aug
+++ b/lenses/tests/test_reprepro_uploaders.aug
@@ -141,3 +141,9 @@ test Reprepro_Uploaders.lns get "allow sections 'desktop/*' by group groupname\n
     { "and" { "or" = "sections" { "or" = "desktop/*" } } }
     { "by" = "group" { "group" = "groupname" } } }
 
+(* Test: Reprepro_Uploaders.lns
+     Declare group condition, GH #283 *)
+test Reprepro_Uploaders.lns get "group groupname add key-id\n" =
+  { "group" = "groupname"
+    { "add" = "key-id" } }
+

--- a/lenses/tests/test_reprepro_uploaders.aug
+++ b/lenses/tests/test_reprepro_uploaders.aug
@@ -147,3 +147,8 @@ test Reprepro_Uploaders.lns get "group groupname add key-id\n" =
   { "group" = "groupname"
     { "add" = "key-id" } }
 
+(* Test: Reprepro_Uploaders.lns
+     Group inheritance, GH #283 *)
+test Reprepro_Uploaders.lns get "group groupname contains group2\n" =
+  { "group" = "groupname"
+    { "contains" = "group2" } }


### PR DESCRIPTION
reprepro's `uploaders` file can contain `group` definitions, see [doc](https://mirrorer.alioth.debian.org/reprepro.1.html#UPLOADERS%20FILES). Unless I'm wrong, those items are not parsed by the lens.

```
allow condition by group groupname
   which allows every member of group groupname. Groups can be manipulated by

group groupname add key-id
   to add a key-id (see above for details) to this group, or

group groupname contains groupname
   to add a whole group to a group.
  To avoid warnings in incomplete config files there is also

group groupname empty
   to declare a group has no members (avoids warnings that it is used without those) and

group groupname unused
   to declare that a group is not yet used (avoid warnings that it is not used).
```