### PR TITLE
Dhclient: avoid put ambiguity for node without value

### DIFF
--- a/lenses/dhclient.aug
+++ b/lenses/dhclient.aug
@@ -95,7 +95,8 @@ let stmt_hash_re      = "send"
 
 let stmt_hash         = [ key stmt_hash_re
                         . sep_spc
-                        . [ key word . sep_spc . (sto_to_spc_noeval|rfc_code|eval) ]
+                        . ( [ key word . sep_spc . sto_to_spc_noeval ]
+                          | [ key word . sep_spc . (rfc_code|eval) ] )
                         . sep_scl
                         . comment_or_eol ]
 

--- a/lenses/tests/test_dhclient.aug
+++ b/lenses/tests/test_dhclient.aug
@@ -148,3 +148,6 @@ test Dhclient.lns get "send dhcp-client-identifier = hardware;\n" =
   { "send"
     { "dhcp-client-identifier"
       { "#eval" = "hardware" } } }
+
+test Dhclient.lns put "send host-name = gethostname();\n"
+  after set "/send/host-name/#eval" "test" = "send host-name = test;\n"


### PR DESCRIPTION
When `dhclient.conf` contains a line like:

```
send host-name = gethostname();
```

*any* change to the file fails to save, since it expects a mandatory value for the node. This PR fixes this by separating the case with a node value from the cases without.