### PR TITLE
Add aug_get_nodes() to the API

### DIFF
--- a/src/augeas.c
+++ b/src/augeas.c
@@ -879,6 +879,25 @@ int aug_get_nodes(const struct augeas *aug, const char *pathin, struct aug_node 
         (*nodes)[i]->path = node_path;
         (*nodes)[i]->label = tree->label;
         (*nodes)[i]->value = tree->value;
+
+        struct span *span = tree->span;
+        if (span != NULL) {
+          (*nodes)[i]->span_label_start = span->label_start;
+          (*nodes)[i]->span_label_end = span->label_end;
+          (*nodes)[i]->span_value_start = span->value_start;
+          (*nodes)[i]->span_value_end = span->value_end;
+          (*nodes)[i]->span_start = span->span_start;
+          (*nodes)[i]->span_end = span->span_end;
+
+          if (span->filename != NULL || span->filename->str != NULL) {
+              (*nodes)[i]->filename = span->filename->str;
+          }
+          (*nodes)[i]->has_span_info = true;
+        }
+        else {
+          (*nodes)[i]->has_span_info = false;
+        }
+
         i += 1;
     }
     ERR_BAIL(aug);

--- a/src/augeas.c
+++ b/src/augeas.c
@@ -836,7 +836,7 @@ int aug_get(const struct augeas *aug, const char *path, const char **value) {
     return -1;
 }
 
-int aug_get_nodes(const struct augeas *aug, const char *pathin, struct aug_node ***nodes) {
+int aug_get_nodes(const struct augeas *aug, const char *pathin, struct aug_node **nodes) {
     struct pathx *p = NULL;
     struct tree *tree;
     int cnt = 0;
@@ -874,9 +874,10 @@ int aug_get_nodes(const struct augeas *aug, const char *pathin, struct aug_node 
         if (node_path == NULL) {
             goto error;
         }
-        (*nodes)[i]->path = node_path;
-        (*nodes)[i]->label = tree->label;
-        (*nodes)[i]->value = tree->value;
+        
+        nodes[i]->path = node_path;
+        nodes[i]->label = tree->label;
+        nodes[i]->value = tree->value;
         i += 1;
     }
     ERR_BAIL(aug);
@@ -889,8 +890,8 @@ int aug_get_nodes(const struct augeas *aug, const char *pathin, struct aug_node 
     if (nodes != NULL) {
         if (*nodes != NULL) {
             for (i=0; i < cnt; i++)
-                free((*nodes)[i]);
-            free(*nodes);
+                free(nodes[i]);
+            free(nodes);
         }
     }
     free_pathx(p);

--- a/src/augeas.c
+++ b/src/augeas.c
@@ -836,7 +836,7 @@ int aug_get(const struct augeas *aug, const char *path, const char **value) {
     return -1;
 }
 
-int aug_get_nodes(const struct augeas *aug, const char *pathin, struct aug_node **nodes) {
+int aug_get_nodes(const struct augeas *aug, const char *pathin, struct aug_node ***nodes) {
     struct pathx *p = NULL;
     struct tree *tree;
     int cnt = 0;
@@ -874,10 +874,11 @@ int aug_get_nodes(const struct augeas *aug, const char *pathin, struct aug_node 
         if (node_path == NULL) {
             goto error;
         }
-        
-        nodes[i]->path = node_path;
-        nodes[i]->label = tree->label;
-        nodes[i]->value = tree->value;
+
+        (*nodes)[i] = malloc(sizeof(aug_node));
+        (*nodes)[i]->path = node_path;
+        (*nodes)[i]->label = tree->label;
+        (*nodes)[i]->value = tree->value;
         i += 1;
     }
     ERR_BAIL(aug);
@@ -890,8 +891,8 @@ int aug_get_nodes(const struct augeas *aug, const char *pathin, struct aug_node 
     if (nodes != NULL) {
         if (*nodes != NULL) {
             for (i=0; i < cnt; i++)
-                free(nodes[i]);
-            free(nodes);
+                free((*nodes)[i]);
+            free(*nodes);
         }
     }
     free_pathx(p);

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -28,16 +28,16 @@
 
 typedef struct augeas augeas;
 typedef struct aug_node {
-  char *path;
-  char *label;
-  char *value;
+  const char *path;
+  const char *label;
+  const char *value;
   uint span_label_start;
   uint span_label_end;
   uint span_value_start;
   uint span_value_end;
   uint span_start;
   uint span_end;
-  char *filename;
+  const char *filename;
   int has_span_info;
 } aug_node;
 

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -173,7 +173,7 @@ int aug_get(const augeas *aug, const char *path, const char **value);
 * matches more than one path segment.
 *
 */
-int aug_get_nodes(const augeas *aug, const char *path, struct aug_node **nodes);
+int aug_get_nodes(const augeas *aug, const char *path, struct aug_node ***nodes);
 
 /* Function: aug_label
  *

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -27,6 +27,11 @@
 #define AUGEAS_H_
 
 typedef struct augeas augeas;
+typedef struct aug_node {
+  char *path;
+  char *label;
+  char *value;
+} aug_node;
 
 /* Enum: aug_flags
  *
@@ -142,6 +147,33 @@ int aug_defnode(augeas *aug, const char *name, const char *expr,
  * PATH is not a legal path expression.
  */
 int aug_get(const augeas *aug, const char *path, const char **value);
+
+/* Function: aug_get_nodes
+*
+* Matches all augeas nodes and returns all the relevant data about them.
+*
+* Returns:
+* the number of matches of the path expression PATH in AUG. If
+* NODES is non-NULL, an array with the returned number of elements will
+* be allocated and filled with the matching nodes. The caller must
+* free both the array and the entries in it.
+*
+* Returns -1 on error, or the total number of matches (which might be 0).
+*
+* Path expressions:
+* Path expressions use a very simple subset of XPath: the path PATH
+* consists of a number of segments, separated by '/'; each segment can
+* either be a '*', matching any tree node, or a string, optionally
+* followed by an index in brackets, matching tree nodes labelled with
+* exactly that string. If no index is specified, the expression matches
+* all nodes with that label; the index can be a positive number N, which
+* matches exactly the Nth node with that label (counting from 1), or the
+* special expression 'last()' which matches the last node with the given
+* label. All matches are done in fixed positions in the tree, and nothing
+* matches more than one path segment.
+*
+*/
+int aug_get_nodes(const augeas *aug, const char *path, struct aug_node ***nodes);
 
 /* Function: aug_label
  *

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -39,6 +39,8 @@ typedef struct aug_node {
   uint span_end;
   const char *filename;
   int has_span_info;
+
+  struct aug_node *next;
 } aug_node;
 
 /* Enum: aug_flags
@@ -181,7 +183,13 @@ int aug_get(const augeas *aug, const char *path, const char **value);
 * matches more than one path segment.
 *
 */
-int aug_get_nodes(const augeas *aug, const char *path, struct aug_node ***nodes);
+int aug_get_nodes(const augeas *aug, const char *path, struct aug_node *node);
+
+/* Function: aug_free_nodes
+*
+*  Frees the node linked list fetched by aug_get_nodes.
+*/
+void aug_free_nodes(struct aug_node *node);
 
 /* Function: aug_label
  *

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -31,6 +31,14 @@ typedef struct aug_node {
   char *path;
   char *label;
   char *value;
+  uint span_label_start;
+  uint span_label_end;
+  uint span_value_start;
+  uint span_value_end;
+  uint span_start;
+  uint span_end;
+  char *filename;
+  int has_span_info;
 } aug_node;
 
 /* Enum: aug_flags

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -173,7 +173,7 @@ int aug_get(const augeas *aug, const char *path, const char **value);
 * matches more than one path segment.
 *
 */
-int aug_get_nodes(const augeas *aug, const char *path, struct aug_node ***nodes);
+int aug_get_nodes(const augeas *aug, const char *path, struct aug_node **nodes);
 
 /* Function: aug_label
  *

--- a/src/augeas_sym.version
+++ b/src/augeas_sym.version
@@ -80,3 +80,9 @@ AUGEAS_0.22.0 {
     global:
       aug_source;
 } AUGEAS_0.21.0;
+
+
+AUGEAS_0.23.0 {
+    global:
+      aug_get_nodes;
+} AUGEAS_0.22.0;

--- a/src/augeas_sym.version
+++ b/src/augeas_sym.version
@@ -85,4 +85,5 @@ AUGEAS_0.22.0 {
 AUGEAS_0.23.0 {
     global:
       aug_get_nodes;
+      aug_free_nodes;
 } AUGEAS_0.22.0;

--- a/tests/cutest.h
+++ b/tests/cutest.h
@@ -100,6 +100,7 @@ void CuAssertPtrNotEqual_LineMsg(CuTest* tc,
 #define CuAssertPtrNotEqual_Msg(tc,ms,ex,ac)    CuAssertPtrNotEqual_LineMsg((tc),__FILE__,__LINE__,(ms),(ex),(ac))
 
 #define CuAssertPtrNotNull(tc,p)        CuAssert_Line((tc),__FILE__,__LINE__,"null pointer unexpected",(p != NULL))
+#define CuAssertPtrNull(tc,p)        		CuAssert_Line((tc),__FILE__,__LINE__,"null pointer expected",(p == NULL))
 #define CuAssertPtrNotNullMsg(tc,msg,p) CuAssert_Line((tc),__FILE__,__LINE__,(msg),(p != NULL))
 
 /* CuSuite */

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -747,8 +747,8 @@ static void testGetNodes(CuTest *tc) {
   r = aug_set(aug, "/files/1/2/3/4/6", "2");
   CuAssertRetSuccess(tc, r);
 
-  struct aug_node **nodes;
-  r = aug_get_nodes(aug, "/files//*", &nodes);
+  struct aug_node *nodes;
+  r = aug_get_nodes(aug, "/files//*", &nodes); // /files/1/2/3/4/5|/files/1/2/3/4/6
   CuAssertRetSuccess(tc, r);
 
   aug_close(aug);

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -747,9 +747,27 @@ static void testGetNodes(CuTest *tc) {
   r = aug_set(aug, "/files/1/2/3/4/6", "2");
   CuAssertRetSuccess(tc, r);
 
-  struct aug_node *nodes;
+  struct aug_node **nodes;
   r = aug_get_nodes(aug, "/files//*", &nodes); // /files/1/2/3/4/5|/files/1/2/3/4/6
-  CuAssertRetSuccess(tc, r);
+  CuAssertIntEquals(tc, 6, r);
+  CuAssertStrEquals(tc, "/files/1", nodes[0]->path);
+  CuAssertStrEquals(tc, "1", nodes[0]->label);
+  CuAssertStrEquals(tc, NULL, nodes[0]->value);
+  CuAssertStrEquals(tc, "/files/1/2", nodes[1]->path);
+  CuAssertStrEquals(tc, "2", nodes[1]->label);
+  CuAssertStrEquals(tc, NULL, nodes[1]->value);
+  CuAssertStrEquals(tc, "/files/1/2/3", nodes[2]->path);
+  CuAssertStrEquals(tc, "3", nodes[2]->label);
+  CuAssertStrEquals(tc, NULL, nodes[2]->value);
+  CuAssertStrEquals(tc, "/files/1/2/3/4", nodes[3]->path);
+  CuAssertStrEquals(tc, "4", nodes[3]->label);
+  CuAssertStrEquals(tc, NULL, nodes[3]->value);
+  CuAssertStrEquals(tc, "/files/1/2/3/4/5", nodes[4]->path);
+  CuAssertStrEquals(tc, "5", nodes[4]->label);
+  CuAssertStrEquals(tc, "1", nodes[4]->value);
+  CuAssertStrEquals(tc, "/files/1/2/3/4/6", nodes[5]->path);
+  CuAssertStrEquals(tc, "6", nodes[5]->label);
+  CuAssertStrEquals(tc, "2", nodes[5]->value);
 
   aug_close(aug);
 }

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -735,6 +735,25 @@ static void testLoadBadPath(CuTest *tc) {
     aug_close(aug);
 }
 
+static void testGetNodes(CuTest *tc) {
+  struct augeas *aug;
+  int r;
+
+  aug = aug_init(root, loadpath, AUG_NO_STDINC|AUG_NO_MODL_AUTOLOAD);
+  CuAssertPtrNotNull(tc, aug);
+
+  r = aug_set(aug, "/files/1/2/3/4/5", "1");
+  CuAssertRetSuccess(tc, r);
+  r = aug_set(aug, "/files/1/2/3/4/6", "2");
+  CuAssertRetSuccess(tc, r);
+
+  struct aug_node **nodes;
+  r = aug_get_nodes(aug, "/files//*", &nodes);
+  CuAssertRetSuccess(tc, r);
+
+  aug_close(aug);
+}
+
 int main(void) {
     char *output = NULL;
     CuSuite* suite = CuSuiteNew();
@@ -757,6 +776,7 @@ int main(void) {
     SUITE_ADD_TEST(suite, testRm);
     SUITE_ADD_TEST(suite, testLoadFile);
     SUITE_ADD_TEST(suite, testLoadBadPath);
+    SUITE_ADD_TEST(suite, testGetNodes);
 
     abs_top_srcdir = getenv("abs_top_srcdir");
     if (abs_top_srcdir == NULL)

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -747,27 +747,47 @@ static void testGetNodes(CuTest *tc) {
   r = aug_set(aug, "/files/1/2/3/4/6", "2");
   CuAssertRetSuccess(tc, r);
 
-  struct aug_node **nodes;
-  r = aug_get_nodes(aug, "/files//*", &nodes); // /files/1/2/3/4/5|/files/1/2/3/4/6
+  struct aug_node *node = malloc(sizeof(aug_node));
+  struct aug_node *current_node = node;
+  r = aug_get_nodes(aug, "/files//*", node);
   CuAssertIntEquals(tc, 6, r);
-  CuAssertStrEquals(tc, "/files/1", nodes[0]->path);
-  CuAssertStrEquals(tc, "1", nodes[0]->label);
-  CuAssertStrEquals(tc, NULL, nodes[0]->value);
-  CuAssertStrEquals(tc, "/files/1/2", nodes[1]->path);
-  CuAssertStrEquals(tc, "2", nodes[1]->label);
-  CuAssertStrEquals(tc, NULL, nodes[1]->value);
-  CuAssertStrEquals(tc, "/files/1/2/3", nodes[2]->path);
-  CuAssertStrEquals(tc, "3", nodes[2]->label);
-  CuAssertStrEquals(tc, NULL, nodes[2]->value);
-  CuAssertStrEquals(tc, "/files/1/2/3/4", nodes[3]->path);
-  CuAssertStrEquals(tc, "4", nodes[3]->label);
-  CuAssertStrEquals(tc, NULL, nodes[3]->value);
-  CuAssertStrEquals(tc, "/files/1/2/3/4/5", nodes[4]->path);
-  CuAssertStrEquals(tc, "5", nodes[4]->label);
-  CuAssertStrEquals(tc, "1", nodes[4]->value);
-  CuAssertStrEquals(tc, "/files/1/2/3/4/6", nodes[5]->path);
-  CuAssertStrEquals(tc, "6", nodes[5]->label);
-  CuAssertStrEquals(tc, "2", nodes[5]->value);
+
+  CuAssertStrEquals(tc, "/files/1", current_node->path);
+  CuAssertStrEquals(tc, "1", current_node->label);
+  CuAssertStrEquals(tc, NULL, current_node->value);
+  current_node = current_node->next;
+  CuAssertPtrNotNull(tc, current_node);
+
+  CuAssertStrEquals(tc, "/files/1/2", current_node->path);
+  CuAssertStrEquals(tc, "2", current_node->label);
+  CuAssertStrEquals(tc, NULL, current_node->value);
+  current_node = current_node->next;
+  CuAssertPtrNotNull(tc, current_node);
+
+  CuAssertStrEquals(tc, "/files/1/2/3", current_node->path);
+  CuAssertStrEquals(tc, "3", current_node->label);
+  CuAssertStrEquals(tc, NULL, current_node->value);
+  current_node = current_node->next;
+  CuAssertPtrNotNull(tc, current_node);
+
+  CuAssertStrEquals(tc, "/files/1/2/3/4", current_node->path);
+  CuAssertStrEquals(tc, "4", current_node->label);
+  CuAssertStrEquals(tc, NULL, current_node->value);
+  current_node = current_node->next;
+  CuAssertPtrNotNull(tc, current_node);
+
+  CuAssertStrEquals(tc, "/files/1/2/3/4/5", current_node->path);
+  CuAssertStrEquals(tc, "5", current_node->label);
+  CuAssertStrEquals(tc, "1", current_node->value);
+  current_node = current_node->next;
+  CuAssertPtrNotNull(tc, current_node);
+
+  CuAssertStrEquals(tc, "/files/1/2/3/4/6", current_node->path);
+  CuAssertStrEquals(tc, "6", current_node->label);
+  CuAssertStrEquals(tc, "2", current_node->value);
+  CuAssertPtrEquals(tc, NULL, current_node->next);
+
+  aug_free_nodes(node);
 
   aug_close(aug);
 }


### PR DESCRIPTION
Currently, the API does not allow fetching all the data for nodes matching a pattern. This addition to the API will allow fetching the path, label, value and possibly the filename of each node in a single tree traversal.
Right now in OSQuery we use `aug_get()` and `aug_label()` on each match we get from `aug_match()` which is inefficient and unnecessary.
`aug_get_nodes()` will return an array of structs with all the relevant information.

Feel free to come up with a better name.
