### PR TITLE
Properly check composite regular expressions for syntax errors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,12 @@
       bytes) and often hard to trigger, but we now have proof that at least
       while running tests there are no leaks at all.
       See https://github.com/hercules-team/augeas/pull/405 for details.
+    * The type checker now checks regexes that are involved in
+      expressions. For example, it used to be possible to write 'let rx =
+      /a/ | /b)/' and not get an error from the syntax checker, even though
+      'let rx = /b)/' would result in an error. Such constructs are now
+      checked properly. This new check might lead to errors in existing
+      lenses, requiring that they be fixed.
   - Lens changes/additions
     * Opendkim: new lens for /etc/opendkim.conf (Craig Miskell)
 

--- a/lenses/cron.aug
+++ b/lenses/cron.aug
@@ -75,7 +75,7 @@ let sep_eq  = Util.del_str "="
  *************************************************************************)
 
 let shellvar =
-  let key_re = /[A-Za-z-1-9_]+(\[[0-9]+\])?/ - "entry" in
+  let key_re = /[A-Za-z1-9_-]+(\[[0-9]+\])?/ - "entry" in
   let sto_to_eol = store /[^\n]*[^ \t\n]/ in
   [ key key_re . sep_eq . sto_to_eol . eol ]
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -539,7 +539,6 @@ static struct term *make_ident(char *qname, struct info *locp) {
 static struct term *make_unit_term(struct info *locp) {
   struct term *term = make_term_locp(A_VALUE, locp);
   term->value = make_unit(ref(term->info));
-  term->type = make_base_type(T_UNIT);
   return term;
 }
 
@@ -547,7 +546,6 @@ static struct term *make_string_term(char *value, struct info *locp) {
   struct term *term = make_term_locp(A_VALUE, locp);
   term->value = make_value(V_STRING, ref(term->info));
   term->value->string = make_string(value);
-  term->type = make_base_type(T_STRING);
   return term;
 }
 
@@ -555,7 +553,6 @@ static struct term *make_regexp_term(char *pattern, int nocase,
                                      struct info *locp) {
   struct term *term = make_term_locp(A_VALUE, locp);
   term->value = make_value(V_REGEXP, ref(term->info));
-  term->type = make_base_type(T_REGEXP);
   term->value->regexp = make_regexp(term->info, pattern, nocase);
   return term;
 }
@@ -603,7 +600,6 @@ static struct term *make_tree_value(struct tree *tree, struct info *locp) {
   struct term *term = make_term_locp(A_VALUE, locp);
   struct value *value = make_value(V_TREE, ref(term->info));
   value->origin = make_tree_origin(tree);
-  term->type = make_base_type(T_TREE);
   term->value = value;
   return term;
 }

--- a/tests/modules/fail_invalid_regexp.aug
+++ b/tests/modules/fail_invalid_regexp.aug
@@ -1,0 +1,6 @@
+module Fail_Invalid_Regexp =
+
+  (* We used to not spot that the second regexp in the union is invalid
+     because we did not properly check expressions that contained
+     literals. This construct now leads to a syntax error *)
+  let rx = /a/ | /d)/


### PR DESCRIPTION
We used to not properly check the syntax of regular expressions that are
constructed. For example, in the construct

    let rx = /a/ | /b)/

we would not check whether /b)/ is syntactically correct, which would later
lead to Augeas crashing. The reason for this was that literals had types
assigned to them before we actually checked them, i.e., the assumption was
that values didn't need any checking beyond setting their type, which is
not true for regular expressions.