### PR TITLE
Fix fa_ambig_example() when the automata involve NULs

### DIFF
--- a/src/fa.c
+++ b/src/fa.c
@@ -2890,6 +2890,7 @@ int fa_ambig_example(struct fa *fa1, struct fa *fa2,
     static const char X = '\001';
     static const char Y = '\002';
     char *result = NULL, *s = NULL;
+    size_t result_len = 0;
     int ret = -1, r;
     struct fa *mp = NULL, *ms = NULL, *sp = NULL, *ss = NULL, *amb = NULL;
     struct fa *a1f = NULL, *a1t = NULL, *a2f = NULL, *a2t = NULL;
@@ -2973,23 +2974,30 @@ int fa_ambig_example(struct fa *fa1, struct fa *fa2,
 
     if (s != NULL) {
         char *t;
-        F(ALLOC_N(result, (strlen(s)-1)/2 + 1));
+        result_len = (s_len-1)/2 - 1;
+        F(ALLOC_N(result, result_len + 1));
         t = result;
         int i = 0;
-        for (i=0; s[2*i] == X; i++)
+        for (i=0; s[2*i] == X; i++) {
+            assert((t - result) < result_len);
             *t++ = s[2*i + 1];
+        }
         if (pv != NULL)
             *pv = t;
         i += 1;
 
-        for ( ;s[2*i] == X; i++)
+        for ( ;s[2*i] == X; i++) {
+            assert((t - result) < result_len);
             *t++ = s[2*i + 1];
+        }
         if (v != NULL)
             *v = t;
         i += 1;
 
-        for (; 2*i+1 < strlen(s); i++)
+        for (; 2*i+1 < s_len; i++) {
+            assert((t - result) < result_len);
             *t++ = s[2*i + 1];
+        }
     }
     ret = 0;
 
@@ -3010,7 +3018,7 @@ int fa_ambig_example(struct fa *fa1, struct fa *fa2,
     FREE(s);
     *upv = result;
     if (result != NULL)
-        *upv_len = strlen(result);
+        *upv_len = result_len;
     return ret;
  error:
     FREE(result);


### PR DESCRIPTION
After the example for \`amb' was calculated, the code that generated the
*UPV string and pointers *PV and *V within this string used strlen() to
calculate the length of the example; however, the example string may
contain NUL bytes. Thus, it could happen that not enough space would be
allocated for the *UPV string.

Instead of computing the length of the example using strlen(), just use
\`s_len'.

Added a new test to fatest, testAmbigWithNuls.