### PR TITLE
Improve put error messages

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+1.9.0 - 2017-??-??
+  - General changes/additions
+    * several improvements to the error messages when transforming a tree
+      back to text fails. They now make it clearer what part of the tree
+      was problematic, and what the tree should have looked like.
+
 1.8.0 - 2017-03-20
   - General changes/additions
     * augtool: add a 'source' command exposing the aug_source API call

--- a/src/lens.c
+++ b/src/lens.c
@@ -542,7 +542,7 @@ static struct regexp *restrict_regexp(struct regexp *r) {
 
     ret = fa_restrict_alphabet(r->pattern->str, strlen(r->pattern->str),
                                &nre, &nre_len,
-                               RESERVED_FROM, RESERVED_TO);
+                               RESERVED_FROM_CH, RESERVED_TO_CH);
     ERR_NOMEM(ret == REG_ESPACE || ret < 0, r->info);
     BUG_ON(ret != 0, r->info, NULL);
     ensure(nre_len == strlen(nre), r->info);

--- a/src/lens.h
+++ b/src/lens.h
@@ -234,8 +234,14 @@ void free_lens(struct lens *lens);
 
    This range must include the ENC_* characters
 */
-#define RESERVED_FROM '\001'
-#define RESERVED_TO   ENC_SLASH_CH
+#define RESERVED_FROM "\001"
+#define RESERVED_TO   ENC_SLASH
+#define RESERVED_FROM_CH (RESERVED_FROM[0])
+#define RESERVED_TO_CH   ENC_SLASH_CH
+/* The range of reserved chars as it appears in a regex */
+#define RESERVED_RANGE_RX RESERVED_FROM "-" RESERVED_TO
+/* The equivalent of "." in a regexp for display */
+#define RESERVED_DOT_RX "[^" RESERVED_RANGE_RX "\n]"
 
 /* The length of the string S encoded */
 #define ENCLEN(s) ((s) == NULL ? strlen(ENC_NULL) : strlen(s))

--- a/src/put.c
+++ b/src/put.c
@@ -121,15 +121,15 @@ static void regexp_match_error(struct state *state, struct lens *lens,
 
     if (count == -1) {
         put_error(state, lens,
-                  "Failed to match tree\n\n%s\n  with pattern\n   %s",
-                  text, pat);
+                  "Failed to match tree under %s\n\n%s\n  with pattern\n   %s\n",
+                  state->path, text, pat);
     } else if (count == -2) {
         put_error(state, lens,
-                  "Internal error matching\n    %s\n  with tree\n   %s",
+                  "Internal error matching\n    %s\n  with tree\n   %s\n",
                   pat, text);
     } else if (count == -3) {
         /* Should have been caught by the typechecker */
-        put_error(state, lens, "Syntax error in tree schema\n    %s", pat);
+        put_error(state, lens, "Syntax error in tree schema\n    %s\n", pat);
     }
     free(pat);
     free(text);

--- a/src/put.c
+++ b/src/put.c
@@ -519,7 +519,7 @@ static void put_concat(struct lens *lens, struct state *state) {
 }
 
 static void error_quant_star(struct split *last_split, struct lens *lens,
-                             struct state *state) {
+                             struct state *state, const char *enc) {
     struct tree *child = NULL;
     if (last_split != NULL) {
         if (last_split->follow != NULL) {
@@ -530,11 +530,25 @@ static void error_quant_star(struct split *last_split, struct lens *lens,
                  child = child->next);
         }
     }
+    char *text = NULL;
+    char *pat = NULL;
+
+    lns_format_atype(lens, &pat);
+    text = enc_format_indent(enc, strlen(enc), 4);
+
     if (child == NULL) {
-        put_error(state, lens, "Malformed child node");
+        put_error(state, lens,
+             "Missing a node: can not match tree\n\n%s\n with pattern\n   %s\n",
+                  text, pat);
     } else {
-        put_error(state, lens, "Malformed child node '%s'", child->label);
+        char *s = path_of_tree(child);
+        put_error(state, lens,
+          "Unexpected node '%s': can not match tree\n\n%s\n with pattern\n   %s\n",
+                  s, text, pat);
+        free(s);
     }
+    free(pat);
+    free(text);
 }
 
 static void put_quant_star(struct lens *lens, struct state *state) {
@@ -560,7 +574,7 @@ static void put_quant_star(struct lens *lens, struct state *state) {
         next_split(state);
     }
     if (state->pos != oldsplit->end)
-        error_quant_star(last_split, lens, state);
+        error_quant_star(last_split, lens, state, oldsplit->enc + state->pos);
     list_free(split);
     set_split(state, oldsplit);
     state->skel = oldskel;
@@ -766,7 +780,7 @@ static void create_quant_star(struct lens *lens, struct state *state) {
         next_split(state);
     }
     if (state->pos != oldsplit->end)
-        error_quant_star(last_split, lens, state);
+        error_quant_star(last_split, lens, state, oldsplit->enc + state->pos);
     list_free(split);
     set_split(state, oldsplit);
 }

--- a/src/put.c
+++ b/src/put.c
@@ -437,14 +437,14 @@ static void put_subtree(struct lens *lens, struct state *state) {
     assert(lens->tag == L_SUBTREE);
     struct state oldstate = *state;
     struct split oldsplit = *state->split;
-    size_t oldpathlen = strlen(state->path);
+    char *       oldpath = state->path;
 
     struct tree *tree = state->split->tree;
     struct split *split = NULL;
 
     state->key = tree->label;
     state->value = tree->value;
-    pathjoin(&state->path, 1, state->key);
+    state->path = path_of_tree(tree);
 
     split = make_split(tree->children);
     set_split(state, split);
@@ -462,7 +462,8 @@ static void put_subtree(struct lens *lens, struct state *state) {
     *state = oldstate;
     *state->split= oldsplit;
     free_split(split);
-    state->path[oldpathlen] = '\0';
+    free(state->path);
+    state->path = oldpath;
 }
 
 static void put_del(ATTRIBUTE_UNUSED struct lens *lens, struct state *state) {
@@ -843,7 +844,7 @@ void lns_put(FILE *out, struct lens *lens, struct tree *tree,
         return;
 
     MEMZERO(&state, 1);
-    state.path = strdup("");
+    state.path = strdup("/");
     state.skel = lns_parse(lens, text, &state.dict, &err1);
 
     if (err1 != NULL) {

--- a/src/regexp.h
+++ b/src/regexp.h
@@ -117,7 +117,9 @@ struct regexp *regexp_make_empty(struct info *);
    regular expressions */
 void regexp_release(struct regexp *regexp);
 
-/* Produce a printable representation of R */
+/* Produce a printable representation of R. The result will in general not
+   be equivalent to the passed regular expression, but be easier for
+   humans to read. */
 char *regexp_escape(const struct regexp *r);
 
 /* If R is case-insensitive, expand its pattern so that it matches the same


### PR DESCRIPTION
These changes improve the error messages when transforming the tree back to a string by giving more context about where the error happened and what the tree was supposed to look like.

One example:
```
module T =

  let nd (k:string) = [ key k ]
  let lns = ((nd "a") | (nd "b"))*

  let s = "ab"
  test lns get s = { "a" } { "b" }
  test lns put s after clear "/xkey[1]/typex" = ?
```

This used to produce the error
```
/tmp/t.aug:8.2-.49:exception thrown in test
/tmp/t.aug:8.7-.45:exception: Malformed child node 'xkey'
    Lens: /tmp/t.aug:4.12-.34:
    Error encountered at path

Syntax error in lens definition
Failed to load /tmp/t.aug
```

but now says
```
/tmp/t.aug:8.2-.49:exception thrown in test
/tmp/t.aug:8.7-.45:exception: Unexpected node '/xkey': can not match tree

     { "xkey" }

 with pattern
   (    { /a/ }
      | { /b/ })*

    Lens: /tmp/t.aug:4.12-.34:
    Error encountered at path /

Syntax error in lens definition
Failed to load /tmp/t.aug
```