### PR TITLE
multipath.conf lense: added bunch of missing keywords

### DIFF
--- a/lenses/multipath.aug
+++ b/lenses/multipath.aug
@@ -45,6 +45,10 @@ let common_setting =
  |kv "rr_weight" /priorities|uniform/
  |kv "no_path_retry" (Rx.integer | /fail|queue/)
  |kv /rr_min_io(_rq)?/ Rx.integer
+ |kv "flush_on_last_del" /yes|no/
+ |kv "reservation_key" Rx.word
+ |kv "delay_watch_checks" (Rx.integer|"no")
+ |kv "delay_wait_checks" (Rx.integer|"no")
 
 let default_setting =
   kv "polling_interval" Rx.integer
@@ -55,9 +59,15 @@ let default_setting =
   |kv "fast_io_fail_tmo" Rx.integer
   |kv "verbosity" /[0-6]/
   |kv "reassign_maps" /yes|no/
-  (* These are not in the manpage but in the example multipath.conf *)
   |kv "prio" Rx.word
   |kv "max_fds" Rx.integer
+  |kv "find_multipaths" /yes|no/
+  |kv "checker_timeout" Rx.integer
+  |kv "hwtable_regex_match" /yes|no/
+  |kv "reload_readwrite" /yes|no/
+  |kv "replace_wwid_whitespace" /yes|no/
+  |kv "force_sync" /yes|no/
+  |kv "config_dir" Rx.fspath
   (* SUSE extensions *)
   |kv "async_timeout" Rx.integer
   |kv "max_polling_interval" Rx.integer
@@ -74,7 +84,6 @@ let default_setting =
   |kv "log_checker_err" Rx.word
   |kv "retain_attached_hw_handler" /yes|no/
   |kv "detect_prio" /yes|no/
-  |kv "flush_on_last_del" /yes|no/
 
 (* A device subsection *)
 let device =
@@ -117,4 +126,5 @@ let devices =
 
 let lns = (comment|empty|defaults|blacklist|devices|multipaths)*
 
-let xfm = transform lns (incl "/etc/multipath.conf")
+let xfm = transform lns (incl "/etc/multipath.conf" .
+                         incl "/etc/multipath/conf.d/*.conf")

--- a/lenses/tests/test_multipath.aug
+++ b/lenses/tests/test_multipath.aug
@@ -40,6 +40,15 @@ defaults {
   reassign_maps yes
   fast_io_fail_tmo  5
   async_timeout 5
+  flush_on_last_del no
+  delay_watch_checks no
+  delay_wait_checks no
+  find_multipaths yes
+  checker_timeout 10
+  hwtable_regex_match yes
+  reload_readwrite no
+  force_sync yes
+  config_dir /etc/multipath/conf.d
 }
 
 # Sections without empty lines in between
@@ -61,6 +70,7 @@ multipaths {
 		failback		manual
 		rr_weight		priorities
 		no_path_retry		5
+        flush_on_last_del yes
 	}
 	multipath {
 		wwid			1DEC_____321816758474
@@ -80,12 +90,15 @@ devices {
 		rr_weight		priorities
 		rr_min_io_rq		75
 		no_path_retry		queue
+        reservation_key a12345
 	}
 	device {
 		vendor			\"COMPAQ  \"
 		product			\"MSA1000         \"
 		path_grouping_policy	multibus
 		polling_interval	9
+        delay_watch_checks 10
+        delay_wait_checks 10
 	}
 }\n"
 
@@ -126,7 +139,16 @@ test Multipath.lns get conf =
     { "verbosity" = "2" }
     { "reassign_maps" = "yes" }
     { "fast_io_fail_tmo" = "5" }
-    { "async_timeout" = "5" } }
+    { "async_timeout" = "5" }
+    { "flush_on_last_del" = "no" }
+    { "delay_watch_checks" = "no" }
+    { "delay_wait_checks" = "no" }
+    { "find_multipaths" = "yes" }
+    { "checker_timeout" = "10" }
+    { "hwtable_regex_match" = "yes" }
+    { "reload_readwrite" = "no" }
+    { "force_sync" = "yes" }
+    { "config_dir" = "/etc/multipath/conf.d" } }
   { }
   { "#comment" = "Sections without empty lines in between" }
   { "blacklist"
@@ -145,7 +167,8 @@ test Multipath.lns get conf =
       { "path_selector" = "round-robin 0" }
       { "failback" = "manual" }
       { "rr_weight" = "priorities" }
-      { "no_path_retry" = "5" } }
+      { "no_path_retry" = "5" }
+      { "flush_on_last_del" = "yes" } }
     { "multipath"
       { "wwid" = "1DEC_____321816758474" }
       { "alias" = "red" } } }
@@ -161,9 +184,12 @@ test Multipath.lns get conf =
       { "failback" = "15" }
       { "rr_weight" = "priorities" }
       { "rr_min_io_rq" = "75" }
-      { "no_path_retry" = "queue" } }
+      { "no_path_retry" = "queue" }
+      { "reservation_key" = "a12345" } }
     { "device"
       { "vendor" = "COMPAQ  " }
       { "product" = "MSA1000         " }
       { "path_grouping_policy" = "multibus" }
-      { "polling_interval" = "9" } } }
+      { "polling_interval" = "9" }
+      { "delay_watch_checks" = "10" }
+      { "delay_wait_checks" = "10" } } }


### PR DESCRIPTION
Improved previous pull request. Now all keywords available in centos6 should be present. Adapted multipath test, to test a new keywords also.