### PR TITLE
Xml: process external entities in DOCTYPE declaration

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
   - Lens changes/additions
     * Tmpfiles: parse 'q'/'Q' modes, parse two-character arguments,
                 parse three-digit file modes
+    * Xml: support external entity declarations in the doctype (Issue #142)
 
 1.7.0 - 2016-11-08
   - General changes/additions

--- a/lenses/xml.aug
+++ b/lenses/xml.aug
@@ -78,7 +78,13 @@ let att_def       = counter "att_id" .
 
 let att_list_def = decl_def /!ATTLIST/ att_def
 
-let entity_def    = decl_def /!ENTITY/ ([sep_spc . label "#decl" . sto_dquote ])
+let entity_def   =
+  let literal (lbl:string) = [ sep_spc . label lbl . sto_dquote ] in
+  decl_def /!ENTITY/
+    ( literal "#decl"
+    | [ sep_spc . key /SYSTEM/ . literal "#systemliteral" ]
+    | [ sep_spc . key /PUBLIC/ . literal "#pubidliteral"
+                               . literal "#systemliteral" ] )
 
 let decl_def_item = elem_def | entity_def | att_list_def | notation_def
 


### PR DESCRIPTION
See http://www.w3.org/TR/2006/REC-xml11-20060816/#sec-external-ent for the
required syntax.

Based on initial patch by Adam Bottchen.

Fixes https://github.com/hercules-team/augeas/issues/142