### PR TITLE
DEREF_OF_NULL

### DIFF
--- a/src/fa.c
+++ b/src/fa.c
@@ -2773,6 +2773,8 @@ static struct fa *expand_alphabet(struct fa *fa, int add_marker,
             continue;
 
         struct state *r = add_state(fa, 0);
+        if (r == NULL)
+            goto error;
         r->trans = p->trans;
         r->tused = p->tused;
         r->tsize = p->tsize;


### PR DESCRIPTION
Return value of a function 'add_state' is dereferenced at fa.c:2776 without checking.
Added check on return value.