### PR TITLE
Cron_User: new lens for user crontab files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@
       checked properly. This new check might lead to errors in existing
       lenses, requiring that they be fixed.
   - Lens changes/additions
+    * Cron_User: New lens to handle user crontab files in /var/spool/cron
     * Opendkim: new lens for /etc/opendkim.conf (Craig Miskell)
 
 1.6.0 - 2016-08-05

--- a/lenses/cron_user.aug
+++ b/lenses/cron_user.aug
@@ -1,0 +1,46 @@
+(*
+Module: Cron_User
+ Parses /var/spool/cron/*
+
+Author: David Lutterkort <lutter@watzmann.net>
+
+About: Reference
+ This lens parses the user crontab files in /var/spool/cron. It produces
+ almost the same tree as teh Cron.lns, except that it never contains a user
+ field.
+
+About: License
+  This file is licensed under the LGPL v2+, like the rest of Augeas.
+
+About: Lens Usage
+  Sample usage of this lens in augtool
+
+    * Get the entry that launches '/usr/bin/ls'
+      >  match '/files/var/spool/cron/foo/entry[. = "/usr/bin/ls"]'
+
+About: Configuration files
+  This lens applies to /var/spool/cron*. See <filter>.
+ *)
+module Cron_User =
+  autoload xfm
+
+(************************************************************************
+ * View: entry
+ *   A crontab entry for a user's crontab
+ *************************************************************************)
+let entry        = [ label "entry" . Cron.indent
+                   . Cron.prefix?
+                   . ( Cron.time | Cron.schedule )
+                   . Cron.sep_spc . store Rx.space_in . Cron.eol ]
+
+(*
+ * View: lns
+ *   The cron_user lens. Almost identical to Cron.lns
+ *)
+let lns = ( Cron.empty | Cron.comment | Cron.shellvar | entry )*
+
+let filter =
+  incl "/var/spool/cron/*" .
+  Util.stdexcl
+
+let xfm = transform lns filter

--- a/lenses/tests/test_cron_user.aug
+++ b/lenses/tests/test_cron_user.aug
@@ -1,0 +1,34 @@
+module Test_Cron_User =
+
+let s = "MAILTO=cron@example.com
+31 * * * * ${HOME}/bin/stuff
+54 16 * * * /usr/sbin/tmpwatch -umc 30d ${HOME}/tmp\n"
+
+let lns = Cron_User.lns
+
+test lns get s =
+  { "MAILTO" = "cron@example.com" }
+  { "entry" = "${HOME}/bin/stuff"
+    { "time"
+      { "minute" = "31" }
+      { "hour" = "*" }
+      { "dayofmonth" = "*" }
+      { "month" = "*" }
+      { "dayofweek" = "*" }
+    }
+  }
+  { "entry" = "/usr/sbin/tmpwatch -umc 30d ${HOME}/tmp"
+    { "time"
+      { "minute" = "54" }
+      { "hour" = "16" }
+      { "dayofmonth" = "*" }
+      { "month" = "*" }
+      { "dayofweek" = "*" }
+    }
+  }
+
+test lns put s after
+rm "/MAILTO";
+rm "/entry[time/minute = '54']";
+set "/entry[. = '${HOME}/bin/stuff']/time/minute" "24" =
+  "24 * * * * ${HOME}/bin/stuff\n"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -49,6 +49,7 @@ lens_tests =			\
   lens-collectd.sh	\
   lens-cpanel.sh	\
   lens-cron.sh			\
+  lens-cron_user.sh			\
   lens-crypttab.sh		\
   lens-csv.sh		\
   lens-cyrus_imapd.sh		\

--- a/tests/root/etc/crontab
+++ b/tests/root/etc/crontab
@@ -1,0 +1,3 @@
+MAILTO=cron@example.com
+42  * * * * lutter /usr/local/bin/backup
+54 16 * * * lutter /usr/sbin/stuff

--- a/tests/root/var/spool/cron/root
+++ b/tests/root/var/spool/cron/root
@@ -1,0 +1,4 @@
+MAILTO=cron@example.com
+RANDOM_DELAY=7
+17 12 */4 * * /usr/sbin/boom
+@reboot       /usr/sbin/boom


### PR DESCRIPTION
The user crontab files in /var/spool/cron have a slightly different format
from /etc/crontab in that they do not have a 'user' field as that's implied
by the filename. Unfortunately, it is not possible to use Cron.lns, since
defining Cron.entry as

  let entry       = [ label "entry" . indent
                    . prefix?
                    . ( time | schedule )
                    . (sep_spc . user)?
                    . sep_spc . store Rx.space_in . eol ]

(i.e., with a ( .. )? around the user name) leads to typecheck errors.

This lens is a minor variation on Cron.lns and just removes the bits about
the user field.
