### PR TITLE
Added nginx locations for homebrew installed nginx

### DIFF
--- a/lenses/nginx.aug
+++ b/lenses/nginx.aug
@@ -120,5 +120,7 @@ let lns = ( Util.comment | Util.empty | directive )*
 let filter = incl "/etc/nginx/nginx.conf"
            . incl "/etc/nginx/conf.d/*.conf"
            . incl "/usr/portage/www-servers/nginx/files/nginx.conf"
+           . incl "/usr/local/etc/nginx/nginx.conf"
+           . incl "/usr/local/etc/nginx/conf.d/*.conf"
 
 let xfm = transform lns filter


### PR DESCRIPTION
Homebrew installs it's configuration in /usr/local/etc/.
We should adjust our lenses to parse them.