### PR TITLE
Skip hidden tree nodes in path expressions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@
   - General changes/additions
     * augtool: new --timing option that prints after each operation how long
       it took
+    * aug_match: fix a bug where expressions like /foo/*[2] would match a
+      hidden node and pretend there was no match at all. We now make sure
+      we never match a hidden node. Thanks to Xavier Mol for reporting the
+      problem.
   - Lens changes/additions
     * AptConf: support hash comments
     * AptSources: support options (Issue #295),

--- a/src/pathx.c
+++ b/src/pathx.c
@@ -2546,7 +2546,11 @@ int pathx_parse(const struct tree *tree,
  *************************************************************************/
 
 static bool step_matches(struct step *step, struct tree *tree) {
-    return (step->name == NULL || streqx(step->name, tree->label));
+    if (step->name == NULL) {
+        return step->axis == ROOT || tree->label != NULL;
+    } else {
+        return streqx(step->name, tree->label);
+    }
 }
 
 static struct tree *tree_prev(struct tree *pos) {

--- a/tests/xpath.tests
+++ b/tests/xpath.tests
@@ -331,3 +331,7 @@ test escape2 /files/etc/sysconfig/network-scripts/ifcfg-weird\ \[\!\]\ \(used\ t
 
 test escape3 /files/etc/sysconfig/network-scripts/*[DEVICE = 'weird']
      /files/etc/sysconfig/network-scripts/ifcfg-weird\ \[\!\]\ \(used\ to\ fail\)
+
+# Test matching in the presence of hidden nodes
+test hidden1 /files/etc/security/limits.conf/*[label() != '#comment'][1]
+     /files/etc/security/limits.conf/domain[1] = @jackuser


### PR DESCRIPTION
When we were evaluating path expressions, we were not skipping hidden tree
nodes, i.e. tree nodes whose label is NULL. In most cases, that's not
visible to users, but when we match something like /foo/*[2] where /foo has
a bunch of hidden children, the result was not what the user might expect,
as we might actually return a hidden node to aug_match, which would
suppress that node and make it seem to the user as if nothing had matched.

With this patch, we try to skip over hidden nodes while evaluating the path
expression to avoid this issue.