### PR TITLE
Recent ntp.conf allows for 'pool' instead of 'server' et al

### DIFF
--- a/lenses/ntp.aug
+++ b/lenses/ntp.aug
@@ -35,7 +35,7 @@ module Ntp =
                       sep_spc . store word ]
         | [ sep_spc . key (/autokey|burst|iburst|noselect|preempt/ |
                            /prefer|true|dynamic/) ] in
-      let cmd = /server|peer|broadcast|manycastclient/
+      let cmd = /pool|server|peer|broadcast|manycastclient/
         | /multicastclient|manycastserver/ in
         record cmd opt*
 


### PR DESCRIPTION
Seen on Ubuntu Xenial (16.04), and not in the man page, but found references at https://www.freebsd.org/cgi/man.cgi?query=ntp.conf&sektion=5.