### PR TITLE
Refine handling of multiple transforms handling the same file

### DIFF
--- a/src/transform.h
+++ b/src/transform.h
@@ -109,6 +109,13 @@ int remove_file(struct augeas *aug, struct tree *tree);
 /* Return a printable name for the transform XFM. Never returns NULL. */
 const char *xfm_lens_name(struct tree *xfm);
 
+/* Return the lens and its name from the transform XFM. LENS_NAME may be
+   NULL, in which case the name of the lens is not returned, only the lens
+   itself.
+*/
+struct lens *xfm_lens(struct augeas *aug,
+                      struct tree *xfm, const char **lens_name);
+
 /* Store a file-specific transformation error in /augeas/files/PATH/error */
 ATTRIBUTE_FORMAT(printf, 4, 5)
 void transform_file_error(struct augeas *aug, const char *status,

--- a/tests/test-save.c
+++ b/tests/test-save.c
@@ -147,9 +147,21 @@ static void testMultipleXfm(CuTest *tc) {
 
     r = aug_set(aug, "/files/etc/yum.repos.d/fedora.repo/fedora/enabled", "0");
     CuAssertIntEquals(tc, 0, r);
+    /* What we have set up is fine: two ways to save the same file with the
+       same lens */
+    r = aug_save(aug);
+    CuAssertIntEquals(tc, 0, r);
+
+    /* Now we make it bad: a different lens for the same file */
+    r = aug_set(aug, "/augeas/load/Yum2/lens", "@Subversion");
+    CuAssertIntEquals(tc, 0, r);
+
+    r = aug_set(aug, "/files/etc/yum.repos.d/fedora.repo/fedora/enabled", "1");
+    CuAssertIntEquals(tc, 0, r);
 
     r = aug_save(aug);
     CuAssertIntEquals(tc, -1, r);
+
     r = aug_error(aug);
     CuAssertIntEquals(tc, AUG_EMXFM, r);
 }


### PR DESCRIPTION
We used to blindly flag an error when there were multiple transforms that
handled the same file. That is now ok as long as these transforms all use
the exact same lens.