### PR TITLE
Exclude network/if-up.d/SuSEfirewall2 in shellvars lens

### DIFF
--- a/lenses/shellvars.aug
+++ b/lenses/shellvars.aug
@@ -270,6 +270,7 @@ module Shellvars =
       sc_incl "network/if-down.d/*" .
       sc_incl "network/ifroute-*" .
       sc_incl "network/if-up.d/*" .
+      sc_excl "network/if-up.d/SuSEfirewall2" .
       sc_incl "network/providers/*" .
       sc_excl "network-scripts" .
       sc_incl "network-scripts/ifcfg-*" .


### PR DESCRIPTION
openSUSE has /etc/sysconfig/network/if-up.d/SuSEfirewall2 that is not a
shell variable script, exclude it to avoid errors.
Split of PR #354