### PR TITLE
Add FreeBSD paths

### DIFF
--- a/lenses/dovecot.aug
+++ b/lenses/dovecot.aug
@@ -128,6 +128,8 @@ let lns = (comment|empty|entry|command|block)*
 (* Variable: filter *)
 let filter = incl "/etc/dovecot/dovecot.conf"
            . (incl "/etc/dovecot/conf.d/*.conf")
+           . incl "/usr/local/etc/dovecot/dovecot.conf"
+           . (incl "/usr/local/etc/dovecot/conf.d/*.conf")
            . Util.stdexcl
 
 let xfm = transform lns filter

--- a/lenses/postfix_access.aug
+++ b/lenses/postfix_access.aug
@@ -26,4 +26,4 @@ module Postfix_Access =
 
   let lns = ( empty | comment | record )*
 
-  let xfm = transform lns (incl "/etc/postfix/access")
+  let xfm = transform lns (incl "/etc/postfix/access" . incl "/usr/local/etc/postfix/access")

--- a/lenses/postfix_main.aug
+++ b/lenses/postfix_main.aug
@@ -45,5 +45,6 @@ let entry     = [ key word . eq . (indent . value)? . eol ]
 let lns        = (comment|empty|entry) *
 
 let filter     = incl "/etc/postfix/main.cf"
+               . incl "/usr/local/etc/postfix/main.cf"
 
 let xfm        = transform lns filter

--- a/lenses/postfix_master.aug
+++ b/lenses/postfix_master.aug
@@ -53,5 +53,6 @@ let entry     = [ key word . ws
 let lns        = (comment|empty|entry) *
 
 let filter     = incl "/etc/postfix/master.cf"
+               . incl "/usr/local/etc/postfix/master.cf"
 
 let xfm        = transform lns filter

--- a/lenses/postfix_passwordmap.aug
+++ b/lenses/postfix_passwordmap.aug
@@ -47,5 +47,6 @@ let lns = (Util.empty | Util.comment | record)*
 
 (* Variable: filter *)
 let filter = incl "/etc/postfix/*passwd"
+           . incl "/usr/local/etc/postfix/*passwd"
 
 let xfm = transform lns filter

--- a/lenses/postfix_sasl_smtpd.aug
+++ b/lenses/postfix_sasl_smtpd.aug
@@ -18,5 +18,6 @@ module Postfix_sasl_smtpd =
   let lns = entries+
 
   let filter = incl "/etc/postfix/sasl/smtpd.conf"
+             . incl "/usr/local/etc/postfix/sasl/smtpd.conf"
 
   let xfm = transform lns filter

--- a/lenses/postfix_transport.aug
+++ b/lenses/postfix_transport.aug
@@ -56,5 +56,6 @@ let lns = (Util.empty | Util.comment | record)*
 
 (* Variable: filter *)
 let filter = incl "/etc/postfix/transport"
+           . incl "/usr/local/etc/postfix/transport"
 
 let xfm = transform lns filter

--- a/lenses/postfix_virtual.aug
+++ b/lenses/postfix_virtual.aug
@@ -52,5 +52,6 @@ let lns = (Util.empty | Util.comment | record)*
 
 (* Variable: filter *)
 let filter = incl "/etc/postfix/virtual"
+           . incl "/usr/local/etc/postfix/virtual"
 
 let xfm = transform lns filter

--- a/lenses/shellvars.aug
+++ b/lenses/shellvars.aug
@@ -311,6 +311,7 @@ module Shellvars =
                      . incl "/etc/periodic.conf"
                      . incl "/etc/popularity-contest.conf"
                      . incl "/etc/rc.conf"
+                     . incl "/etc/rc.conf.d/*"
                      . incl "/etc/rc.conf.local"
                      . incl "/etc/selinux/config"
                      . incl "/etc/ucf.conf"


### PR DESCRIPTION
Adds FreeBSD support for the Postfix lenses.

I noticed that other lenses don't change the comments (eg. `About: Configuration files`) to reflect the additional paths, so I didn't either. Glad to modify if needed.