### PR TITLE
Run with address sanitizer in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
-sudo: false
-addons:
-  apt:
-    packages:
-      - libxml2-dev
-      - libreadline-dev
-      - valgrind
+sudo: true
+dist: trusty
+cache:
+  ccache: true
+  directories:
+    - $TRAVIS_BUILD_DIR/gnulib
 install:
-  - ./autogen.sh
-  - sed -i '41s/ENOENT/ENOENT || errno == EINVAL/' gnulib/tests/test-readlink.h
+  - ./ci/install.sh
 language: c
+compiler:
+  - gcc-6
 notifications:
   email: false
   irc:
     channels:
       - "irc.freenode.org#augeas"
-script: ./configure && make && make check && ./src/try valgrind
+script: ./ci/test.sh

--- a/bootstrap
+++ b/bootstrap
@@ -98,4 +98,6 @@ $gnulib_tool                    \
   --aux-dir=build/ac-aux        \
   --libtool                     \
   --quiet                       \
+  --update                      \
+  --no-vc-files                 \
   --import $modules

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -35,7 +35,7 @@ sudo pip3 install -q colout2
 end_fold_marker 'dependencies'
 
 start_fold_marker 'autogen'
-./autogen.sh 2>&1 | colout2 -t autogen
+./autogen.sh --enable-asan 2>&1 | colout2 -t autogen
 exit_status=$?
 end_fold_marker 'autogen'
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -o pipefail
 
 start_fold_marker() {
   echo "travis_fold:start:install.$1"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+start_fold_marker() {
+  echo "travis_fold:start:install.$1"
+}
+
+end_fold_marker() {
+  echo "travis_fold:end:install.$1"
+}
+
+start_fold_marker 'dependencies'
+if [[ $CC = "gcc"* ]];
+then
+  sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+# elif [[ $CC = 'clang'* ]]; then
+#   sudo apt-add-repository 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-${CC#clang-} main'
+#   wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+fi
+sudo add-apt-repository ppa:jonathonf/binutils -y &&\
+  sudo add-apt-repository ppa:ondrej/autotools -y
+
+sudo apt-get -qq update
+
+sudo apt-get install aria2
+git clone https://github.com/ilikenwf/apt-fast /tmp/apt-fast --depth 1
+sudo cp /tmp/apt-fast/apt-fast /usr/bin
+sudo chmod +x /usr/bin/apt-fast
+sudo cp /tmp/apt-fast/apt-fast.conf /etc
+
+sudo apt-fast -qq install --only-upgrade automake autoconf binutils -y
+sudo apt-fast -qq install python3 python3-pip libselinux1-dev $CC libxml2-dev libreadline-dev valgrind -y
+
+sudo pip3 install -q colout2
+end_fold_marker 'dependencies'
+
+start_fold_marker 'autogen'
+./autogen.sh 2>&1 | colout2 -t autogen
+exit_status=$?
+end_fold_marker 'autogen'
+
+if [[ $exit_status -ne 0 ]];
+then
+  start_fold_marker 'error'
+  echo "An error occured while running autogen. Exit status is $exit_status."
+  start_fold_marker 'error.autogen'
+  cat config.log
+  end_fold_marker 'error.autogen'
+  end_fold_marker 'error'
+  exit $exit_status
+fi
+
+sed -i '41s/ENOENT/ENOENT || errno == EINVAL/' gnulib/tests/test-readlink.h

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -24,7 +24,7 @@ print_error_log() {
 }
 
 start_fold_marker 'configure'
-./configure --enable-debug=yes 2>&1 | colout2 -t configure
+./configure --enable-asan 2>&1 | colout2 -t configure
 end_fold_marker 'configure'
 
 start_fold_marker 'compilation'

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -e
+
+start_fold_marker() {
+  echo "travis_fold:start:script.$1"
+}
+
+end_fold_marker() {
+  echo "travis_fold:end:script.$1"
+}
+
+print_error_log() {
+  file=$1
+  maximuxsize=100
+  actualsize=$(du -k "$file" | cut -f 1)
+
+  if [ $actualsize -ge $maximuxsize ]; then
+    echo "Error log file '$file' is bigger than 100kb. Please inspect test failures locally."
+  else
+    cat $file
+  fi
+}
+
+start_fold_marker 'configure'
+./configure --enable-debug=yes 2>&1 | colout2 -t configure
+end_fold_marker 'configure'
+
+start_fold_marker 'compilation'
+make -j 2
+end_fold_marker 'compilation'
+
+start_fold_marker 'test'
+set +e
+make check -j 2
+exit_status=$?
+end_fold_marker 'test'
+
+if [[ $exit_status -ne 0 ]];
+then
+start_fold_marker 'error'
+start_fold_marker 'error.gnulib'
+print_error_log gnulib/tests/test-suite.log
+end_fold_marker 'error.gnulib'
+start_fold_marker 'error.augeas'
+print_error_log tests/test-suite.log
+end_fold_marker 'error.augeas'
+end_fold_marker 'error'
+exit $exit_status
+fi
+
+set -e
+
+start_fold_marker 'test.lenses'
+./src/try valgrind 2>&1 | colout2 -t valgrind
+end_fold_marker 'test.lenses'

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 start_fold_marker() {
   echo "travis_fold:start:script.$1"
@@ -50,7 +51,6 @@ exit $exit_status
 fi
 
 set -e
-
 start_fold_marker 'test.lenses'
 ./src/try valgrind 2>&1 | colout2 -t valgrind
 end_fold_marker 'test.lenses'

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -52,5 +52,11 @@ fi
 
 set -e
 start_fold_marker 'test.lenses'
+start_fold_marker 'test.lenses.asan'
+./src/try asan
+end_fold_marker 'test.lenses.asan'
+start_fold_marker 'test.lenses.valgrind'
+./configure --enable-debug 2>&1 | colout2 -t configure
 ./src/try valgrind 2>&1 | colout2 -t valgrind
+end_fold_marker 'test.lenses.valgrind'
 end_fold_marker 'test.lenses'

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -58,6 +58,7 @@ end_fold_marker 'test.lenses.asan'
 start_fold_marker 'test.lenses.valgrind'
 make clean
 ./autogen.sh --enable-debug 2>&1 | colout2 -t autogen
+make -j 2
 ./src/try valgrind 2>&1 | colout2 -t valgrind
 end_fold_marker 'test.lenses.valgrind'
 end_fold_marker 'test.lenses'

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -56,7 +56,8 @@ start_fold_marker 'test.lenses.asan'
 ./src/try asan
 end_fold_marker 'test.lenses.asan'
 start_fold_marker 'test.lenses.valgrind'
-./configure --enable-debug 2>&1 | colout2 -t configure
+make clean
+./autogen.sh --enable-debug 2>&1 | colout2 -t autogen
 ./src/try valgrind 2>&1 | colout2 -t valgrind
 end_fold_marker 'test.lenses.valgrind'
 end_fold_marker 'test.lenses'

--- a/configure.ac
+++ b/configure.ac
@@ -68,11 +68,11 @@ dnl --enable-asan=(yes|no)
 AC_ARG_ENABLE([asan],
               [AC_HELP_STRING([--enable-asan=no/yes],
                              [enable address sanitizers])],[],[enable_asan=yes])
-AM_CONDITIONAL([ENABLE_DEBUG], test x"$enable_debug" = x"yes")
+AM_CONDITIONAL([ENABLE_ASAN], test x"$enable_asan" = x"yes")
 if test x"$enable_asan" = x"yes"; then
    CFLAGS="${CFLAGS} -O0 -g3 -fsanitize=address -fno-omit-frame-pointer"
    LDFLAGS="${LDFLAGS} -fsanitize=address"
-   AC_DEFINE([ENABLE_DEBUG], [1], [whether address sanitizers are enabled])
+   AC_DEFINE([ENABLE_ASAN], [1], [whether address sanitizers are enabled])
 fi
 
 dnl Version info in libtool's notation

--- a/configure.ac
+++ b/configure.ac
@@ -61,9 +61,18 @@ AC_ARG_ENABLE([debug],
                              [enable debugging output])],[],[enable_debug=yes])
 AM_CONDITIONAL([ENABLE_DEBUG], test x"$enable_debug" = x"yes")
 if test x"$enable_debug" = x"yes"; then
-   CFLAGS="${CFLAGS} -O0 -g3 -fsanitize=address -fno-omit-frame-pointer -lasan -lpthread"
-   LDFLAGS="${LDFLAGS} -fsanitize=address -lasan"
-   AC_DEFINE([ENABLE_DEBUG], [1], [whether debugging is enabled])
+  AC_DEFINE([ENABLE_DEBUG], [1], [whether debugging is enabled])
+fi
+
+dnl --enable-asan=(yes|no)
+AC_ARG_ENABLE([asan],
+              [AC_HELP_STRING([--enable-asan=no/yes],
+                             [enable address sanitizers])],[],[enable_asan=yes])
+AM_CONDITIONAL([ENABLE_DEBUG], test x"$enable_debug" = x"yes")
+if test x"$enable_asan" = x"yes"; then
+   CFLAGS="${CFLAGS} -O0 -g3 -fsanitize=address -fno-omit-frame-pointer"
+   LDFLAGS="${LDFLAGS} -fsanitize=address"
+   AC_DEFINE([ENABLE_DEBUG], [1], [whether address sanitizers are enabled])
 fi
 
 dnl Version info in libtool's notation

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,8 @@ AC_ARG_ENABLE([debug],
                              [enable debugging output])],[],[enable_debug=yes])
 AM_CONDITIONAL([ENABLE_DEBUG], test x"$enable_debug" = x"yes")
 if test x"$enable_debug" = x"yes"; then
+   CFLAGS="${CFLAGS} -O0 -g3 -fsanitize=address -fno-omit-frame-pointer -lasan -lpthread"
+   LDFLAGS="${LDFLAGS} -fsanitize=address"
    AC_DEFINE([ENABLE_DEBUG], [1], [whether debugging is enabled])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ AC_ARG_ENABLE([debug],
 AM_CONDITIONAL([ENABLE_DEBUG], test x"$enable_debug" = x"yes")
 if test x"$enable_debug" = x"yes"; then
    CFLAGS="${CFLAGS} -O0 -g3 -fsanitize=address -fno-omit-frame-pointer -lasan -lpthread"
-   LDFLAGS="${LDFLAGS} -fsanitize=address"
+   LDFLAGS="${LDFLAGS} -fsanitize=address -lasan"
    AC_DEFINE([ENABLE_DEBUG], [1], [whether debugging is enabled])
 fi
 

--- a/src/try
+++ b/src/try
@@ -32,6 +32,9 @@ elif [[ "x$1" == "xstrace" ]] ; then
 elif [[ "x$1" == "xvalgrind" ]] ; then
     shift
     libtool --mode=execute valgrind --leak-check=full ./augtool --nostdinc "$@" < $AUGCMDS
+elif [[ "x$1" == "xasan" ]] ; then
+    shift
+    libtool --mode=execute ./augtool --nostdinc "$@" < $AUGCMDS
 elif [[ "x$1" == "xcallgrind" ]] ; then
     libtool --mode=execute valgrind --tool=callgrind ./augtool --nostdinc < $AUGCMDS
 elif [[ "x$1" == "xcli" ]] ; then


### PR DESCRIPTION
This will prevent bugs like #403 from ever hitting master.
The address sanitizer is able to detect use-after-free issues and other bad memory handling issues.
