### PR TITLE
Fix for rsyslog rainerscript module loading, with options

### DIFF
--- a/lenses/rsyslog.aug
+++ b/lenses/rsyslog.aug
@@ -26,10 +26,10 @@ autoload xfm
 let macro_rx = /[^,# \n\t][^#\n]*[^,# \n\t]|[^,# \n\t]/
 let macro = [ key /$[A-Za-z0-9]+/ . Sep.space . store macro_rx . Util.comment_or_eol ]
 
-let config_object_param = [ key /[A-Za-z]+/ . Sep.equal . Quote.dquote
-                          . store /[^"]+/ . Quote.dquote . Sep.opt_space ]
+let config_object_param = [ key /[A-Za-z.]+/ . Sep.equal . Quote.dquote
+                          . store /[^"]+/ . Quote.dquote ]
 let config_object = [ key /action|global|input|module|parser|timezone/ . Sep.lbracket
-                    . config_object_param+ . Sep.rbracket . Util.comment_or_eol ]
+                    . config_object_param . ( Sep.space . config_object_param )* . Sep.rbracket . Util.comment_or_eol ]
 
 (* View: users
    Map :omusrmsg: and a list of users, or a single *

--- a/lenses/tests/test_rsyslog.aug
+++ b/lenses/tests/test_rsyslog.aug
@@ -10,7 +10,7 @@ let conf = "# rsyslog v5 configuration file
 
 $ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
 $ModLoad imklog   # provides kernel logging support (previously done by rklogd)
-module(load=\"immark\") #provides --MARK-- message capability
+module(load=\"immark\" markmessageperiod=\"60\" fakeoption=\"bar\") #provides --MARK-- message capability
 
 timezone(id=\"CET\" offset=\"+01:00\")
 
@@ -42,6 +42,8 @@ test Rsyslog.lns get conf =
   }
   { "module"
     { "load" = "immark" }
+    { "markmessageperiod" = "60" }
+    { "fakeoption" = "bar" }
     { "#comment" = "provides --MARK-- message capability" }
   }
   {  }
@@ -172,3 +174,18 @@ test Rsyslog.lns get ":msg,!contains,\"garbage\" ~\n" =
     { "value" = "garbage" }
     { "action"
       { "discard" } } }
+
+test Rsyslog.lns put "" after
+  set "/module[1]/load" "imuxsock"
+  = "module(load=\"imuxsock\")\n"
+
+test Rsyslog.lns put "" after
+  set "/module[1]/load" "imuxsock" ;
+  set "/module[1]/SysSock.RateLimit.Interval" "0"
+  = "module(load=\"imuxsock\" SysSock.RateLimit.Interval=\"0\")\n"
+
+test Rsyslog.lns put "" after
+  set "/module[1]/load" "imuxsock" ;
+  set "/module[1]/SysSock.RateLimit.Interval" "0" ;
+  set "/module[1]/SysSock.RateLimit.Burst" "1"
+  = "module(load=\"imuxsock\" SysSock.RateLimit.Interval=\"0\" SysSock.RateLimit.Burst=\"1\")\n"


### PR DESCRIPTION
Turns out module loads can have more than one option.  This fixes handling of that, and adds some related tests to be really sure.