### PR TITLE
fixes #407 - add support for Splunk Universal Forwarder and new configs

### DIFF
--- a/lenses/splunk.aug
+++ b/lenses/splunk.aug
@@ -1,20 +1,20 @@
 (*
 Module: Splunk
-  Parses /opt/splunk/etc/*
+  Parses /opt/splunk/etc/*, /opt/splunkforwarder/etc/system/local/*.conf and /opt/splunkforwarder/etc/apps/*/(default|local)/*.conf
 
-Author: Tim Brigham
+Author: Tim Brigham, Jason Antman
 
 About: Reference
-  http://docs.splunk.com/Documentation/Splunk/5.0.2/Admin/AboutConfigurationFiles
+  https://docs.splunk.com/Documentation/Splunk/6.5.0/Admin/AboutConfigurationFiles
 
 About: License
    This file is licenced under the LGPL v2+
 
 About: Lens Usage
-   Works like IniFile lens, with anonymous section for entries without enclosing section.
+   Works like IniFile lens, with anonymous section for entries without enclosing section and allowing underscore-prefixed keys.
 
 About: Configuration files
-   This lens applies to conf files under /opt/splunk/etc See <filter>.
+   This lens applies to conf files under /opt/splunk/etc and /opt/splunkforwarder/etc See <filter>.
 
 About: Examples
    The <Test_Splunk> file contains various examples and tests.
@@ -27,9 +27,10 @@ module Splunk =
   let sep       = IniFile.sep IniFile.sep_re IniFile.sep_default
   let empty     = IniFile.empty
 
-  let setting   = IniFile.entry_re
+  let entry_re  = ( /[A-Za-z_][A-Za-z0-9._-]*/ )
+  let setting   = entry_re
   let title     =  IniFile.indented_title_label "target" IniFile.record_label_re
-  let entry     = [ key IniFile.entry_re . sep . IniFile.sto_to_eol? . IniFile.eol ] | comment
+  let entry     = [ key entry_re . sep . IniFile.sto_to_eol? . IniFile.eol ] | comment
 
 
   let record    = IniFile.record title entry
@@ -38,4 +39,7 @@ module Splunk =
 
   let filter    = incl "/opt/splunk/etc/system/local/*.conf"
                 . incl "/opt/splunk/etc/apps/*/local/*.conf"
+                . incl "/opt/splunkforwarder/etc/system/local/*.conf"
+                . incl "/opt/splunkforwarder/etc/apps/*/default/*.conf"
+                . incl "/opt/splunkforwarder/etc/apps/*/local/*.conf"
   let xfm       = transform lns filter

--- a/lenses/tests/test_splunk.aug
+++ b/lenses/tests/test_splunk.aug
@@ -12,6 +12,7 @@ module Test_splunk =
    let inputs = "[default]
 host = splunk-node-1.example.com
 enable_autocomplete_login = False
+_meta = metakey::metaval foo::bar
 
 [udp://514]
 connection_host = none
@@ -23,6 +24,7 @@ test Splunk.lns get inputs =
   { "target" = "default"
       { "host" = "splunk-node-1.example.com" }
       { "enable_autocomplete_login" = "False" }
+      { "_meta" = "metakey::metaval foo::bar" }
   {}}
   { "target" = "udp://514"
       { "connection_host" = "none" }


### PR DESCRIPTION
- add support to Splunk lens for Splunk Universal Forwarder and new 6.x config that includes underscore-prefixed keys

See #407 for description of problem.