### PR TITLE
[krb5.aug] Support realms that start with numbers

### DIFF
--- a/lenses/krb5.aug
+++ b/lenses/krb5.aug
@@ -21,8 +21,8 @@ let closebr = del /[ \t]*\}/ "}"
    and realms in the [appdefaults] section.
 *)
 
-let realm_re = /[A-Z][.a-zA-Z0-9-]*/
-let realm_anycase_re = /[A-Za-z][.a-zA-Z0-9-]*/
+let realm_re = /[A-Z0-9][.a-zA-Z0-9-]*/
+let realm_anycase_re = /[A-Za-z0-9][.a-zA-Z0-9-]*/
 let app_re = /[a-z][a-zA-Z0-9_]*/
 let name_re = /[.a-zA-Z0-9_-]+/
 

--- a/lenses/tests/test_krb5.aug
+++ b/lenses/tests/test_krb5.aug
@@ -92,6 +92,10 @@ module Test_krb5 =
                         }
                 }
 	}
+    1TS.ORG = {
+        kdc = kerberos.1ts.org
+        admin_server = kerberos.1ts.org
+    }
         stanford.edu = {
                 kdc = krb5auth1.stanford.edu
                 kdc = krb5auth2.stanford.edu
@@ -366,6 +370,10 @@ test Krb5.lns get fermi_str =
           { "rcmd" = "host" }
         }
       }
+    }
+    { "realm" = "1TS.ORG"
+      { "kdc" = "kerberos.1ts.org" }
+      { "admin_server" = "kerberos.1ts.org" }
     }
     { "realm" = "stanford.edu"
       { "kdc" = "krb5auth1.stanford.edu" }


### PR DESCRIPTION
Currently, the default kerberos configuration that ships with
Ubuntu has a realm that starts with a number (1TS.ORG). This
causes the parser to fail and prevents krb5.conf from being
available via augtool.

This patch allows numbers 0-9 as the first character of a
realm.

```
[realms]
~~<snip>~~
    1TS.ORG = {
        kdc = kerberos.1ts.org
        admin_server = kerberos.1ts.org
    }
```