### PR TITLE
Aptsources lens can't handle cdrom:// URLs properly

### DIFF
--- a/lenses/aptsources.aug
+++ b/lenses/aptsources.aug
@@ -23,6 +23,14 @@ module Aptsources =
   (* View: word *)
   let word = /[^][# \n\t]+/
 
+  (* View: uri *)
+  let uri =
+       let protocol = /[a-z+]+:/
+    in let path = /\/[^] \t]*/
+    in let path_brack = /\[[^]]+\]\/?/
+    in protocol? . path
+     | protocol . path_brack
+
 (************************************************************************
  * Group: Keywords
  ************************************************************************)
@@ -38,7 +46,7 @@ module Aptsources =
     in [ Util.indent . seq "source"
        . [ label "type" . store word ] . sep_ws
        . options?
-       . [ label "uri"  . store word ] . sep_ws
+       . [ label "uri"  . store uri ] . sep_ws
        . [ label "distribution" . store word ]
        . [ label "component" . sep_ws . store word ]*
        . del /[ \t]*(#.*)?/ ""

--- a/lenses/tests/test_aptsource.aug
+++ b/lenses/tests/test_aptsource.aug
@@ -88,6 +88,14 @@ deb [ arch+=amd64 trusted-=true ] http://ftp.us.debian.org/debian sid main contr
     { "component" = "main" }
     { "component" = "contrib" } }
 
+    (* cdrom entries may have spaces, GH #296 *)
+    test Aptsources.lns get "deb cdrom:[Debian GNU/Linux 7.5.0 _Wheezy_ - Official amd64 CD Binary-1 20140426-13:37]/ wheezy main\n" =
+  { "1"
+    { "type" = "deb" }
+    { "uri" = "cdrom:[Debian GNU/Linux 7.5.0 _Wheezy_ - Official amd64 CD Binary-1 20140426-13:37]/" }
+    { "distribution" = "wheezy" }
+    { "component" = "main" } }
+
 
 (* Local Variables: *)
 (* mode: caml       *)


### PR DESCRIPTION
CDROM URLs in /etc/apt/sources.list may contain spaces in them.  This is not properly handled by `aptsources` lens properly.  For example, the following is a valid sources.list repository entry.
```
deb cdrom:[Debian GNU/Linux 7.5.0 _Wheezy_ - Official amd64 CD Binary-1 20140426-13:37]/ wheezy main
```
With this entry, aptsources lens parses as follows:
```
augtool> ls /files/etc/apt/sources.list/1
type = deb
uri = cdrom:[Debian
distribution = GNU/Linux
component[1] = 7.5.0
component[2] = _Wheezy_
component[3] = -
component[4] = Official
component[5] = amd64
component[6] = CD
component[7] = Binary-1
component[8] = 20140426-13:37]/
component[9] = wheezy
component[10] = main
augtool> 
```

Aptsources lens should be fixed to allow spaces in URL when enclosed in "[" and "]".