### PR TITLE
update rsyslog lens to includ files in rsyslog.d dir

### DIFF
--- a/lenses/rsyslog.aug
+++ b/lenses/rsyslog.aug
@@ -68,6 +68,8 @@ let entries = ( Syslog.empty | Syslog.comment | entry | macro | config_object | 
 let lns = entries . ( Syslog.program | Syslog.hostname )*
 
 let filter = incl "/etc/rsyslog.conf"
+           . incl "/etc/rsyslog.d/*"
+           . Util.stdexcl
 
 let xfm = transform lns filter
 


### PR DESCRIPTION
this is in response to the question I raised here: https://github.com/hercules-team/augeas/issues/465 -- just updating the rsyslog.aug lens so that it covers additional configuration files in the rsyslog.d directory.

Sorry it took so long to get back to it.