### PR TITLE
logrotate: support dateyesterday option (GH #367)

### DIFF
--- a/lenses/logrotate.aug
+++ b/lenses/logrotate.aug
@@ -78,6 +78,7 @@ module Logrotate =
         | value_to_eol "extension" word
         | select_to_eol "dateext" /(no)?dateext/
         | value_to_eol "dateformat" word
+        | flag_to_eol "dateyesterday"
         | value_to_eol "compresscmd" word
         | value_to_eol "uncompresscmd" word
         | value_to_eol "compressext" word


### PR DESCRIPTION
Adds support for the 'dateyesterday' directive for logrotate.

I didn't add any tests for this as it is a trivial addition, and there are no existing tests for the other flags. I have, however, tested this locally with no issues. I'm happy to submit a new pull request with tests if that is preferred.