### PR TITLE
Httpd: parse backslashes at the start of directive args

### DIFF
--- a/lenses/httpd.aug
+++ b/lenses/httpd.aug
@@ -59,7 +59,7 @@ let empty               = Util.empty_dos
 let indent              = Util.indent
 
 (* borrowed from shellvars.aug *)
-let char_arg_dir  = /([^\\ '"\t\r\n]|[^\\ '"\t\r\n][^ '"\t\r\n]*[^\\ '"\t\r\n])|\\\\"|\\\\'/
+let char_arg_dir  = /([^\\ '"\t\r\n]|[^ '"\t\r\n]+[^\\ '"\t\r\n])|\\\\"|\\\\'/
 let char_arg_sec  = /[^ '"\t\r\n>]|\\\\"|\\\\'/
 let cdot = /\\\\./
 let cl = /\\\\\n/

--- a/lenses/tests/test_httpd.aug
+++ b/lenses/tests/test_httpd.aug
@@ -470,10 +470,15 @@ test Httpd.lns get "<IfModule mod_ssl.c>
 (* Issue #307: backslashes in regexes *)
 test Httpd.lns get "<VirtualHost *:80>
   RewriteRule ^/(.*) http\:\/\/example\.com\/$1 [L,R,NE]
+  RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1]
 </VirtualHost>\n" =
   { "VirtualHost"
     { "arg" = "*:80" }
     { "directive" = "RewriteRule"
       { "arg" = "^/(.*)" }
       { "arg" = "http\:\/\/example\.com\/$1" }
-      { "arg" = "[L,R,NE]" } } }
+      { "arg" = "[L,R,NE]" } }
+    { "directive" = "RewriteRule"
+      { "arg" = "\.css\.gz$" }
+      { "arg" = "-" }
+      { "arg" = "[T=text/css,E=no-gzip:1]" } } }


### PR DESCRIPTION
Fixes #324