### PR TITLE
Fix a Clang 'sometimes-uninitialized' warning

### DIFF
--- a/src/fa.c
+++ b/src/fa.c
@@ -1455,6 +1455,8 @@ static int minimize_hopcroft(struct fa *fa) {
     int *nsnum = NULL;
     int *nsind = NULL;
     int result = -1;
+    unsigned int nstates = 0;
+    int nsigma = 0;
 
     F(determinize(fa, NULL));
 
@@ -1474,9 +1476,8 @@ static int minimize_hopcroft(struct fa *fa) {
     list_for_each(s, fa->initial) {
         F(state_set_push(states, s));
     }
-    unsigned int nstates = states->used;
+    nstates = states->used;
 
-    int nsigma;
     sigma = start_points(fa, &nsigma);
     E(sigma == NULL);
 


### PR DESCRIPTION
clang-700.1.76 was issuing a 'sometimes-uninitialized' warning for
minimize_hopcroft() because it was possible for control flow to reach
the \`for (int i=0; i < nstates*nsigma; i++)' loop in done: before
\`nstates' and/or \`nsigma' were initialized.