### PR TITLE
httpd lens fails on parsing perl blocks

### DIFF
--- a/lenses/httpd.aug
+++ b/lenses/httpd.aug
@@ -95,10 +95,19 @@ let arg_wordlist =
 
 let argv (l:lens) = l . (sep_spc . l)*
 
+(* arg_dir_msg may be the last or only argument *)
+let dir_args = (argv (arg_dir|arg_wordlist) . (sep_spc . arg_dir_msg)?) | arg_dir_msg
+
 let directive =
-    (* arg_dir_msg may be the last or only argument *)
-     let dir_args = (argv (arg_dir|arg_wordlist) . (sep_spc . arg_dir_msg)?) | arg_dir_msg
-  in [ indent . label "directive" . store word .  (sep_spc . dir_args)? . eol ]
+  [ indent . label "directive" . store word .  (sep_spc . dir_args)? . eol ]
+
+let perl_directive =
+     let perl_word = word . ("::" . word)* . "->" . word
+  in [ indent . label "perl_directive" . store perl_word
+     . Sep.opt_space . Util.del_str "(" . Sep.opt_space
+     . dir_args
+     . Sep.opt_space . Util.del_str ")" . Sep.opt_space . Util.del_str ";"
+     . eol ]
 
 let section (body:lens) =
     (* opt_eol includes empty lines *)
@@ -110,7 +119,7 @@ let section (body:lens) =
     let dword = del word "a" in
         [ indent . dels "<" . square kword inner dword . del />[ \t\n\r]*/ ">\n" ]
 
-let rec content = section (content|directive)
+let rec content = section (content|directive|perl_directive)
 
 let lns = (content|directive|comment|empty)*
 

--- a/lenses/httpd.aug
+++ b/lenses/httpd.aug
@@ -95,19 +95,10 @@ let arg_wordlist =
 
 let argv (l:lens) = l . (sep_spc . l)*
 
-(* arg_dir_msg may be the last or only argument *)
-let dir_args = (argv (arg_dir|arg_wordlist) . (sep_spc . arg_dir_msg)?) | arg_dir_msg
-
 let directive =
-  [ indent . label "directive" . store word .  (sep_spc . dir_args)? . eol ]
-
-let perl_directive =
-     let perl_word = word . ("::" . word)* . "->" . word
-  in [ indent . label "directive" . store perl_word
-     . Sep.opt_space . Util.del_str "(" . Sep.opt_space
-     . dir_args
-     . Sep.opt_space . Util.del_str ")" . Sep.opt_space . Util.del_str ";"
-     . eol ]
+    (* arg_dir_msg may be the last or only argument *)
+     let dir_args = (argv (arg_dir|arg_wordlist) . (sep_spc . arg_dir_msg)?) | arg_dir_msg
+  in [ indent . label "directive" . store word .  (sep_spc . dir_args)? . eol ]
 
 let section (body:lens) =
     (* opt_eol includes empty lines *)

--- a/lenses/httpd.aug
+++ b/lenses/httpd.aug
@@ -103,23 +103,28 @@ let directive =
 
 let perl_directive =
      let perl_word = word . ("::" . word)* . "->" . word
-  in [ indent . label "perl_directive" . store perl_word
+  in [ indent . label "directive" . store perl_word
      . Sep.opt_space . Util.del_str "(" . Sep.opt_space
      . dir_args
      . Sep.opt_space . Util.del_str ")" . Sep.opt_space . Util.del_str ";"
      . eol ]
 
-let section (body:lens) =
+let generic_section (kw:regexp) (default:string) (body:lens) =
     (* opt_eol includes empty lines *)
     let opt_eol = del /([ \t]*#?\r?\n)*/ "\n" in
     let inner = (sep_spc . argv arg_sec)? . sep_osp .
              dels ">" . opt_eol . ((body|comment) . (body|empty|comment)*)? .
              indent . dels "</" in
-    let kword = key word in
-    let dword = del word "a" in
+    let kword = key kw in
+    let dword = del kw default in
         [ indent . dels "<" . square kword inner dword . del />[ \t\n\r]*/ ">\n" ]
 
-let rec content = section (content|directive|perl_directive)
+let section (body:lens) = generic_section (word - /perl/i) "a" body
+
+let perl_section = generic_section /perl/i "Perl" perl_directive
+
+let rec content = section (content|directive)
+                | perl_section
 
 let lns = (content|directive|comment|empty)*
 

--- a/lenses/httpd.aug
+++ b/lenses/httpd.aug
@@ -109,19 +109,20 @@ let perl_directive =
      . Sep.opt_space . Util.del_str ")" . Sep.opt_space . Util.del_str ";"
      . eol ]
 
-let generic_section (kw:regexp) (default:string) (body:lens) =
+let section (body:lens) =
     (* opt_eol includes empty lines *)
     let opt_eol = del /([ \t]*#?\r?\n)*/ "\n" in
     let inner = (sep_spc . argv arg_sec)? . sep_osp .
              dels ">" . opt_eol . ((body|comment) . (body|empty|comment)*)? .
              indent . dels "</" in
-    let kword = key kw in
-    let dword = del kw default in
+    let kword = key (word - /perl/i) in
+    let dword = del (word - /perl/i) "a" in
         [ indent . dels "<" . square kword inner dword . del />[ \t\n\r]*/ ">\n" ]
 
-let section (body:lens) = generic_section (word - /perl/i) "a" body
+let perl_section = [ indent . label "Perl" . del /<perl>/i "<Perl>"
+                   . store /[^<]*/
+                   . del /<\/perl>/i "</Perl>" . eol ]
 
-let perl_section = generic_section /perl/i "Perl" perl_directive
 
 let rec content = section (content|directive)
                 | perl_section

--- a/lenses/tests/test_httpd.aug
+++ b/lenses/tests/test_httpd.aug
@@ -536,7 +536,5 @@ test Httpd.lns get "<VirtualHost *:80>
 test Httpd.lns get "<Perl>
     Apache::AuthDBI->setCacheTime(600);
 </Perl>\n" =
-  { "Perl"
-    { "directive" = "Apache::AuthDBI->setCacheTime"
-      { "arg" = "600" } } }
+  { "Perl" = "\n    Apache::AuthDBI->setCacheTime(600);\n" }
 

--- a/lenses/tests/test_httpd.aug
+++ b/lenses/tests/test_httpd.aug
@@ -531,3 +531,12 @@ test Httpd.lns get "<VirtualHost *:80>
       { "arg" = "inactivity-timeout=120" }
       { "arg" = "user=_graphite" }
       { "arg" = "group=_graphite" } } }
+
+(* Issue #327: perl blocks *)
+test Httpd.lns get "<Perl>
+    Apache::AuthDBI->setCacheTime(600);
+</Perl>\n" =
+  { "Perl"
+    { "perl_directive" = "Apache::AuthDBI->setCacheTime"
+      { "arg" = "600" } } }
+

--- a/lenses/tests/test_httpd.aug
+++ b/lenses/tests/test_httpd.aug
@@ -537,6 +537,6 @@ test Httpd.lns get "<Perl>
     Apache::AuthDBI->setCacheTime(600);
 </Perl>\n" =
   { "Perl"
-    { "perl_directive" = "Apache::AuthDBI->setCacheTime"
+    { "directive" = "Apache::AuthDBI->setCacheTime"
       { "arg" = "600" } } }
 


### PR DESCRIPTION
a perl section like
	<Perl>
		Apache::AuthDBI->setCacheTime(600);
	</Perl>
in a VirtualHost gives a parse_failed error for the file which defines the vhost

Errror:
/augeas/files/etc/apache2/sites-available/000-test.conf/error = "parse_failed"
/augeas/files/etc/apache2/sites-available/000-test.conf/error/pos = "108"
/augeas/files/etc/apache2/sites-available/000-test.conf/error/line = "7"
/augeas/files/etc/apache2/sites-available/000-test.conf/error/char = "2"
/augeas/files/etc/apache2/sites-available/000-test.conf/error/lens = "/usr/share/augeas/lenses/dist/httpd.aug:98.10-.44:"
/augeas/files/etc/apache2/sites-available/000-test.conf/error/message = "Syntax error"

 sample vhost file:
<VirtualHost *:80>
	ServerAdmin webmaster@muze.nl
	DocumentRoot /var/wwww/
	ServerName localhost

	<Perl>
		Apache::AuthDBI->setCacheTime(600);
	</Perl>

</VirtualHost>


