### PR TITLE
* src/pathx.c (parse_name): correctly handle trailing whitespace in n…

### DIFF
--- a/src/pathx.c
+++ b/src/pathx.c
@@ -1710,6 +1710,16 @@ int pathx_escape_name(const char *in, char **out) {
     return 0;
 }
 
+/* Return true if POS is preceded by an odd number of backslashes, i.e., if
+ * POS is escaped. Stop the search when we get to START */
+static bool backslash_escaped(const char *pos, const char *start) {
+    bool result=false;
+    while (pos-- > start && *pos == '\\') {
+        result = !result;
+    }
+    return result;
+}
+
 /*
  * NameNoWS ::= [^][|/\= \t\n] | \\.
  * NameWS   ::= [^][|/\=] | \\.
@@ -1719,11 +1729,14 @@ static char *parse_name(struct state *state) {
     const char *s = state->pos;
     char *result;
 
+    /* Advance state->pos until it points to the first character that is
+     * not part of a name. */
     while (*state->pos != '\0' && strchr(name_follow, *state->pos) == NULL) {
-        /* This is a hack: since we allow spaces in names, we need to avoid
-         * gobbling up stuff that is in follow(Name), e.g. 'or' so that
-         * things like [name1 or name2] still work.
-         */
+        /* Since we allow spaces in names, we need to avoid gobbling up
+         * stuff that is in follow(Name), e.g. 'or' so that things like
+         * [name1 or name2] still work. In other words, we'll parse 'x frob
+         * y' as one name, but for 'x or y', we consider 'x' a name in its
+         * own right. */
         if (STREQLEN(state->pos, " or ", strlen(" or ")) ||
             STREQLEN(state->pos, " and ", strlen(" and ")))
             break;
@@ -1738,10 +1751,12 @@ static char *parse_name(struct state *state) {
         state->pos += 1;
     }
 
-    /* Strip trailing white space */
+    /* Strip trailing white space. Make sure we respect escaped whitespace
+     * and don't strip it as in "x\\ " */
     if (state->pos > s) {
         state->pos -= 1;
-        while (isspace(*state->pos) && state->pos >= s)
+        while (isspace(*state->pos) && state->pos > s
+               && !backslash_escaped(state->pos, s))
             state->pos -= 1;
         state->pos += 1;
     }


### PR DESCRIPTION
…ames

When a name ended in whitespace, we incorrectly assumed it was always ok to
trim that whitespace. That is not true if that whitespace is escaped,
i.e. if the path expression is something like '/x\ '. In that case, the
name really needs to be literally 'x ', i.e., we can not trim that
whitespace.

The incorrect behavior led to turning '/x\ ' first into 'x\' and then,
because we assume that '\' is always followed by a character inside the
string, when we removed the escaping '\', we would read beyond the end of
the intermediate string result; if we were lucky, that would lead to a
crash, otherwise we'd continue with junk.

We now make sure that escaped whitespace at the end of a string does not
get stripped, avoiding all these headaches.

Fixes RHBZ https://bugzilla.redhat.com/show_bug.cgi?id=1475621