### PR TITLE
Yum lenses work on DNF, add them to import list

### DIFF
--- a/lenses/yum.aug
+++ b/lenses/yum.aug
@@ -53,6 +53,9 @@ let lns    = (empty | comment)* . record*
       . (incl "/etc/yum/yum-cron*.conf") 
       . (incl "/etc/yum/pluginconf.d/*")
       . (excl "/etc/yum/pluginconf.d/versionlock.list")
+      . (incl "/etc/dnf/dnf.conf")
+      . (incl "/etc/dnf/automatic.conf")
+      . (incl "/etc/dnf/plugins/*.conf")
       . Util.stdexcl
 
   let xfm = transform lns filter


### PR DESCRIPTION
My tests of the Yum lenses on DNF had no errors.  Added DNF configs to the import list.