### PR TITLE
shelllvars lens fails for default configuration of aufs

### DIFF
--- a/lenses/shellvars.aug
+++ b/lenses/shellvars.aug
@@ -218,10 +218,11 @@ module Shellvars =
         . keyword "esac" . comment_or_eol ]
 
   let function (entry:lens) =
-    [ Util.indent . label "@function"
+       let func_eol = del /[ \t\n]*/ "\n"
+    in [ Util.indent . label "@function"
       . del /(function[ \t]+)?/ ""
       . store Rx.word . del /[ \t]*\(\)/ "()"
-      . (comment_eol|eol) . Util.del_str "{" . eol
+      . (comment_eol|func_eol) . Util.del_str "{" . func_eol
       . entry+
       . Util.indent . Util.del_str "}" . eol ]
 

--- a/lenses/shellvars.aug
+++ b/lenses/shellvars.aug
@@ -220,7 +220,7 @@ module Shellvars =
     [ Util.indent . label "@function"
       . del /(function[ \t]+)?/ ""
       . store Rx.word . del /[ \t]*\(\)/ "()"
-      . eol . Util.del_str "{" . eol
+      . (comment_eol|eol) . Util.del_str "{" . eol
       . entry+
       . Util.indent . Util.del_str "}" . eol ]
 

--- a/lenses/shellvars.aug
+++ b/lenses/shellvars.aug
@@ -107,8 +107,9 @@ module Shellvars =
     . ( Util.del_ws_spc . store Rx.integer )?
 
   let action (operator:string) (lbl:string) (sto:lens) =
-    [ del (Rx.cl_or_opt_space . operator . Rx.cl_or_opt_space) (" " . operator . " ")
-    . label ("@".lbl) . sto ]
+       let sp = Rx.cl_or_opt_space | /[ \t\n]+/
+    in [ del (sp . operator . sp) (" " . operator . " ")
+       . label ("@".lbl) . sto ]
 
   let action_pipe = action "|" "pipe"
   let action_and = action "&&" "and"

--- a/lenses/tests/test_shellvars.aug
+++ b/lenses/tests/test_shellvars.aug
@@ -692,6 +692,15 @@ test Shellvars.lns get "foo && \\\nbar baz \\\n|| qux \\\n    quux\\\ncorge  gra
     }
   }
 
+(* Comment after function definition (Issue #339) *)
+test Shellvars.lns get "SetDir() # hello
+{
+ echo
+}\n" =
+  { "@function" = "SetDir"
+    { "#comment" = "hello" }
+    { "@command" = "echo" }
+  }
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)

--- a/lenses/tests/test_shellvars.aug
+++ b/lenses/tests/test_shellvars.aug
@@ -702,6 +702,15 @@ test Shellvars.lns get "SetDir() # hello
     { "@command" = "echo" }
   }
 
+(* Function with new lines *)
+test Shellvars.lns get "MyFunc()
+{
+ echo
+}\n" =
+  { "@function" = "MyFunc"
+    { "@command" = "echo" }
+  }
+
 (* Pipe and newline without cl (Issue #339) *)
 test Shellvars.lns get "echo |
 tr\n" =

--- a/lenses/tests/test_shellvars.aug
+++ b/lenses/tests/test_shellvars.aug
@@ -718,6 +718,20 @@ tr\n" =
     { "@pipe"
       { "@command" = "tr" } } }
 
+
+(* Subshell (Issue #339) *)
+test Shellvars.lns get "{ echo
+}\n" =
+  { "@subshell"
+    { "@command" = "echo" }
+  } 
+
+(* One-liner function *)
+test Shellvars.lns get "MyFunc() { echo; }\n" =
+  { "@function" = "MyFunc"
+    { "@command" = "echo" }
+  }
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)

--- a/lenses/tests/test_shellvars.aug
+++ b/lenses/tests/test_shellvars.aug
@@ -701,6 +701,14 @@ test Shellvars.lns get "SetDir() # hello
     { "#comment" = "hello" }
     { "@command" = "echo" }
   }
+
+(* Pipe and newline without cl (Issue #339) *)
+test Shellvars.lns get "echo |
+tr\n" =
+  { "@command" = "echo"
+    { "@pipe"
+      { "@command" = "tr" } } }
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)


### PR DESCRIPTION
This is the stock /etc/default configuration for aufs.
```bash
# aufs variables for shell scripts
AUFS_VERSION=3.13-20140303
AUFS_SUPER_MAGIC=1635083891
AUFS_SUPER_MAGIC_HEX=0x61756673
AUFS_ROOT_INO=2
AUFS_WH_PFX=.wh.
AUFS_WH_PFX2=.wh..wh.
AUFS_MAX_NAMELEN=242
AUFS_WKQ_NAME=aufsd
AUFS_WH_DIROPQ=.wh..wh..opq
AUFS_WH_BASE=.wh..wh.aufs
AUFS_WH_PLINKDIR=.wh..wh.plnk
AUFS_WH_ORPHDIR=.wh..wh.orph

# library functions for aufs shell scripts

# path in canonical representation
# note: bash builtin "pwd -P" modies $PWD unexpectedly
SetDir() # var dir
{
	cd "$2"
	eval "$1=\"$(pwd -P)\""
	cd "$OLDPWD"
}

# escape the unprintable characters, mainly for grep-ping /proc/mounts
Esc() # [-e]
{
	sed -r -e '
	s/\\/\\134/g
	s/$/\\012/
	' |
	tr -d '\n' |
	sed -r -e '
	s/ /\\040/g
	s/\t/\\011/g
	s/\r/\\015/g
	s/\\012$//
	' |
	{ test $# -eq 1 &&
	test "$1" = "-e" &&
	sed -r -e 's/\\/\\\\/g' ||
	cat; }
	echo
}

# find a mount-entry by its mount-point
FindMntEnt() # mntpnt
{
	proc_mounts=/proc/self/mounts
	test ! -e $proc_mounts && proc_mounts=/proc/$$/mounts
	test ! -e $proc_mounts && proc_mounts=/proc/mounts
	fgrep \ $(echo "$1" | Esc)\ aufs\  $proc_mounts |
	tail -n 1
}

# current mount options
MntOpts() # mntpnt
{
	FindMntEnt "$1" |
	cut -f4 -d' '
}

########################################

AuDebug() # 1 | 0 [sec]
{
	test $1 -eq 0 && set +x
	aufs_debug=/sys/module/aufs/parameters/debug
	if [ -f $aufs_debug ]
	then
		echo $1 | sudo dd of=$aufs_debug 2> /dev/null
		test $# -eq 2 && sleep $2
	fi
	test $1 -eq 1 && set -x
	true
}

# Local variables: ;
# mode: text;
# End: ;
```

It includes some bash and I think we should be able to ignore it somehow.