### PR TITLE
Aptsources lens can't handle [ options ] in /etc/apt/sources.list

### DIFF
--- a/lenses/aptsources.aug
+++ b/lenses/aptsources.aug
@@ -10,7 +10,7 @@ module Aptsources =
  * Group: Utility variables/functions
  ************************************************************************)
   (* View:  sep_ws *)
-  let sep_ws = del /[ \t]+/ " "
+  let sep_ws = Sep.space
 
   (* View: eol *)
   let eol = Util.del_str "\n"
@@ -21,18 +21,27 @@ module Aptsources =
   let empty = Util.empty
 
   (* View: word *)
-  let word = /[^# \n\t]+/
+  let word = /[^][# \n\t]+/
 
 (************************************************************************
  * Group: Keywords
  ************************************************************************)
   (* View: record *)
-  let record = [ Util.indent . seq "source" . [ label "type" . store word ] . sep_ws .
-                                [ label "uri"  . store word ] . sep_ws .
-                                [ label "distribution" . store word ]  .
-                                [ label "component" . sep_ws . store word ]* .
-                                del /[ \t]*(#.*)?/ ""
-                 . eol ]
+  let record =
+       let option = Build.key_value Rx.word Sep.equal (store Rx.word)
+    in let options = [ label "options"
+                . Util.del_str "[" . Sep.opt_space
+                . Build.opt_list option Sep.space
+                . Sep.opt_space . Util.del_str "]"
+                . sep_ws ]
+    in [ Util.indent . seq "source"
+       . [ label "type" . store word ] . sep_ws
+       . options?
+       . [ label "uri"  . store word ] . sep_ws
+       . [ label "distribution" . store word ]
+       . [ label "component" . sep_ws . store word ]*
+       . del /[ \t]*(#.*)?/ ""
+       . eol ]
 
 (************************************************************************
  * Group: Lens

--- a/lenses/aptsources.aug
+++ b/lenses/aptsources.aug
@@ -28,7 +28,8 @@ module Aptsources =
  ************************************************************************)
   (* View: record *)
   let record =
-       let option = Build.key_value Rx.word Sep.equal (store Rx.word)
+       let option_sep = [ label "operation" . store /[+-]/]? . Sep.equal
+    in let option = Build.key_value /arch|trusted/ option_sep (store Rx.word)
     in let options = [ label "options"
                 . Util.del_str "[" . Sep.opt_space
                 . Build.opt_list option Sep.space

--- a/lenses/tests/test_aptsource.aug
+++ b/lenses/tests/test_aptsource.aug
@@ -67,7 +67,7 @@ deb ftp://mirror.bytemark.co.uk/debian/ etch main non-free contrib
 
     (* Support options, GH #295 *)
     test Aptsources.lns get "deb [arch=amd64] tor+http://ftp.us.debian.org/debian sid main contrib
-deb [ arch=amd64 trusted=true ] http://ftp.us.debian.org/debian sid main contrib\n" =
+deb [ arch+=amd64 trusted-=true ] http://ftp.us.debian.org/debian sid main contrib\n" =
   { "1"
     { "type" = "deb" }
     { "options"
@@ -80,8 +80,8 @@ deb [ arch=amd64 trusted=true ] http://ftp.us.debian.org/debian sid main contrib
   { "2"
     { "type" = "deb" }
     { "options"
-      { "arch" = "amd64" }
-      { "trusted" = "true" }
+      { "arch" = "amd64" { "operation" = "+" } }
+      { "trusted" = "true" { "operation" = "-" } }
     }
     { "uri" = "http://ftp.us.debian.org/debian" }
     { "distribution" = "sid" }

--- a/lenses/tests/test_aptsource.aug
+++ b/lenses/tests/test_aptsource.aug
@@ -65,6 +65,30 @@ deb ftp://mirror.bytemark.co.uk/debian/ etch main non-free contrib
       set "/1/type" "deb"
     = trailing_comment
 
+    (* Support options, GH #295 *)
+    test Aptsources.lns get "deb [arch=amd64] tor+http://ftp.us.debian.org/debian sid main contrib
+deb [ arch=amd64 trusted=true ] http://ftp.us.debian.org/debian sid main contrib\n" =
+  { "1"
+    { "type" = "deb" }
+    { "options"
+      { "arch" = "amd64" }
+    }
+    { "uri" = "tor+http://ftp.us.debian.org/debian" }
+    { "distribution" = "sid" }
+    { "component" = "main" }
+    { "component" = "contrib" } }
+  { "2"
+    { "type" = "deb" }
+    { "options"
+      { "arch" = "amd64" }
+      { "trusted" = "true" }
+    }
+    { "uri" = "http://ftp.us.debian.org/debian" }
+    { "distribution" = "sid" }
+    { "component" = "main" }
+    { "component" = "contrib" } }
+
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)


### PR DESCRIPTION
Sources.list files may contain options in the format "[arch=amd64,armhf]" immediately after type field.  This is not understood properly understood by the aptsources lens leading to incorrect parsing.  For example, with the following repository lines in sources.list:

```
deb [arch=amd64] tor+http://ftp.us.debian.org/debian sid main contrib
deb [ arch=amd64 trusted=true ] http://ftp.us.debian.org/debian sid main contrib
```
Augeas parses parses as follows:
```
augtool> ls /files/etc/apt/sources.list/1
type = deb
uri = [arch=amd64]
distribution = tor+http://ftp.us.debian.org/debian
component[1] = sid
component[2] = main
component[3] = contrib
component[4] = non-free
augtool> ls /files/etc/apt/sources.list/2
type = deb
uri = [
distribution = arch=amd64
component[1] = trusted=true
component[2] = ]
component[3] = http://ftp.us.debian.org/debian
component[4] = sid
component[5] = main
component[6] = contrib
component[7] = non-free
```
Options can contain multiple settings as key=value pairs separated by spaces.  Multiple values are possible as a comma separated list.  Current set of options are "arch=", "arch+=", "arch-=" and "trusted=".  For more information about options see man page for sources.list.

Augeas should properly parse and understand options so that not are other fields properly understood but also options and read and set properly.