### PR TITLE
Reduce the total amount of memory used by Augeas

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,16 @@
 1.8.0 - ???
   - General changes/additions
     * augtool: add a 'source' command exposing the aug_source API call
+    * augtool: dramatically reduce memory consumption when all lenses are
+      loaded by more aggressively releasing temporary data structures.  On
+      my machine, maximum memory usage of 'augtool -L' drops from roughly
+      90MB to about 20MB. This will not change the amount of memory used
+      when only specific lenses are used, only the default behavior of
+      loading all lenses, i.e., when -A is not passed.
   - API changes
     * add aug_source to find the source file for a particular node
+    * reduce memory consumption when AUG_NO_MODL_AUTOLOAD is _not_ passed;
+      exact same details as described above for augtool
   - Lens changes/additions
     * Ssh: also look for files in in /etc/ssh/ssh_config.d (Ian Mortimer)
     * Tmpfiles: parse 'q'/'Q' modes, parse two-character arguments,

--- a/src/lens.c
+++ b/src/lens.c
@@ -1056,6 +1056,10 @@ void lens_release(struct lens *lens) {
         }
     }
 
+    if (lens->tag == L_REC && !lens->rec_internal) {
+        lens_release(lens->body);
+    }
+
     jmt_free(lens->jmt);
     lens->jmt = NULL;
 }

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -2002,9 +2002,14 @@ int load_module_file(struct augeas *aug, const char *filename,
          */
         module = module_create(name);
     }
-    if (module != NULL)
+    if (module != NULL) {
         list_append(aug->modules, module);
-
+        list_for_each(bnd, module->bindings) {
+            if (bnd->value->tag == V_LENS) {
+                lens_release(bnd->value->lens);
+            }
+        }
+    }
     ERR_THROW(bad_module, aug, AUG_ESYNTAX, "Failed to load %s", filename);
 
     result = 0;


### PR DESCRIPTION
The pattern buffers for compiled regular expressions take up a large amount
of space. Previously, we had placed calls to lens_release strategically so
that that memory gets released when we are done with a lens for a while
(for example, after loading all files described by a transform)

That overlooked that the interpreter compiles regular expressions when it
loads lenses. We now also release lens storage after loading an entire
module. That requires that regular expressions are compiled again when we
start actually loading files, but the additional regex compilation does not
seem to affect the overall runtime. It does dramatically reduce maximum
memory needed by an 'augtool -L quit'. On my machine, it drops from about
90MB to about 20MB.