### PR TITLE
Ntp lense fix

### DIFF
--- a/lenses/ntp.aug
+++ b/lenses/ntp.aug
@@ -67,10 +67,9 @@ module Ntp =
 
     (* Define restrict *)
     let restrict_record   =
+      let ip_restrict = [ label "ip" . sep_spc . Util.del_str "-" . store /[46]/ ] in 
       let action    = [ label "action" . sep_spc . store word ] in
-      [ key "restrict" . sep_spc .
-          [ label "ipv6" . Util.del_str "-6" . sep_spc ]? .
-          store (word - "-6") . action* . eol ]
+      [ key "restrict" . ip_restrict? . action* . eol ]
 
     (* Define statistics *)
     let statistics_flag (kw:string) = [ sep_spc . key kw ]

--- a/lenses/ntp.aug
+++ b/lenses/ntp.aug
@@ -23,7 +23,7 @@ module Ntp =
 
 
     let kv (k:regexp) (v:regexp) =
-      [ key k . sep_spc. store v . eol ]
+      [ key k . sep_spc. store v ]
 
     (* Define generic record *)
     let record (kw:regexp) (value:lens) =
@@ -53,12 +53,12 @@ module Ntp =
       let flag = [ label "flag" . store flags_re ] in
         [ key /enable|disable/ . (sep_spc . flag)* . eol ]
 
-    let simple_setting (k:regexp) = kv k word
+    let simple_setting (k:regexp) = kv k word . eol
 
     (* Still incomplete, misses logconfig, phone, setvar, tos,
        trap, ttl *)
     let simple_settings =
-        kv "broadcastdelay" Rx.decimal
+        kv "broadcastdelay" Rx.decimal . eol
       | flags
       | simple_setting /driftfile|leapfile|logfile|includefile/
 	  | simple_setting "statsdir"
@@ -96,11 +96,12 @@ module Ntp =
     let filegen_record = [ label "filegen" . filegen . filegen_opts* . eol ]
 
     (* Authentication commands, see authopt.html#cmd; incomplete *)
-    let auth_command =
+    let auth_command_internal =
       [ key /controlkey|keys|keysdir|requestkey|authenticate/ .
-            sep_spc . store word . eol ]
-     | [ key /autokey|revoke/ . [sep_spc . store word]? . eol ]
-     | [ key /trustedkey/ . [ sep_spc . label "key" . store word ]+ . eol ]
+            sep_spc . store word ]
+     | [ key /autokey|revoke/ . [sep_spc . store word]? ]
+     | [ key /trustedkey/ . [ sep_spc . label "key" . store word ]+ ]
+    let auth_command = auth_command_internal . eol
 
     (* tinker [step step | panic panic | dispersion dispersion |
                stepout stepout | minpoll minpoll | allan allan | huffpuff huffpuff] *)


### PR DESCRIPTION
Two fixes that is needed to run trivial load/save on default opensuse configuration.

The first issue is with restrict keywork, which doesn't work well with -6 and also missing -4 and failed during save.

The second issue is problem that comments are attached under simple options, which cause augeas to failed. Example ( output is from my ruby project, but I hope it is understandable what happen ):

```
obtain aug key for {:key=>"keys", :value=>#<CFA::AugeasTree:0x000000017c2120 @data=[{:key=>"#comment", :value=>"# path for keys file"}]>} res: /store/keys
obtain aug key for {:key=>"#comment", :value=>"# path for keys file"} res: /store/keys/#comment


Augeas parsing/serializing error: Malformed child node 'keys' at /usr/share/augeas/lenses/dist/ntp.aug:125.14-128.45:
```

With these fixes it works.

BTW how to run properly `tests/test_ntp.aug`? I try to run it and it failed on my system even with original one:

```
augparse --nostdin -I .. tests/test_ntp.aug 
Syntax error in lens definition
tests/test_ntp.aug:33.8-.15:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:33.8-.15:Undefined variable Ntp.lns
tests/test_ntp.aug:85.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:85.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:90.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:90.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:94.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:94.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:98.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:98.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:107.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:107.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:107.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:107.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:113.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:113.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:123.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:123.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:127.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:127.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:130.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:130.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:134.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:134.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:137.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:137.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:137.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:137.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:140.7-.23:Could not load module Ntp for Ntp.auth_command
tests/test_ntp.aug:140.7-.23:Undefined variable Ntp.auth_command
tests/test_ntp.aug:146.7-.23:Could not load module Ntp for Ntp.auth_command
tests/test_ntp.aug:146.7-.23:Undefined variable Ntp.auth_command
tests/test_ntp.aug:149.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:149.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:152.7-.14:Could not load module Ntp for Ntp.lns
tests/test_ntp.aug:152.7-.14:Undefined variable Ntp.lns
tests/test_ntp.aug:161.5-.15:Could not load module Ntp for Ntp.tinker
tests/test_ntp.aug:161.5-.15:Undefined variable Ntp.tinker
tests/test_ntp.aug:167.5-.12:Could not load module Ntp for Ntp.tos
tests/test_ntp.aug:167.5-.12:Undefined variable Ntp.tos
```