### PR TITLE
Improve performance of some path expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,12 +35,14 @@ src/parser.[ch]
 src/lexer.[ch]
 src/augtool
 src/augparse
+src/callgrind.*
 tests/fatest
 tests/leak
 tests/lens-*.sh
 tests/test-api
 tests/test-xpath
 tests/test-load
+tests/test-perf
 tests/test-run
 tests/test-save
 tests/*.trs

--- a/src/internal.h
+++ b/src/internal.h
@@ -36,6 +36,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <locale.h>
+#include <stdint.h>
 
 /*
  * Various parameters about env vars, special tree nodes etc.
@@ -377,6 +378,7 @@ struct tree {
     struct tree *children;   /* List of children through NEXT */
     char        *value;
     int          dirty;
+    uint8_t      added;      /* only used by ns_add to dedupe nodesets */
     struct span *span;
 };
 

--- a/src/try
+++ b/src/try
@@ -31,6 +31,8 @@ elif [[ "x$1" == "xstrace" ]] ; then
     libtool --mode=execute /usr/bin/strace ./augtool --nostdinc < $AUGCMDS
 elif [[ "x$1" == "xvalgrind" ]] ; then
     libtool --mode=execute valgrind --leak-check=full ./augtool --nostdinc < $AUGCMDS
+elif [[ "x$1" == "xcallgrind" ]] ; then
+    libtool --mode=execute valgrind --tool=callgrind ./augtool --nostdinc < $AUGCMDS
 elif [[ "x$1" == "xcli" ]] ; then
     shift
     exec ./augtool --nostdinc "$@"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -265,7 +265,7 @@ noinst_SCRIPTS = $(check_SCRIPTS)
 
 noinst_PROGRAMS = leak
 
-check_PROGRAMS = fatest test-xpath test-load test-save test-api test-run
+check_PROGRAMS = fatest test-xpath test-load test-perf test-save test-api test-run
 
 TESTS_ENVIRONMENT = \
   PATH='$(abs_top_builddir)/src$(PATH_SEPARATOR)'"$$PATH" \
@@ -294,6 +294,9 @@ test_api_LDADD = $(top_builddir)/src/libaugeas.la $(LIBXML_LIBS) $(GNULIB)
 
 test_run_SOURCES = test-run.c cutest.c cutest.h $(top_srcdir)/src/memory.c $(top_srcdir)/src/memory.h
 test_run_LDADD = $(top_builddir)/src/libaugeas.la $(LIBXML_LIBS) $(GNULIB)
+
+test_perf_SOURCES = test-perf.c cutest.c cutest.h $(top_srcdir)/src/memory.c $(top_srcdir)/src/memory.h
+test_perf_LDADD = $(top_builddir)/src/libaugeas.la $(LIBXML_LIBS) $(GNULIB)
 
 leak_SOURCES = leak.c
 leak_LDADD =  $(top_builddir)/src/libaugeas.la $(LIBXML_LIBS) $(GNULIB)

--- a/tests/test-perf.c
+++ b/tests/test-perf.c
@@ -1,0 +1,111 @@
+/*
+ * test-perf.c: test performance of API functions
+ *
+ * Copyright (C) 2009-2015 Red Hat Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ *
+ * Author: David Lutterkort <lutter@redhat.com>
+ */
+
+#include <config.h>
+
+#include "augeas.h"
+
+#include "cutest.h"
+#include "internal.h"
+
+#include <sys/time.h>
+#include <unistd.h>
+
+static const char *abs_top_srcdir;
+static char *root;
+static char *loadpath;
+
+#define die(msg)                                                    \
+    do {                                                            \
+        fprintf(stderr, "%d: Fatal error: %s\n", __LINE__, msg);    \
+        exit(EXIT_FAILURE);                                         \
+    } while(0)
+
+#define time_taken(start, stop) \
+    ((stop.tv_sec - start.tv_sec)*1000 + (stop.tv_usec - start.tv_usec)/1000)
+
+/* Test performance of basic predicate [1..n] with many nodes */
+static void testPerfPredicate(CuTest *tc) {
+    const char *value;
+    char *path;
+    struct timeval stop, start;
+    struct augeas *aug;
+
+    aug = aug_init(root, loadpath, AUG_NO_STDINC|AUG_NO_LOAD);
+    CuAssertPtrNotNull(tc, aug);
+
+    gettimeofday(&start, NULL);
+
+    for (int i=1; i <= 5000; i++) {
+        if (!asprintf(&path, "/test/service[%i]", i))
+            die("failed to generate set path");
+        aug_set(aug, path, "test");
+    }
+
+    for (int i=1; i <= 5000; i++) {
+        if (!asprintf(&path, "/test/service[%i]", i))
+            die("failed to generate set path");
+        aug_get(aug, path, &value);
+        CuAssertStrEquals(tc, "test", value);
+    }
+
+    gettimeofday(&stop, NULL);
+    printf("testPerfPredicate = %lums\n", time_taken(start, stop));
+
+    aug_close(aug);
+}
+
+int main(void) {
+    char *output = NULL;
+    CuSuite* suite = CuSuiteNew();
+    CuSuiteSetup(suite, NULL, NULL);
+
+    SUITE_ADD_TEST(suite, testPerfPredicate);
+
+    abs_top_srcdir = getenv("abs_top_srcdir");
+    if (abs_top_srcdir == NULL)
+        die("env var abs_top_srcdir must be set");
+
+    if (asprintf(&root, "%s/tests/root", abs_top_srcdir) < 0) {
+        die("failed to set root");
+    }
+
+    if (asprintf(&loadpath, "%s/lenses", abs_top_srcdir) < 0) {
+        die("failed to set loadpath");
+    }
+
+    CuSuiteRun(suite);
+    CuSuiteSummary(suite, &output);
+    CuSuiteDetails(suite, &output);
+    printf("%s\n", output);
+    free(output);
+    return suite->failCount;
+}
+
+/*
+ * Local variables:
+ *  indent-tabs-mode: nil
+ *  c-indent-level: 4
+ *  c-basic-offset: 4
+ *  tab-width: 4
+ * End:
+ */


### PR DESCRIPTION
Path expressions of the form `service[75]` were very slow when there were a large number of `service` nodes. These patches try to speed that up.

Tons of thanks to @domcleal for figuring out why this was slow, writing a test that demonstrates the problem and providing lots of detail on what exactly was going on.