### PR TITLE
Reflect Ubuntu 16.04 location of php.ini

### DIFF
--- a/lenses/php.aug
+++ b/lenses/php.aug
@@ -47,6 +47,7 @@ let record_anon = [ label ".anon" . ( entry | empty )+ ]
 let lns    = record_anon? . record*
 
 let filter = (incl "/etc/php*/*/*.ini")
+             . (incl "/etc/php/*/*/*.ini")
              . (incl "/etc/php.ini")
              . (incl "/etc/php.d/*.ini")
              (* PHPFPM Support *)


### PR DESCRIPTION
php.ini has moved with upgrade from PHP5 to PHP7 (included in Ubuntu 16.04).

There is an additional folder for the version. Example for Apache's php.ini:

    /etc/php/7.0/apache2/php.ini

Previously it was

    /etc/php5/apache2/php.ini

Added the corresponding include line.