### PR TITLE
Invalid rules to parse /etc/network/interfaces

### DIFF
--- a/lenses/interfaces.aug
+++ b/lenses/interfaces.aug
@@ -38,7 +38,7 @@ let stanza_param (l:string) = [ sep_spc . label l . sto_to_spc ]
 
 (* Define reseverved words and multi-value options*)
 let stanza_word =
-   /(source|iface|auto|allow-[a-z-]+|mapping|bond-slaves|bridge-ports)/
+   /(source(-directory)?|iface|auto|allow-[a-z-]+|mapping|bond-slaves|bridge-ports)/
 
 (* Define stanza option indentation *)
 let stanza_indent = del /[ \t]*/ "   "
@@ -100,6 +100,12 @@ let iface   = [ Util.indent
 let source = [ key "source" . sep_spc . sto_to_eol ]
 
 (************************************************************************
+ *                              SOURCE-DIRECTORY
+ *************************************************************************)
+
+let source_directory = [ key "source-directory" . sep_spc . sto_to_eol ]
+
+(************************************************************************
  *                              STANZAS
  *************************************************************************)
 
@@ -109,7 +115,7 @@ let source = [ key "source" . sep_spc . sto_to_eol ]
    come after an auto or hotplug stanza, otherwise they are considered part
    of a iface or mapping block *)
 
-let stanza_single = (auto|allow|source) . (comment|empty)*
+let stanza_single = (auto|allow|source|source_directory) . (comment|empty)*
 let stanza_multi  = iface|mapping
 
 (************************************************************************

--- a/lenses/tests/test_interfaces.aug
+++ b/lenses/tests/test_interfaces.aug
@@ -134,3 +134,8 @@ test Interfaces.lns put "" after
 test Interfaces.lns put "" after
     set "/source[0]" "/etc/network/conf.d/*.conf"
 = "source /etc/network/conf.d/*.conf\n"
+
+(* Test: Interfaces.lns
+     source-directory (Issue #306) *)
+test Interfaces.lns get "source-directory interfaces.d\n" =
+  { "source-directory" = "interfaces.d" }


### PR DESCRIPTION
Current rule contains unconditional parse of interfaces.d subdirectory. But it is not valid, because Debian parses it only when instruction 'source-directory interfaces.d' specified in the /etc/network/interfaces file. Moreover, parser does not understand 'source-directory' instruction which causes empty tree.
Current rule: 
  let filter = (incl "/etc/network/interfaces") . (incl "/etc/network/interfaces.d/*") . Util.stdexcl