### PR TITLE
host_conf lens: spaces between list items support

### DIFF
--- a/lenses/host_conf.aug
+++ b/lenses/host_conf.aug
@@ -44,7 +44,7 @@ let bool_warn (kw:regexp) = Build.key_value_line kw Sep.space sto_bool_warn
 (* View: list
     A list of items *)
 let list (kw:regexp) (elem:string) =
-  let list_elems = Build.opt_list [seq elem . store Rx.word] (Sep.comma) in
+  let list_elems = Build.opt_list [seq elem . store Rx.word] (Sep.comma . Sep.opt_space) in
   Build.key_value_line kw Sep.space list_elems
 
 (* View: trim *)

--- a/lenses/tests/test_host_conf.aug
+++ b/lenses/tests/test_host_conf.aug
@@ -3,7 +3,7 @@ module Test_Host_Conf =
 let conf = "
 # /etc/host.conf
 # We have named running, but no NIS (yet)
-order   bind,hosts
+order   bind, hosts
 # Allow multiple addrs
 multi   on
 # Guard against spoof attempts


### PR DESCRIPTION
List items are separated by commas in host.conf, but we may find spaces
on top of the comma.
Split of PR #354