### PR TITLE
DEREF_OF_NULL

### DIFF
--- a/src/lens.c
+++ b/src/lens.c
@@ -1556,6 +1556,8 @@ static struct prod *make_prod(struct rtn *rtn, struct lens *l) {
     ERR_BAIL(l->info);
 
     result->end->next = rtn->states;
+    if (result->end == NULL)
+        goto error;
     rtn->states = result->start;
 
     return result;


### PR DESCRIPTION
Return value of a function 'add_state' is dereferenced at lens.c:1558 without checking.
Added check on return value.