### PR TITLE
Allow underscores in postfix_virtual

### DIFF
--- a/lenses/postfix_virtual.aug
+++ b/lenses/postfix_virtual.aug
@@ -32,7 +32,7 @@ let space_or_eol (sep:regexp) (default:string) =
   del (space_or_eol_re? . sep . space_or_eol_re?) default
 
 (* View: word *)
-let word = store /[A-Za-z0-9@\*.+=-_]+/
+let word = store /[A-Za-z0-9@\*.+=_-]+/
 
 (* View: comma *)
 let comma = space_or_eol "," ", "

--- a/lenses/postfix_virtual.aug
+++ b/lenses/postfix_virtual.aug
@@ -32,7 +32,7 @@ let space_or_eol (sep:regexp) (default:string) =
   del (space_or_eol_re? . sep . space_or_eol_re?) default
 
 (* View: word *)
-let word = store /[A-Za-z0-9@\*.+=-]+/
+let word = store /[A-Za-z0-9@\*.+=-_]+/
 
 (* View: comma *)
 let comma = space_or_eol "," ", "

--- a/lenses/tests/test_postfix_virtual.aug
+++ b/lenses/tests/test_postfix_virtual.aug
@@ -16,6 +16,7 @@ user2@virtual-alias.domain
 root    robert.oot@domain.com
 @example.net  root,postmaster
 postmaster  mtaadmin+root=mta1
+some_user  localuser
 "
 
 (* Test: Postfix_Virtual.lns *)
@@ -43,4 +44,7 @@ test Postfix_Virtual.lns get conf =
   }
   { "pattern" = "postmaster"
     { "destination" = "mtaadmin+root=mta1" }
+  }
+  { "pattern" = "some_user"
+    { "destination" = "localuser" }
   }


### PR DESCRIPTION
As per #439, understores are legal in an e-mail address.