### PR TITLE
Inherit ktype and vtype in subtree lens

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -527,12 +527,20 @@ static struct value *lns_atype(struct info *info, struct value *l) {
 
 /* V_LENS -> V_REGEXP */
 static struct value *lns_vtype(struct info *info, struct value *l) {
-    return lns_value_of_type(info, l->lens->vtype);
+    if (l->lens->tag == L_SUBTREE) {
+        return lns_value_of_type(info, l->lens->sub->vtype);
+    } else {
+        return lns_value_of_type(info, l->lens->vtype);
+    }
 }
 
 /* V_LENS -> V_REGEXP */
 static struct value *lns_ktype(struct info *info, struct value *l) {
-    return lns_value_of_type(info, l->lens->ktype);
+    if (l->lens->tag == L_SUBTREE) {
+        return lns_value_of_type(info, l->lens->sub->ktype);
+    } else {
+      return lns_value_of_type(info, l->lens->ktype);
+    }
 }
 
 /* V_LENS -> V_STRING */

--- a/src/lens.c
+++ b/src/lens.c
@@ -334,6 +334,7 @@ struct value *lns_make_subtree(struct info *info, struct lens *l) {
 
     lens = make_lens_unop(L_SUBTREE, info, l);
     lens->ctype = ref(l->ctype);
+    lens->sub = l;
     if (! l->recursive)
         lens->atype = subtree_atype(info, l->ktype, l->vtype);
     lens->value = lens->key = 0;

--- a/src/lens.h
+++ b/src/lens.h
@@ -80,6 +80,7 @@ struct lens {
     struct regexp            *ktype;
     struct regexp            *vtype;
     struct jmt               *jmt;    /* When recursive == 1, might have jmt */
+    struct lens              *sub;
     unsigned int              value : 1;
     unsigned int              key : 1;
     unsigned int              recursive : 1;


### PR DESCRIPTION
Currently, subtree lenses do not have ktype and vtype set. For this reason, the following code:

```augeas
module Test =
let lns = [ key "a" . store "b" ]
let _ = print_string "\nktype:\n"
let _ = print_regexp (lens_ktype lns)
let _ = print_string "\nvtype:\n"
let _ = print_regexp (lens_vtype lns)
let _ = print_string "\n"
```

returns:

```
$ augparse test.aug 

ktype:
/()/
vtype:
/()/
```

 It would make sense (and it would be very useful) for them to inherit their sublens types, such that the above code returns:

```

ktype:
/a/
vtype:
/b/
```


I've tried two approaches so far:

## Set ktype and vtype in `lns_make_subtree`

```diff
diff --git a/src/lens.c b/src/lens.c
index 37db306..078fdfa 100644
--- a/src/lens.c
+++ b/src/lens.c
@@ -334,6 +334,8 @@ struct value *lns_make_subtree(struct info *info, struct lens *l) {
 
     lens = make_lens_unop(L_SUBTREE, info, l);
     lens->ctype = ref(l->ctype);
+    lens->ktype = l->ktype;
+    lens->vtype = l->vtype;
     if (! l->recursive)
         lens->atype = subtree_atype(info, l->ktype, l->vtype);
     lens->value = lens->key = 0;
```

* this is the most obvious/simple option
* it makes my tests pass

but it makes lots of lenses fail typechecking, and I have no idea why (and digging into fa stuff gives me a headache)


## Add a `sub` field in lenses, and use it to print ktype and vtype

```diff
diff --git a/src/builtin.c b/src/builtin.c
index e674181..8cf210c 100644
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -527,12 +527,20 @@ static struct value *lns_atype(struct info *info, struct value *l) {
 
 /* V_LENS -> V_REGEXP */
 static struct value *lns_vtype(struct info *info, struct value *l) {
-    return lns_value_of_type(info, l->lens->vtype);
+    if (l->lens->tag == L_SUBTREE) {
+        return lns_value_of_type(info, l->lens->sub->vtype);
+    } else {
+        return lns_value_of_type(info, l->lens->vtype);
+    }
 }
 
 /* V_LENS -> V_REGEXP */
 static struct value *lns_ktype(struct info *info, struct value *l) {
-    return lns_value_of_type(info, l->lens->ktype);
+    if (l->lens->tag == L_SUBTREE) {
+        return lns_value_of_type(info, l->lens->sub->ktype);
+    } else {
+      return lns_value_of_type(info, l->lens->ktype);
+    }
 }
 
 /* V_LENS -> V_STRING */
diff --git a/src/lens.c b/src/lens.c
index 37db306..b0430bb 100644
--- a/src/lens.c
+++ b/src/lens.c
@@ -334,6 +334,7 @@ struct value *lns_make_subtree(struct info *info, struct lens *l) {
 
     lens = make_lens_unop(L_SUBTREE, info, l);
     lens->ctype = ref(l->ctype);
+    lens->sub = l;
     if (! l->recursive)
         lens->atype = subtree_atype(info, l->ktype, l->vtype);
     lens->value = lens->key = 0;
diff --git a/src/lens.h b/src/lens.h
index dfa7cbd..051988d 100644
--- a/src/lens.h
+++ b/src/lens.h
@@ -80,6 +80,7 @@ struct lens {
     struct regexp            *ktype;
     struct regexp            *vtype;
     struct jmt               *jmt;    /* When recursive == 1, might have jmt */
+    struct lens              *sub;
     unsigned int              value : 1;
     unsigned int              key : 1;
     unsigned int              recursive : 1;
```

* this doesn't break the lenses typechecking as the first option
* but it fails on recursive cases, such as `[ key "a" ] | [ key "b" ]`, because each lens in the union has a NULL ktype and vtype.