### PR TITLE
Add lens for radicale config file

### DIFF
--- a/lenses/radicale.aug
+++ b/lenses/radicale.aug
@@ -1,0 +1,43 @@
+(* Radicale module for Augeas
+ Based on Puppet lens.
+
+ /etc/radicale/config is a standard INI File.
+*)
+
+
+module Radicale =
+  autoload xfm
+
+(************************************************************************
+ * INI File settings
+ *
+ * /etc/radicale/config only supports "#" as commentary and "=" as separator
+ *************************************************************************)
+let comment    = IniFile.comment "#" "#"
+let sep        = IniFile.sep "=" "="
+
+
+(************************************************************************
+ *                        ENTRY
+ * /etc/radicale/config uses standard INI File entries
+ *************************************************************************)
+let entry   = IniFile.indented_entry IniFile.entry_re sep comment
+
+
+(************************************************************************
+ *                        RECORD
+ * /etc/radicale/config uses standard INI File records
+ *************************************************************************)
+let title   = IniFile.indented_title IniFile.record_re
+let record  = IniFile.record title entry
+
+
+(************************************************************************
+ *                        LENS & FILTER
+ * /etc/radicale/config uses standard INI File records
+ *************************************************************************)
+let lns     = IniFile.lns record comment
+
+let filter = (incl "/etc/radicale/config")
+
+let xfm = transform lns filter

--- a/lenses/tests/test_radicale.aug
+++ b/lenses/tests/test_radicale.aug
@@ -1,0 +1,77 @@
+module Test_radicale =
+
+   let conf = "
+[server]
+
+[encoding]
+
+[well-known]
+
+[auth]
+
+[git]
+
+[rights]
+
+[storage]
+
+[logging]
+
+[headers]
+
+"
+
+   test Radicale.lns get conf =
+      {}
+      { "server"
+         {} }
+      { "encoding"
+         {} }
+      { "well-known"
+         {} }
+      { "auth"
+         {} }
+      { "git"
+         {} }
+      { "rights"
+         {} }
+      { "storage"
+         {} }
+      { "logging"
+         {} }
+      { "headers"
+         {} }
+
+    test Radicale.lns put conf after
+       set "server/hosts" "127.0.0.1:5232, [::1]:5232";
+       set "server/base_prefix" "/radicale/";
+       set "well-known/caldav" "/radicale/%(user)s/caldav/";
+       set "well-known/cardav" "/radicale/%(user)s/carddav/";
+       set "auth/type" "remote_user";
+       set "rights/type" "owner_only"
+    = "
+[server]
+
+hosts=127.0.0.1:5232, [::1]:5232
+base_prefix=/radicale/
+[encoding]
+
+[well-known]
+
+caldav=/radicale/%(user)s/caldav/
+cardav=/radicale/%(user)s/carddav/
+[auth]
+
+type=remote_user
+[git]
+
+[rights]
+
+type=owner_only
+[storage]
+
+[logging]
+
+[headers]
+
+"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -168,6 +168,7 @@ lens_tests =			\
   lens-qpid.sh		\
   lens-quote.sh		\
   lens-rabbitmq.sh		\
+  lens-radicale.sh		\
   lens-redis.sh		\
   lens-reprepro_uploaders.sh		\
   lens-resolv.sh		\


### PR DESCRIPTION
This lens can parse /etc/radicale/config. It's a standard INI file, so the lens is basically the same as Puppet lens, except for the included path.