### PR TITLE
Add new nslcd.conf lenses to parse nss-pam-ldapd configuration file

### DIFF
--- a/doc/naturaldocs/conf/lenses/Menu.txt
+++ b/doc/naturaldocs/conf/lenses/Menu.txt
@@ -31,22 +31,22 @@ Don't Index: Properties
 
 
 # --------------------------------------------------------------------------
-# 
+#
 # Cut and paste the lines below to change the order in which your files
 # appear on the menu.  Don't worry about adding or removing files, Natural
 # Docs will take care of that.
-# 
+#
 # You can further organize the menu by grouping the entries.  Add a
 # "Group: [name] {" line to start a group, and add a "}" to end it.
-# 
+#
 # You can add text and web links to the menu by adding "Text: [text]" and
 # "Link: [name] ([URL])" lines, respectively.
-# 
+#
 # The formatting and comments are auto-generated, so don't worry about
 # neatness when editing the file.  Natural Docs will clean it up the next
 # time it is run.  When working with groups, just deal with the braces and
 # forget about the indentation and comments.
-# 
+#
 # --------------------------------------------------------------------------
 
 
@@ -134,6 +134,7 @@ Group: Specific Modules  {
    File: Networks  (networks.aug)
    File: Nginx  (nginx.aug)
    File: Nrpe  (nrpe.aug)
+   File: Nslcd  (nslcd.aug)
    File: Nsswitch  (nsswitch.aug)
    File: Ntpd  (ntpd.aug)
    File: OpenShift_Config  (openshift_config.aug)
@@ -261,6 +262,7 @@ Group: Tests and Examples  {
    File: Test_NagiosCfg  (tests/test_nagioscfg.aug)
    File: Test_NetworkManager  (tests/test_networkmanager.aug)
    File: Test_Nginx  (tests/test_nginx.aug)
+   File: Test_Nslcd  (tests/test_nslcd
    File: Test_Ntpd  (tests/test_ntpd.aug)
    File: Test_OpenShift_Config  (tests/test_openshift_config.aug)
    File: Test_OpenShift_Http  (tests/test_openshift_http.aug)
@@ -319,4 +321,3 @@ Group: Index  {
    File Index: Files
    Variable Index: Variables
    }  # Group: Index
-

--- a/lenses/nslcd.aug
+++ b/lenses/nslcd.aug
@@ -1,0 +1,248 @@
+(*
+Module: nslcd
+  Parses /etc/nslcd.conf
+
+Author: Jose Plana <jplana@gmail.com>
+
+About: Reference
+  This lens tries to keep as close as possible to `man 5 nslcd.conf` where
+  possible.
+
+License
+   This file is licenced under the LGPL v2+, like the rest of Augeas.
+
+
+About: Lens Usage
+
+       Sample usage of this lens in augtool:
+
+       * get uid
+         > get /files/etc/nslcd.conf/threads
+
+       * set ldap URI
+         > set /files/etc/nslcd.conf/uri "ldaps://x.y.z"
+
+       * get cache values
+         > get /files/etc/nslcd.conf/cache
+
+       * change syslog level to debug
+         > set /files/etc/nslcd.conf/log "syslog debug"
+
+       * add/change filter for the passwd map
+         > set /files/etc/nslcd.conf/filter/passwd "(objectClass=posixGroup)"
+
+       * change the default search scope
+         > set /files/etc/nslcd.conf/scope[count( * )] "subtree"
+
+       * get the default search scope
+         > get /files/etc/nslcd.conf/scope[count( * )] "subtree"
+
+       * add/set a scope search value for a specific (host) map
+         > set /files/etc/nslcd.conf/scope[host]/host "subtree"
+
+       * get all default base search
+         > match /files/etc/nslcd.conf/base[count( * ) = 0]
+
+       * get the 3rd base search default value
+         > get /files/etc/nslcd.conf/base[3]
+
+       * add a new base search default value
+         > set /files/etc/nslcd.conf/base[last()+1] "dc=example,dc=com"
+
+       * change a base search default value to a new base value
+         > set /files/etc/nslcd.conf/base[self::* = "dc=example,dc=com"] "dc=test,dc=com"
+
+       * add/change a base search for a specific map (hosts)
+         > set /files/etc/nslcd.conf/base[hosts]/hosts "dc=hosts,dc=example,dc=com"
+
+       * add a base search for a specific map (passwd)
+         > set /files/etc/nslcd.conf/base[last()+1]/passwd "dc=users,dc=example,dc=com"
+
+       * remove all base search value for a map (rpc)
+         > rm /files/etc/nslcd.conf/base/rpc
+
+       * remove a specific search base value for a map (passwd)
+         > rm /files/etc/nslcd.conf/base/passwd[self::* = "dc=users,dc=example,dc=com"]
+
+       * get an attribute mapping value for a map
+         > get /files/etc/nslcd.conf/map/passwd/homeDirectory
+
+       * get all attribute values for a map
+         > match /files/etc/nslcd.conf/map/passwd/*
+
+       * set a specific attribute for a map
+         > set /files/etc/nslcd.conf/map/passwd/homeDirectory "\"${homeDirectory:-/home/$uid}\""
+
+       * add/change a specific attribute for a map (a map that might not be defined before)
+         > set /files/etc/nslcd.conf/map[shadow/userPassword]/shadow/userPassword "*"
+
+       * remove an attribute for a specific map
+         > rm /files/etc/nslcd.conf/map/shadow/userPassword
+
+       * remove all attributes for a specific map
+         > rm /files/etc/nslcd.conf/map/passwd/*
+
+About: Configuration files
+   This lens applies to /etc/nslcd.conf. See <filter>.
+
+About: Examples
+   The <Test_Nslcd> file contains various examples and tests.
+*)
+
+module Nslcd =
+autoload xfm
+
+
+(************************************************************************
+ * Group:                 USEFUL PRIMITIVES
+ *************************************************************************)
+
+
+(* Group: Comments and empty lines *)
+
+(* View: eol *)
+let eol                       = Util.eol
+(* View: empty *)
+let empty                     = Util.empty
+(* View: spc *)
+let spc                       = Util.del_ws_spc
+(* View: comment *)
+let comment                   = Util.comment
+
+(* Group: Ldap related values
+Values that need to be parsed.
+*)
+
+(* Variable: ldap_rdn *)
+let ldap_rdn                  = /[A-Za-z][A-Za-z]+=[A-Za-z0-9_.-]+/
+(* Variable: ldap_dn *)
+let ldap_dn                   = ldap_rdn . (/(,)?/ . ldap_rdn)*
+(* Variable: ldap_filter *)
+let ldap_filter               = /\(.*\)/
+(* Variable: ldap_scope *)
+let ldap_scope                = /sub(tree)?|one(level)?|base/
+(* Variable: map_names *)
+let map_names                 = /alias(es)?/
+                              | /ether(s)?/
+                              | /group/
+                              | /host(s)?/
+                              | /netgroup/
+                              | /network(s)?/
+                              | /passwd/
+                              | /protocol(s)?/
+                              | /rpc/
+                              | /service(s)?/
+                              | /shadow/
+(* Variable: key_name *)
+let key_name                  = /[^ #\n\t\/][^ #\n\t\/]+/
+
+
+(************************************************************************
+ * Group:                 CONFIGURATION ENTRIES
+ *************************************************************************)
+
+(* Group: Generic definitions *)
+
+(* View: simple_entry
+The simplest configuration option a key spc value. As in `gid id`
+*)
+let simple_entry  (kw:string) = Build.key_ws_value kw
+
+(* View: key_value_line_regexp
+A simple configuration option but specifying the regex for the value.
+*)
+let key_value_line_regexp (kw:string) (sto:regexp) = Build.key_value_line kw spc (store sto)
+
+(* View: mapped_entry
+A mapped configuration as in `filter MAP option`.
+*)
+let mapped_entry (kw:string) (sto:regexp)  = [ key kw . spc
+                                               . Build.key_value_line map_names spc (store sto)
+                                             ]
+(* View: key_value_line_regexp_opt_map
+A mapped configuration but the MAP value is optional as in scope [MAP] value`.
+*)
+let key_value_line_regexp_opt_map (kw:string) (sto:regexp) =
+    ( key_value_line_regexp kw sto | mapped_entry kw sto )
+
+(* View: map_entry
+A map entry as in `map MAP ATTRIBUTE NEWATTRIBUTE`.
+*)
+let map_entry                 = [ key "map" . spc
+                                . [ key map_names . spc
+                                  . [  key key_name . spc . store Rx.no_spaces ]
+                                  ] .eol
+                                ]
+
+(* Group: Option definitions *)
+
+(* View: Base entry *)
+let base_entry                = key_value_line_regexp_opt_map "base" ldap_dn
+
+(* View: Scope entry *)
+let scope_entry               = key_value_line_regexp_opt_map "scope" ldap_scope
+
+(* View: Filter entry *)
+let filter_entry              = mapped_entry "filter" ldap_filter
+
+(* View: entries
+All the combined entries.
+*)
+let entries                   = map_entry
+                              | base_entry
+                              | scope_entry
+                              | filter_entry
+                              | simple_entry "threads"
+                              | simple_entry "uid"
+                              | simple_entry "gid"
+                              | simple_entry "uri"
+                              | simple_entry "ldap_version"
+                              | simple_entry "binddn"
+                              | simple_entry "bindpw"
+                              | simple_entry "rootpwmoddn"
+                              | simple_entry "rootpwmodpw"
+                              | simple_entry "sasl_mech"
+                              | simple_entry "sasl_realm"
+                              | simple_entry "sasl_authcid"
+                              | simple_entry "sasl_authzid"
+                              | simple_entry "sasl_secprops"
+                              | simple_entry "sasl_canonicalize"
+                              | simple_entry "krb5_ccname"
+                              | simple_entry "deref"
+                              | simple_entry "referrals"
+                              | simple_entry "bind_timelimit"
+                              | simple_entry "timelimit"
+                              | simple_entry "idle_timelimit"
+                              | simple_entry "reconnect_sleeptime"
+                              | simple_entry "reconnect_retrytime"
+                              | simple_entry "ssl"
+                              | simple_entry "tls_reqcert"
+                              | simple_entry "tls_cacertdir"
+                              | simple_entry "tls_cacertfile"
+                              | simple_entry "tls_randfile"
+                              | simple_entry "tls_ciphers"
+                              | simple_entry "tls_cert"
+                              | simple_entry "tls_key"
+                              | simple_entry "pagesize"
+                              | simple_entry "nss_initgroups_ignoreusers"
+                              | simple_entry "nss_min_uid"
+                              | simple_entry "nss_nested_groups"
+                              | simple_entry "nss_getgrent_skipmembers"
+                              | simple_entry "nss_disable_enumeration"
+                              | simple_entry "validnames"
+                              | simple_entry "ignorecase"
+                              | simple_entry "pam_authz_search"
+                              | simple_entry "pam_password_prohibit_message"
+                              | simple_entry "reconnect_invalidate"
+                              | simple_entry "cache"
+                              | simple_entry "log"
+                              | simple_entry "pam_authc_ppolicy"
+
+(* View: lens *)
+let lns                       = (entries|empty|comment)+
+
+(* View: filter *)
+let filter                    = incl "/etc/nslcd.conf"
+                              . Util.stdexcl
+
+let xfm                       = transform lns filter

--- a/lenses/nslcd.aug
+++ b/lenses/nslcd.aug
@@ -106,8 +106,14 @@ let eol                       = Util.eol
 let empty                     = Util.empty
 (* View: spc *)
 let spc                       = Util.del_ws_spc
+(* View: comma *)
+let comma                     = Sep.comma
 (* View: comment *)
 let comment                   = Util.comment
+(* View: do_dquote *)
+let do_dquote                 = Quote.do_dquote
+(* View: opt_list *)
+let opt_list                  = Build.opt_list
 
 (* Group: Ldap related values
 Values that need to be parsed.
@@ -148,6 +154,15 @@ The simplest configuration option a key spc value. As in `gid id`
 *)
 let simple_entry  (kw:string) = Build.key_ws_value kw
 
+(* View: simple_entry_quoted_value
+Simple entry with quoted value
+*)
+let simple_entry_quoted_value (kw:string) = Build.key_value_line kw spc (do_dquote (store /.*/))
+
+(* View simple_entry_opt_list_comma_value
+Simple entry that contains a optional list separated by commas
+*)
+let simple_entry_opt_list_value (kw:string) (lsep:lens) = Build.key_value_line kw spc (opt_list [ seq kw . store /[^, \t\n\r]+/ ] (lsep))
 (* View: key_value_line_regexp
 A simple configuration option but specifying the regex for the value.
 *)
@@ -195,7 +210,7 @@ let entries                   = map_entry
                               | simple_entry "threads"
                               | simple_entry "uid"
                               | simple_entry "gid"
-                              | simple_entry "uri"
+                              | simple_entry_opt_list_value "uri" spc
                               | simple_entry "ldap_version"
                               | simple_entry "binddn"
                               | simple_entry "bindpw"
@@ -224,7 +239,7 @@ let entries                   = map_entry
                               | simple_entry "tls_cert"
                               | simple_entry "tls_key"
                               | simple_entry "pagesize"
-                              | simple_entry "nss_initgroups_ignoreusers"
+                              | simple_entry_opt_list_value "nss_initgroups_ignoreusers" comma
                               | simple_entry "nss_min_uid"
                               | simple_entry "nss_nested_groups"
                               | simple_entry "nss_getgrent_skipmembers"
@@ -232,7 +247,7 @@ let entries                   = map_entry
                               | simple_entry "validnames"
                               | simple_entry "ignorecase"
                               | simple_entry "pam_authz_search"
-                              | simple_entry "pam_password_prohibit_message"
+                              | simple_entry_quoted_value "pam_password_prohibit_message"
                               | simple_entry "reconnect_invalidate"
                               | simple_entry "cache"
                               | simple_entry "log"

--- a/lenses/tests/test_nslcd.aug
+++ b/lenses/tests/test_nslcd.aug
@@ -1,0 +1,408 @@
+(*
+Module: Test_Nslcd
+  Provides unit tests and examples for the <Nslcd> lens.
+*)
+
+module Test_nslcd =
+
+let real_file = "# /etc/nslcd.conf
+# nslcd configuration file. See nslcd.conf(5)
+# for details.
+
+# Specifies the number of threads to start that can handle requests and perform LDAP queries.
+threads 5
+
+# The user and group nslcd should run as.
+uid nslcd
+gid nslcd
+
+# This option controls the way logging is done.
+log syslog info
+
+# The location at which the LDAP server(s) should be reachable.
+uri ldaps://XXX.XXX.XXX
+
+# The search base that will be used for all queries.
+base dc=XXX,dc=XXX
+
+# The LDAP protocol version to use.
+ldap_version 3
+
+# The DN to bind with for normal lookups.
+binddn cn=annonymous,dc=example,dc=net
+bindpw secret
+
+
+# The DN used for password modifications by root.
+rootpwmoddn cn=admin,dc=example,dc=com
+
+# The password used for password modifications by root.
+rootpwmodpw XXXXXX
+
+
+# SASL authentication options
+sasl_mech OTP
+sasl_realm realm
+sasl_authcid authcid
+sasl_authzid dn:cn=annonymous,dc=example,dc=net
+sasl_secprops noanonymous,noplain,minssf=0,maxssf=2,maxbufsize=65535
+sasl_canonicalize yes
+
+# Kerberos authentication options
+krb5_ccname ccname
+
+# Search/mapping options
+
+# Specifies the base distinguished name (DN) to use as search base.
+base dc=people,dc=example,dc=com
+base dc=morepeople,dc=example,dc=com
+base alias dc=aliases,dc=example,dc=com
+base alias dc=morealiases,dc=example,dc=com
+base group dc=group,dc=example,dc=com
+base group dc=moregroup,dc=example,dc=com
+base passwd dc=users,dc=example,dc=com
+
+# Specifies the search scope (subtree, onelevel, base or children).
+scope sub
+scope passwd sub
+scope aliases sub
+
+# Specifies the policy for dereferencing aliases.
+deref never
+
+# Specifies whether automatic referral chasing should be enabled.
+referrals yes
+
+# The FILTER is an LDAP search filter to use for a specific map.
+filter group (objectClass=posixGroup)
+
+# This option allows for custom attributes to be looked up instead of the default RFC 2307 attributes.
+map passwd homeDirectory \"${homeDirectory:-/home/$uid}\"
+map passwd loginShell \"${loginShell:-/bin/bash}\"
+map shadow userPassword myPassword
+
+# Timing/reconnect options
+
+# Specifies the time limit (in seconds) to use when connecting to the directory server.
+bind_timelimit 30
+
+# Specifies the time limit (in seconds) to wait for a response from the LDAP server.
+timelimit 5
+
+# Specifies the period if inactivity (in seconds) after which the connection to the LDAP server will be closed.
+idle_timelimit 10
+
+# Specifies the number of seconds to sleep when connecting to all LDAP servers fails.
+reconnect_sleeptime 10
+
+# Specifies the time after which the LDAP server is considered to be permanently unavailable.
+reconnect_retrytime 10
+
+# SSL/TLS options
+
+# Specifies whether to use SSL/TLS or not (the default is not to).
+ssl start_tls
+# Specifies what checks to perform on a server-supplied certificate.
+tls_reqcert never
+# Specifies the directory containing X.509 certificates for peer authentication.
+tls_cacertdir /etc/ssl/ca
+# Specifies the path to the X.509 certificate for peer authentication.
+tls_cacertfile /etc/ssl/certs/ca-certificates.crt
+# Specifies the path to an entropy source.
+tls_randfile /dev/random
+# Specifies the ciphers to use for TLS.
+tls_ciphers TLSv1
+# Specifies the path to the file containing the local certificate for client TLS authentication.
+tls_cert /etc/ssl/certs/cert.pem
+# Specifies the path to the file containing the private key for client TLS authentication.
+tls_key /etc/ssl/private/cert.pem
+
+# Other options
+pagesize 100
+nss_initgroups_ignoreusers user1,user2,user3
+nss_min_uid 1000
+nss_nested_groups yes
+nss_getgrent_skipmembers yes
+nss_disable_enumeration yes
+validnames /^[a-z0-9._@$()]([a-z0-9._@$() \\~-]*[a-z0-9._@$()~-])?$/i
+ignorecase yes
+pam_authc_ppolicy yes
+pam_authz_search (&(objectClass=posixAccount)(uid=$username)(|(authorizedService=$service)(!(authorizedService=*))))
+pam_password_prohibit_message \"MESSAGE LONG AND WITH SPACES\"
+reconnect_invalidate nfsidmap,db2,db3
+cache dn2uid 1s 2h
+
+"
+
+test Nslcd.lns get real_file =
+ { "#comment" = "/etc/nslcd.conf" }
+  { "#comment" = "nslcd configuration file. See nslcd.conf(5)" }
+  { "#comment" = "for details." }
+  {  }
+  { "#comment" = "Specifies the number of threads to start that can handle requests and perform LDAP queries." }
+  { "threads" = "5" }
+  {  }
+  { "#comment" = "The user and group nslcd should run as." }
+  { "uid" = "nslcd" }
+  { "gid" = "nslcd" }
+  {  }
+  { "#comment" = "This option controls the way logging is done." }
+  { "log" = "syslog info" }
+  {  }
+  { "#comment" = "The location at which the LDAP server(s) should be reachable." }
+  { "uri" = "ldaps://XXX.XXX.XXX" }
+  {  }
+  { "#comment" = "The search base that will be used for all queries." }
+  { "base" = "dc=XXX,dc=XXX" }
+  {  }
+  { "#comment" = "The LDAP protocol version to use." }
+  { "ldap_version" = "3" }
+  {  }
+  { "#comment" = "The DN to bind with for normal lookups." }
+  { "binddn" = "cn=annonymous,dc=example,dc=net" }
+  { "bindpw" = "secret" }
+  {  }
+  {  }
+  { "#comment" = "The DN used for password modifications by root." }
+  { "rootpwmoddn" = "cn=admin,dc=example,dc=com" }
+  {  }
+  { "#comment" = "The password used for password modifications by root." }
+  { "rootpwmodpw" = "XXXXXX" }
+  {  }
+  {  }
+  { "#comment" = "SASL authentication options" }
+  { "sasl_mech" = "OTP" }
+  { "sasl_realm" = "realm" }
+  { "sasl_authcid" = "authcid" }
+  { "sasl_authzid" = "dn:cn=annonymous,dc=example,dc=net" }
+  { "sasl_secprops" = "noanonymous,noplain,minssf=0,maxssf=2,maxbufsize=65535" }
+  { "sasl_canonicalize" = "yes" }
+  {  }
+  { "#comment" = "Kerberos authentication options" }
+  { "krb5_ccname" = "ccname" }
+  {  }
+  { "#comment" = "Search/mapping options" }
+  {  }
+  { "#comment" = "Specifies the base distinguished name (DN) to use as search base." }
+  { "base" = "dc=people,dc=example,dc=com" }
+  { "base" = "dc=morepeople,dc=example,dc=com" }
+  { "base"
+    { "alias" = "dc=aliases,dc=example,dc=com" }
+  }
+  { "base"
+    { "alias" = "dc=morealiases,dc=example,dc=com" }
+  }
+  { "base"
+    { "group" = "dc=group,dc=example,dc=com" }
+  }
+  { "base"
+    { "group" = "dc=moregroup,dc=example,dc=com" }
+  }
+  { "base"
+    { "passwd" = "dc=users,dc=example,dc=com" }
+  }
+  {  }
+  { "#comment" = "Specifies the search scope (subtree, onelevel, base or children)." }
+  { "scope" = "sub" }
+  { "scope"
+    { "passwd" = "sub" }
+  }
+  { "scope"
+    { "aliases" = "sub" }
+  }
+  {  }
+  { "#comment" = "Specifies the policy for dereferencing aliases." }
+  { "deref" = "never" }
+  {  }
+  { "#comment" = "Specifies whether automatic referral chasing should be enabled." }
+  { "referrals" = "yes" }
+  {  }
+  { "#comment" = "The FILTER is an LDAP search filter to use for a specific map." }
+  { "filter"
+    { "group" = "(objectClass=posixGroup)" }
+  }
+  {  }
+  { "#comment" = "This option allows for custom attributes to be looked up instead of the default RFC 2307 attributes." }
+  { "map"
+    { "passwd"
+      { "homeDirectory" = "\"${homeDirectory:-/home/$uid}\"" }
+    }
+  }
+  { "map"
+    { "passwd"
+      { "loginShell" = "\"${loginShell:-/bin/bash}\"" }
+    }
+  }
+  { "map"
+    { "shadow"
+      { "userPassword" = "myPassword" }
+    }
+  }
+  {  }
+  { "#comment" = "Timing/reconnect options" }
+  {  }
+  { "#comment" = "Specifies the time limit (in seconds) to use when connecting to the directory server." }
+  { "bind_timelimit" = "30" }
+  {  }
+  { "#comment" = "Specifies the time limit (in seconds) to wait for a response from the LDAP server." }
+  { "timelimit" = "5" }
+  {  }
+  { "#comment" = "Specifies the period if inactivity (in seconds) after which the connection to the LDAP server will be closed." }
+  { "idle_timelimit" = "10" }
+  {  }
+  { "#comment" = "Specifies the number of seconds to sleep when connecting to all LDAP servers fails." }
+  { "reconnect_sleeptime" = "10" }
+  {  }
+  { "#comment" = "Specifies the time after which the LDAP server is considered to be permanently unavailable." }
+  { "reconnect_retrytime" = "10" }
+  {  }
+  { "#comment" = "SSL/TLS options" }
+  {  }
+  { "#comment" = "Specifies whether to use SSL/TLS or not (the default is not to)." }
+  { "ssl" = "start_tls" }
+  { "#comment" = "Specifies what checks to perform on a server-supplied certificate." }
+  { "tls_reqcert" = "never" }
+  { "#comment" = "Specifies the directory containing X.509 certificates for peer authentication." }
+  { "tls_cacertdir" = "/etc/ssl/ca" }
+  { "#comment" = "Specifies the path to the X.509 certificate for peer authentication." }
+  { "tls_cacertfile" = "/etc/ssl/certs/ca-certificates.crt" }
+  { "#comment" = "Specifies the path to an entropy source." }
+  { "tls_randfile" = "/dev/random" }
+  { "#comment" = "Specifies the ciphers to use for TLS." }
+  { "tls_ciphers" = "TLSv1" }
+  { "#comment" = "Specifies the path to the file containing the local certificate for client TLS authentication." }
+  { "tls_cert" = "/etc/ssl/certs/cert.pem" }
+  { "#comment" = "Specifies the path to the file containing the private key for client TLS authentication." }
+  { "tls_key" = "/etc/ssl/private/cert.pem" }
+  {  }
+  { "#comment" = "Other options" }
+  { "pagesize" = "100" }
+  { "nss_initgroups_ignoreusers" = "user1,user2,user3" }
+  { "nss_min_uid" = "1000" }
+  { "nss_nested_groups" = "yes" }
+  { "nss_getgrent_skipmembers" = "yes" }
+  { "nss_disable_enumeration" = "yes" }
+  { "validnames" = "/^[a-z0-9._@$()]([a-z0-9._@$() \~-]*[a-z0-9._@$()~-])?$/i" }
+  { "ignorecase" = "yes" }
+  { "pam_authc_ppolicy" = "yes" }
+  { "pam_authz_search" = "(&(objectClass=posixAccount)(uid=$username)(|(authorizedService=$service)(!(authorizedService=*))))" }
+  { "pam_password_prohibit_message" = "\"MESSAGE LONG AND WITH SPACES\"" }
+  { "reconnect_invalidate" = "nfsidmap,db2,db3" }
+  { "cache" = "dn2uid 1s 2h" }
+  {  }
+(* Test writes *)
+
+(* Test a simple parameter *)
+test Nslcd.lns put "pagesize 9999\n" after
+   set "/pagesize" "1000" =
+   "pagesize 1000\n"
+
+(* Test base parameter *)
+test Nslcd.lns put "\n" after
+   set "/base" "dc=example,dc=com" =
+   "\nbase dc=example,dc=com\n"
+
+test Nslcd.lns put "base dc=change,dc=me\n" after
+   set "/base" "dc=example,dc=com" =
+   "base dc=example,dc=com\n"
+
+test Nslcd.lns put "\n" after
+   set "/base/passwd" "dc=example,dc=com" =
+   "\nbase passwd dc=example,dc=com\n"
+
+test Nslcd.lns put "base passwd dc=change,dc=me\n" after
+   set "/base[passwd]/passwd" "dc=example,dc=com";
+   set "/base[shadow]/shadow" "dc=example,dc=com" =
+   "base passwd dc=example,dc=com\nbase shadow dc=example,dc=com\n"
+
+(* Test scope entry *)
+test Nslcd.lns put "\n" after
+   set "/scope" "sub" =
+   "\nscope sub\n"
+
+test Nslcd.lns put "scope one\n" after
+   set "/scope" "subtree" =
+   "scope subtree\n"
+
+test Nslcd.lns put "\n" after
+   set "/scope/passwd" "base" =
+   "\nscope passwd base\n"
+
+test Nslcd.lns put "scope shadow onelevel\n" after
+   set "/scope[passwd]/passwd" "subtree";
+   set "/scope[shadow]/shadow" "base" =
+   "scope shadow base\nscope passwd subtree\n"
+
+(* Test filter entry *)
+test Nslcd.lns put "\n" after
+   set "/filter/passwd" "(objectClass=posixAccount)" =
+   "\nfilter passwd (objectClass=posixAccount)\n"
+
+test Nslcd.lns put "filter shadow (objectClass=posixAccount)\n" after
+   set "/filter[passwd]/passwd" "(objectClass=Account)";
+   set "/filter[shadow]/shadow" "(objectClass=Account)" =
+   "filter shadow (objectClass=Account)\nfilter passwd (objectClass=Account)\n"
+
+(* Test map entry *)
+test Nslcd.lns put "map passwd loginShell ab\n" after
+   set "/map/passwd/loginShell" "bc" =
+   "map passwd loginShell bc\n"
+
+test Nslcd.lns put "map passwd loginShell ab\n" after
+   set "/map[2]/passwd/homeDirectory" "bc" =
+   "map passwd loginShell ab\nmap passwd homeDirectory bc\n"
+
+test Nslcd.lns put "map passwd loginShell ab\n" after
+   set "/map[passwd/homeDirectory]/passwd/homeDirectory" "bc" =
+   "map passwd loginShell ab\nmap passwd homeDirectory bc\n"
+
+test Nslcd.lns put "map passwd loginShell ab\nmap passwd homeDirectory ab\n" after
+   set "/map[passwd/homeDirectory]/passwd/homeDirectory" "bc" =
+   "map passwd loginShell ab\nmap passwd homeDirectory bc\n"
+
+
+(* Test simple entries *)
+let simple = "uid nslcd\n"
+
+test Nslcd.lns get simple =
+{ "uid" = "nslcd" }
+
+(* Test simple entries with spaces at the end *)
+let simple_spaces = "uid nslcd   \n"
+
+test Nslcd.lns get simple_spaces =
+{ "uid" = "nslcd" }
+
+(* Test multi valued entries *)
+
+let multi_valued = "cache 1 2    \n"
+
+test Nslcd.lns get multi_valued =
+{ "cache" = "1 2" }
+
+let multi_valued_real = "map passwd homeDirectory ${homeDirectory:-/home/$uid}\n"
+
+test Nslcd.lns get multi_valued_real =
+{ "map"
+  { "passwd"
+    { "homeDirectory" = "${homeDirectory:-/home/$uid}" }
+  }
+}
+
+(* Test multiline *)
+
+let simple_multiline = "uid nslcd\ngid nslcd\n"
+
+test Nslcd.lns get simple_multiline =
+{"uid" = "nslcd"}
+{"gid" = "nslcd"}
+
+
+let multiline_separators  = "\n\n  \nuid nslcd    \ngid nslcd          \n"
+
+test Nslcd.lns get multiline_separators =
+{}
+{}
+{}
+{"uid" = "nslcd"}
+{"gid" = "nslcd"}

--- a/lenses/tests/test_nslcd.aug
+++ b/lenses/tests/test_nslcd.aug
@@ -20,7 +20,7 @@ gid nslcd
 log syslog info
 
 # The location at which the LDAP server(s) should be reachable.
-uri ldaps://XXX.XXX.XXX
+uri ldaps://XXX.XXX.XXX ldaps://YYY.YYY.YYY
 
 # The search base that will be used for all queries.
 base dc=XXX,dc=XXX
@@ -150,7 +150,10 @@ test Nslcd.lns get real_file =
   { "log" = "syslog info" }
   {  }
   { "#comment" = "The location at which the LDAP server(s) should be reachable." }
-  { "uri" = "ldaps://XXX.XXX.XXX" }
+  { "uri"
+    { "1" = "ldaps://XXX.XXX.XXX" }
+    { "2" = "ldaps://YYY.YYY.YYY" }
+  }
   {  }
   { "#comment" = "The search base that will be used for all queries." }
   { "base" = "dc=XXX,dc=XXX" }
@@ -277,7 +280,11 @@ test Nslcd.lns get real_file =
   {  }
   { "#comment" = "Other options" }
   { "pagesize" = "100" }
-  { "nss_initgroups_ignoreusers" = "user1,user2,user3" }
+  { "nss_initgroups_ignoreusers"
+    { "1" =  "user1" }
+    { "2" =  "user2" }
+    { "3" =  "user3" }
+  }
   { "nss_min_uid" = "1000" }
   { "nss_nested_groups" = "yes" }
   { "nss_getgrent_skipmembers" = "yes" }
@@ -286,7 +293,7 @@ test Nslcd.lns get real_file =
   { "ignorecase" = "yes" }
   { "pam_authc_ppolicy" = "yes" }
   { "pam_authz_search" = "(&(objectClass=posixAccount)(uid=$username)(|(authorizedService=$service)(!(authorizedService=*))))" }
-  { "pam_password_prohibit_message" = "\"MESSAGE LONG AND WITH SPACES\"" }
+  { "pam_password_prohibit_message" = "MESSAGE LONG AND WITH SPACES" }
   { "reconnect_invalidate" = "nfsidmap,db2,db3" }
   { "cache" = "dn2uid 1s 2h" }
   {  }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -134,6 +134,7 @@ lens_tests =			\
   lens-ntpd.sh			\
   lens-nrpe.sh          \
   lens-nsswitch.sh		\
+  lens-nslcd.sh			\
   lens-odbc.sh          \
   lens-opendkim.sh          \
   lens-openshift_config.sh	\

--- a/tests/root/etc/nslcd.conf
+++ b/tests/root/etc/nslcd.conf
@@ -121,6 +121,6 @@ validnames /^[a-z0-9._@$()]([a-z0-9._@$() \\~-]*[a-z0-9._@$()~-])?$/i
 ignorecase yes
 pam_authc_ppolicy yes
 pam_authz_search (&(objectClass=posixAccount)(uid=$username)(|(authorizedService=$service)(!(authorizedService=*))))
-pam_password_prohibit_message \"MESSAGE LONG AND WITH SPACES\"
+pam_password_prohibit_message "MESSAGE LONG AND WITH SPACES"
 reconnect_invalidate nfsidmap,db2,db3
 cache dn2uid 1s 2h 

--- a/tests/root/etc/nslcd.conf
+++ b/tests/root/etc/nslcd.conf
@@ -1,0 +1,126 @@
+# /etc/nslcd.conf
+# nslcd configuration file. See nslcd.conf(5)
+# for details.
+
+# Specifies the number of threads to start that can handle requests and perform LDAP queries.
+threads 5
+
+# The user and group nslcd should run as.
+uid nslcd
+gid nslcd
+
+# This option controls the way logging is done.
+log syslog info
+
+# The location at which the LDAP server(s) should be reachable.
+uri ldaps://XXX.XXX.XXX
+
+# The search base that will be used for all queries.
+base dc=XXX,dc=XXX
+
+# The LDAP protocol version to use.
+ldap_version 3
+
+# The DN to bind with for normal lookups.
+binddn cn=annonymous,dc=example,dc=net
+bindpw secret
+
+
+# The DN used for password modifications by root.
+rootpwmoddn cn=admin,dc=example,dc=com
+
+# The password used for password modifications by root.
+rootpwmodpw XXXXXX
+
+
+# SASL authentication options
+sasl_mech OTP
+sasl_realm realm
+sasl_authcid authcid
+sasl_authzid dn:cn=annonymous,dc=example,dc=net
+sasl_secprops noanonymous,noplain,minssf=0,maxssf=2,maxbufsize=65535
+sasl_canonicalize yes
+
+# Kerberos authentication options
+krb5_ccname ccname
+
+# Search/mapping options
+
+# Specifies the base distinguished name (DN) to use as search base. 
+base dc=people,dc=example,dc=com
+base dc=morepeople,dc=example,dc=com
+base alias dc=aliases,dc=example,dc=com
+base alias dc=morealiases,dc=example,dc=com
+base group dc=group,dc=example,dc=com
+base group dc=moregroup,dc=example,dc=com
+base passwd dc=users,dc=example,dc=com
+
+# Specifies the search scope (subtree, onelevel, base or children).
+scope sub
+scope passwd sub
+scope aliases sub
+
+# Specifies the policy for dereferencing aliases.
+deref never
+
+# Specifies whether automatic referral chasing should be enabled.
+referrals yes
+
+# The FILTER is an LDAP search filter to use for a specific map.
+filter passwd (objectClass=posixAccount)
+
+# This option allows for custom attributes to be looked up instead of the default RFC 2307 attributes. 
+map passwd homeDirectory \"${homeDirectory:-/home/$uid}\"
+map passwd loginShell \"${loginShell:-/bin/bash}\"
+map shadow userPassword myPassword
+
+# Timing/reconnect options
+
+# Specifies the time limit (in seconds) to use when connecting to the directory server.
+bind_timelimit 30
+
+# Specifies the time limit (in seconds) to wait for a response from the LDAP server. 
+timelimit 5
+
+# Specifies the period if inactivity (in seconds) after which the connection to the LDAP server will be closed.
+idle_timelimit 10
+
+# Specifies the number of seconds to sleep when connecting to all LDAP servers fails.
+reconnect_sleeptime 10
+
+# Specifies the time after which the LDAP server is considered to be permanently unavailable. 
+reconnect_retrytime 10
+
+# SSL/TLS options
+
+# Specifies whether to use SSL/TLS or not (the default is not to).
+ssl start_tls
+# Specifies what checks to perform on a server-supplied certificate. 
+tls_reqcert never
+# Specifies the directory containing X.509 certificates for peer authentication.
+tls_cacertdir /etc/ssl/ca
+# Specifies the path to the X.509 certificate for peer authentication.
+tls_cacertfile /etc/ssl/certs/ca-certificates.crt
+# Specifies the path to an entropy source. 
+tls_randfile /dev/random
+# Specifies the ciphers to use for TLS.
+tls_ciphers TLSv1
+# Specifies the path to the file containing the local certificate for client TLS authentication.
+tls_cert /etc/ssl/certs/cert.pem
+# Specifies the path to the file containing the private key for client TLS authentication.
+tls_key /etc/ssl/private/cert.pem
+
+# Other options
+pagesize 100
+nss_initgroups_ignoreusers user1,user2,user3
+nss_min_uid 1000
+nss_nested_groups yes
+nss_getgrent_skipmembers yes
+nss_disable_enumeration yes
+validnames /^[a-z0-9._@$()]([a-z0-9._@$() \\~-]*[a-z0-9._@$()~-])?$/i
+ignorecase yes
+pam_authc_ppolicy yes
+pam_authz_search (&(objectClass=posixAccount)(uid=$username)(|(authorizedService=$service)(!(authorizedService=*))))
+pam_password_prohibit_message \"MESSAGE LONG AND WITH SPACES\"
+reconnect_invalidate nfsidmap,db2,db3
+cache dn2uid 1s 2h 


### PR DESCRIPTION
Here's support for the /etc/nslcd.conf, the configuration file for nss-pam-ldapd (https://arthurdejong.org/nss-pam-ldapd/).

In the PR I've tried to include tests, an example file and some documentation that might help others use the lenses, but please let me know if something is missing. 
