### PR TITLE
nginx lense can't parse example from linguist

### DIFF
--- a/lenses/tests/test_nginx.aug
+++ b/lenses/tests/test_nginx.aug
@@ -206,6 +206,35 @@ test lns get http =
          { "root" = "html" } } }
     { "gzip" = "on" } }
 
+
+(* GH #335 - server single line entries *)
+let http_server_single_line_entries = "http {
+  upstream big_server_com {
+    server 127.0.0.3:8000 weight=5;
+    server 127.0.0.3:8001 weight=5;
+    server 192.168.0.1:8000;
+    server 192.168.0.1:8001;
+    server backend2.example.com:8080 fail_timeout=5s slow_start=30s;
+    server backend3.example.com      resolve;
+  }
+}\n"
+
+test lns get http_server_single_line_entries =
+  { "http"
+    { "upstream"
+      { "#name" = "big_server_com" }
+      { "@server" { "@address" = "127.0.0.3:8000" } { "weight" = "5" } }
+      { "@server" { "@address" = "127.0.0.3:8001" } { "weight" = "5" } }
+      { "@server" { "@address" = "192.168.0.1:8000" } }
+      { "@server" { "@address" = "192.168.0.1:8001" } }
+      { "@server"
+        { "@address" = "backend2.example.com:8080" }
+        { "fail_timeout" = "5s" }
+        { "slow_start" = "30s" } }
+      { "@server"
+        { "@address" = "backend3.example.com" }
+        { "resolve" } } } }
+
 (* Make sure we do not screw up the indentation of the file *)
 test lns put http after set "/http/gzip" "off" =
 "http {
@@ -246,4 +275,3 @@ test lns get "http {
       { "::1" = "2" }
       { "2001:0db8::" = "1"
         { "mask" = "32" } } } }
-


### PR DESCRIPTION
I'm trying to learn how to use augtool so I copy pasted the nginx.conf from https://github.com/github/linguist/blob/master/samples/Nginx/filenames/nginx.conf
```nginx
user       www www;
worker_processes  5;
error_log  logs/error.log;
pid        logs/nginx.pid;
worker_rlimit_nofile 8192;

events {
  worker_connections  4096;
}

http {
  include    conf/mime.types;
  include    /etc/nginx/proxy.conf;
  include    /etc/nginx/fastcgi.conf;
  index    index.html index.htm index.php;

  default_type application/octet-stream;
  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
    '"$request" $body_bytes_sent "$http_referer" '
    '"$http_user_agent" "$http_x_forwarded_for"';
  access_log   logs/access.log  main;
  sendfile     on;
  tcp_nopush   on;
  server_names_hash_bucket_size 128; # this seems to be required for some vhosts

  server { # php/fastcgi
    listen       80;
    server_name  domain1.com www.domain1.com;
    access_log   logs/domain1.access.log  main;
    root         html;

    location ~ \.php$ {
      fastcgi_pass   127.0.0.1:1025;
    }
  }

  server { # simple reverse-proxy
    listen       80;
    server_name  domain2.com www.domain2.com;
    access_log   logs/domain2.access.log  main;

    # serve static files
    location ~ ^/(images|javascript|js|css|flash|media|static)/  {
      root    /var/www/virtual/big.server.com/htdocs;
      expires 30d;
    }

    # pass requests for dynamic content to rails/turbogears/zope, et al
    location / {
      proxy_pass      http://127.0.0.1:8080;
    }
  }

  upstream big_server_com {
    server 127.0.0.3:8000 weight=5;
    server 127.0.0.3:8001 weight=5;
    server 192.168.0.1:8000;
    server 192.168.0.1:8001;
  }

  server { # simple load balancing
    listen          80;
    server_name     big.server.com;
    access_log      logs/big.server.access.log main;

    location / {
      proxy_pass      http://big_server_com;
    }
  }
}
```
Any idea why it's not parsing?
I'm getting:
/augeas/files/etc/nginx/nginx.conf/error = "parse_failed"
/augeas/files/etc/nginx/nginx.conf/error/pos = "163"
/augeas/files/etc/nginx/nginx.conf/error/line = "11"
/augeas/files/etc/nginx/nginx.conf/error/char = "0"
/augeas/files/etc/nginx/nginx.conf/error/lens = "/usr/share/augeas/lenses/dist/nginx.aug:57.10-.57:"
/augeas/files/etc/nginx/nginx.conf/error/message = "Iterated lens matched less than it should"

which points to:
http {
Is the lens out of date?