### PR TITLE
WIP: speed up iterating and getting information about lots of nodes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@
       back to text fails. They now make it clearer what part of the tree
       was problematic, and what the tree should have looked like.
     * Fixed the pkg-config file, which should now be usable
+  - API changes
+    * add function aug_ns_attr to allow iterating through a nodeset
+      quickly. See examples/dump.c for an example of how to use them
+      instead of aug_get, aug_label etc. and for a way to measure
+      performance gains.
   - Lens changes/additions
     * Sshd: split HostKeyAlgorithms into list of values
 

--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,7 @@ if test x"$enable_debug" = x"yes"; then
 fi
 
 dnl Version info in libtool's notation
-AC_SUBST([LIBAUGEAS_VERSION_INFO], [22:0:22])
+AC_SUBST([LIBAUGEAS_VERSION_INFO], [23:0:23])
 AC_SUBST([LIBFA_VERSION_INFO], [5:4:4])
 
 AC_GNU_SOURCE

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -2,10 +2,15 @@
 GNULIB= ../gnulib/lib/libgnu.la
 GNULIB_CFLAGS= -I $(top_srcdir)/gnulib/lib
 
-AM_CFLAGS = @AUGEAS_CFLAGS@ @WARN_CFLAGS@ $(GNULIB_CFLAGS) \
+AM_CFLAGS = @AUGEAS_CFLAGS@ @WARN_CFLAGS@ @LIBXML_CFLAGS@ $(GNULIB_CFLAGS) \
 			-I $(top_srcdir)/src
 
-bin_PROGRAMS = fadot
+bin_PROGRAMS = fadot dump
 
 fadot_SOURCES = fadot.c
 fadot_LDADD = $(top_builddir)/src/libfa.la $(GNULIB)
+
+dump_sources = dump.c
+dump_LDFLAGS = -static
+dump_LDADD =  $(top_builddir)/src/libaugeas.la $(top_builddir)/src/libfa.la
+	          $(GNULIB)

--- a/examples/dump.c
+++ b/examples/dump.c
@@ -1,0 +1,161 @@
+/*
+ * dump.c:
+ *
+ * Copyright (C) 2009 Red Hat Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ *
+ * Author: David Lutterkort <lutter@redhat.com>
+ */
+
+/*
+ * Example program for dumping (part of) the Augeas tree.
+ *
+ * Run it as 'dump [-n] [pattern] > /tmp/out.txt' to dump all the nodes
+ * matching PATTERN. The PATTERN '/files//descendant::*' dumps all nodes
+ * from files, and '//descendant::*' dumps absolutely everything. If -n is
+ * passed, uses a variable and aug_ns_* functions. Without -n, uses
+ * aug_match and straight aug_get/aug_label/aug_source.
+ *
+ * You might have to set AUGEAS_ROOT and AUGEAS_LENS_LIB to point at the
+ * right things. For example, to run dump against the tree that the Augeas
+ * tests use, and to use the lenses in the checkout, run it as
+ *    AUGEAS_ROOT=$PWD/tests/root AUGEAS_LENS_LIB=$PWD/lenses \
+ *    dump '//descendant::*'
+ *
+ */
+#define _GNU_SOURCE
+
+#include "config.h"
+#include "augeas.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/time.h>
+
+/*
+ * Print out information for all nodes matching PATH using aug_match and
+ * then aug_get etc. on each of the matches.
+ */
+static void dump_match(struct augeas *aug, const char *path) {
+    char **matches;
+    int nmatches;
+    int i;
+
+    nmatches = aug_match(aug, path, &matches);
+    if (nmatches < 0) {
+        fprintf(stderr, "aug_match for '%s' failed\n", path);
+        fprintf(stderr, "error: %s\n", aug_error_message(aug));
+        exit(1);
+    }
+
+    fprintf(stderr, "iterating matches\n");
+    fprintf(stderr, "%d matches for %s\n", nmatches, path);
+
+    for (i=0; i < nmatches; i++) {
+        const char *value, *label;
+        char *file;
+
+        aug_get(aug, matches[i], &value);
+        aug_label(aug, matches[i], &label);
+        aug_source(aug, matches[i], &file);
+
+        printf("%s: %s %s %s\n", matches[i], label, value, file);
+        free(file);
+        free(matches[i]);
+    }
+    free(matches);
+}
+
+/*
+ * Print out information for all nodes matching PATH using aug_ns_*
+ * functions
+ */
+static void dump_var(struct augeas *aug, const char *path) {
+    int nmatches;
+    int i;
+
+    /* Define the variable 'matches' to hold all the nodes we are
+       interested in */
+    aug_defvar(aug, "matches", path);
+
+    /* Count how many nodes we have */
+    nmatches = aug_match(aug, "$matches", NULL);
+    if (nmatches < 0) {
+        fprintf(stderr, "aug_match for '%s' failed\n", path);
+        fprintf(stderr, "error: %s\n", aug_error_message(aug));
+        exit(1);
+    }
+
+    fprintf(stderr, "using var and aug_ns_*\n");
+    fprintf(stderr, "%d matches for %s\n", nmatches, path);
+
+    for (i=0; i < nmatches; i++) {
+        const char *value, *label;
+        char *file = NULL;
+
+        /* Get information about the ith node, equivalent to calling
+         * aug_get etc. for "$matches[i]" but much more efficient internally
+         */
+        aug_ns_attr(aug, "matches", i, &value, &label, &file);
+
+        printf("%d: %s %s %s\n", i, label, value, file);
+        free(file);
+    }
+}
+
+static void print_time_taken(const struct timeval *start,
+                             const struct timeval *stop) {
+    time_t elapsed = (stop->tv_sec - start->tv_sec)*1000
+                   + (stop->tv_usec - start->tv_usec)/1000;
+    fprintf(stderr, "time: %ld ms\n", elapsed);
+}
+
+int main(int argc, char **argv) {
+    int opt;
+    int use_var = 0;
+    const char *pattern = "/files//*";
+    struct timeval stop, start;
+
+    while ((opt = getopt(argc, argv, "n")) != -1) {
+        switch (opt) {
+        case 'n':
+            use_var = 1;
+            break;
+        default:
+            fprintf(stderr, "Usage: %s [-n] [pattern]\n", argv[0]);
+            fprintf(stderr, "      without '-n', iterate matches\n");
+            fprintf(stderr, "      with '-n', use a variable and aug_ns_*\n");
+            exit(EXIT_FAILURE);
+            break;
+        }
+    }
+
+    struct augeas *aug = aug_init(NULL, NULL, 0);
+
+    if (optind < argc)
+        pattern = argv[optind];
+
+    gettimeofday(&start, NULL);
+    if (use_var) {
+        dump_var(aug, pattern);
+    } else {
+        dump_match(aug, pattern);
+    }
+    gettimeofday(&stop, NULL);
+    print_time_taken(&start, &stop);
+    return 0;
+}

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -473,6 +473,34 @@ int aug_srun(augeas *aug, FILE *out, const char *text);
  */
 void aug_close(augeas *aug);
 
+// We can't put //* into the examples in these comments since the C
+// preprocessor complains about that. So we'll resort to the equivalent but
+// more wordy notation /descendant::*
+
+/*
+ * Function: aug_ns_get
+ *
+ * Look up the ith node in the variable VAR and retrieve information about
+ * it. Set *VALUE to the value of the node, *LABEL to its label, and
+ * *FILE_PATH to the path of the file it belongs to, or to NULL if that
+ * node does not belong to a file. It is permissible to pass NULL for any
+ * of these variables to indicate that the caller is not interested in that
+ * attribute.
+
+ * It is assumed that VAR was defined with a path expression evaluating to
+ * a nodeset, like '/files/etc/hosts/descendant::*'. This function is
+ * equivalent to, but faster than, aug_get(aug, "$VAR[I]", value),
+ * respectively the corresponding calls to aug_label and aug_source.
+ *
+ * If VAR does not exist, or is not a nodeset, or if it has fewer than I
+ * nodes, this call fails.
+ *
+ * Returns:
+ * 1 on success (for consistency with aug_get), a negative value on failure
+ */
+int aug_ns_attr(const augeas* aug, const char *var, int i,
+                const char **value, const char **label, char **file_path);
+
 /*
  * Error reporting
  */

--- a/src/augeas_sym.version
+++ b/src/augeas_sym.version
@@ -80,3 +80,8 @@ AUGEAS_0.22.0 {
     global:
       aug_source;
 } AUGEAS_0.21.0;
+
+AUGEAS_0.23.0 {
+    global:
+      aug_ns_attr;
+} AUGEAS_0.22.0;

--- a/src/internal.h
+++ b/src/internal.h
@@ -606,6 +606,12 @@ int pathx_symtab_assign_tree(struct pathx_symtab **symtab, const char *name,
 int pathx_symtab_undefine(struct pathx_symtab **symtab, const char *name);
 void pathx_symtab_remove_descendants(struct pathx_symtab *symtab,
                                      const struct tree *tree);
+/* Return the tree stored in the variable NAME at position I, which is the
+   same as evaluating the path expression '$NAME[I]'. If the variable NAME
+   does not exist, or does not contain a nodeset, or if I is bigger than
+   the size of the nodeset, return NULL */
+struct tree *pathx_symtab_get_tree(struct pathx_symtab *symtab,
+                                   const char *name, int i);
 void free_symtab(struct pathx_symtab *symtab);
 
 /* Escape a name so that it is safe to pass to parse_name and have it


### PR DESCRIPTION
This PR introduces new functions `aug_ns_*` which make it possible to iterate quickly over a large number of nodes and retrieve information for them. See `examples/dump.c` for how to use them and a small program that can be used to assess the performance improvement of these functions.

This is still work in progress, as it needs tests and some more thinking about error handling from `aug_ns_*`.