### PR TITLE
Uses spaces between tokens instead of tabs for pam files

### DIFF
--- a/lenses/pam.aug
+++ b/lenses/pam.aug
@@ -48,11 +48,11 @@ module Pam =
   (* Shared with PamConf *)
   let record = [ label "optional" . del "-" "-" ]? .
                [ label "type" . store types ] .
-               Util.del_ws_tab .
+               Sep.space .
                [ label "control" . store control] .
-               Util.del_ws_tab .
+               Sep.space .
                [ label "module" . store word ] .
-               [ Util.del_ws_tab . label "argument" . store argument ]* .
+               [ Sep.space . label "argument" . store argument ]* .
                comment_or_eol
 
   let record_svc = [ seq "record" . indent . record ]

--- a/lenses/pamconf.aug
+++ b/lenses/pamconf.aug
@@ -39,7 +39,7 @@ let service = Rx.word
 
 let record  = [ seq "record" . indent .
               [ label "service" . store service ] .
-              Util.del_ws_tab .
+              Sep.space .
               Pam.record ]
 
 let lns = ( empty | comment | include | record ) *

--- a/tests/test-augtool/rec-append-record.sh
+++ b/tests/test-augtool/rec-append-record.sh
@@ -15,4 +15,4 @@ diff='--- /etc/pam.d/newrole
  account    include\tsystem-auth
  password   include\tsystem-auth
  session    required\tpam_namespace.so unmnt_remnt no_unmount_on_close
-+auth\tinclude\tsystem-auth'
++auth include system-auth'

--- a/tests/test-augtool/rec-ins-record.sh
+++ b/tests/test-augtool/rec-ins-record.sh
@@ -14,6 +14,6 @@ diff='--- /etc/pam.d/newrole
  #%PAM-1.0
  auth       include\tsystem-auth
  account    include\tsystem-auth
-+session\tinclude\tsystem-auth
++session include system-auth
  password   include\tsystem-auth
  session    required\tpam_namespace.so unmnt_remnt no_unmount_on_close'

--- a/tests/test-augtool/rec-mod-field.sh
+++ b/tests/test-augtool/rec-mod-field.sh
@@ -13,5 +13,5 @@ diff='--- /etc/pam.d/newrole
  auth       include\tsystem-auth
  account    include\tsystem-auth
 -password   include\tsystem-auth
-+password   include\tother_module\tother_module_opts
++password   include\tother_module other_module_opts
  session    required\tpam_namespace.so unmnt_remnt no_unmount_on_close'


### PR DESCRIPTION
pam.d(5) man page states: "The format of each rule is a space
separated collection of tokens..." Previsouly, pam.aug used
`Util.del_ws_tab` to insert tabs as a token separator. This patch
modifies pamconf.aug and pam.aug to use `Sep.space`, which
uses a space as a separator instead.

Fixes #236