### PR TITLE
Fix memory corruption when using spans with a recursive lens (bug #397)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+1.7.0 - ???
+  - General changes/additions
+    * fix a use-after-free in recursive lenses when spans are
+      enabled (Issue #397)
+
 1.6.0 - 2016-08-05
   - General changes/additions
     * augtool: add --load-file option, and corresponding load-file command

--- a/src/augtool.c
+++ b/src/augtool.c
@@ -720,6 +720,7 @@ int main(int argc, char **argv) {
     if (history_file != NULL)
         write_history(history_file);
 
+    aug_close(aug);
     return r == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 

--- a/src/transform.c
+++ b/src/transform.c
@@ -830,8 +830,10 @@ int transform_load(struct augeas *aug, struct tree *xfm, const char *file) {
         const char *filename = matches[i] + strlen(aug->root) - 1;
         struct tree *finfo = file_info(aug, filename);
 
-        if (file != NULL && STRNEQ(filename, file))
-          continue;
+        if (file != NULL && STRNEQ(filename, file)) {
+            FREE(matches[i]);
+            continue;
+        }
 
         if (finfo != NULL && !finfo->dirty &&
             tree_child(finfo, s_lens) != NULL) {

--- a/src/try
+++ b/src/try
@@ -30,7 +30,8 @@ if [[ "x$1" == "xgdb" ]] ; then
 elif [[ "x$1" == "xstrace" ]] ; then
     libtool --mode=execute /usr/bin/strace ./augtool --nostdinc < $AUGCMDS
 elif [[ "x$1" == "xvalgrind" ]] ; then
-    libtool --mode=execute valgrind --leak-check=full ./augtool --nostdinc < $AUGCMDS
+    shift
+    libtool --mode=execute valgrind --leak-check=full ./augtool --nostdinc "$@" < $AUGCMDS
 elif [[ "x$1" == "xcallgrind" ]] ; then
     libtool --mode=execute valgrind --tool=callgrind ./augtool --nostdinc < $AUGCMDS
 elif [[ "x$1" == "xcli" ]] ; then

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -259,7 +259,8 @@ check_SCRIPTS = \
   test-put-mount.sh test-put-mount-augnew.sh test-put-mount-augsave.sh \
   test-save-empty.sh test-bug-1.sh test-idempotent.sh test-preserve.sh \
   test-events-saved.sh test-save-mode.sh test-unlink-error.sh \
-  test-augtool-empty-line.sh test-augtool-modify-root.sh
+  test-augtool-empty-line.sh test-augtool-modify-root.sh \
+  test-span-rec-lens.sh
 
 EXTRA_DIST = \
   test-augtool root lens-test-1 \

--- a/tests/root/etc/default/im-config
+++ b/tests/root/etc/default/im-config
@@ -1,0 +1,6 @@
+# This somewhat nonsensical file used to segfault in test-api.c
+if [ 1 ]; then
+# K
+else
+# I
+fi

--- a/tests/test-span-rec-lens.sh
+++ b/tests/test-span-rec-lens.sh
@@ -1,0 +1,30 @@
+# This test checks that https://github.com/hercules-team/augeas/issues/397 is
+# fixed. It would otherwise lead to a segfault in augtool
+
+if [ -z "$abs_top_builddir" ]; then
+    echo "abs_top_builddir is not set"
+    exit 1
+fi
+
+if [ -z "$abs_top_srcdir" ]; then
+    echo "abs_top_srcdir is not set"
+    exit 1
+fi
+
+ROOT=$abs_top_builddir/build/test-span-rec-lens
+LENSES=$abs_top_srcdir/lenses
+
+FILE=$ROOT/etc/default/im-config
+
+rm -rf $ROOT
+mkdir -p $(dirname $FILE)
+cat <<EOF > $FILE
+if [ 1 ]; then
+# K
+else
+# I
+fi
+EOF
+
+# If bug 397 is not fixed, this will abort because of memory corruption
+augtool --nostdinc -I $LENSES -r $ROOT --span rm /files >/dev/null


### PR DESCRIPTION
The problem described in bug #397 is caused by an error handling memory when spans are enabled. The fix for this problem is the last patch in hte series, the others were merely minor unrelated things I encountered when fixing this bug.