### PR TITLE
Fix sudoers lens: recognize "match_group_by_gid"

### DIFF
--- a/lenses/sudoers.aug
+++ b/lenses/sudoers.aug
@@ -315,7 +315,7 @@ let parameter_flag_kw    = "always_set_home" | "authenticate" | "env_editor"
                          | "tty_tickets" | "visiblepw" | "closefrom_override"
                          | "closefrom_override" | "compress_io" | "fast_glob"
                          | "log_input" | "log_output" | "pwfeedback"
-                         | "umask_override" | "use_pty"
+                         | "umask_override" | "use_pty" | "match_group_by_gid"
 
 let parameter_flag       = [ del_negate . negate_node?
                                . key parameter_flag_kw ]


### PR DESCRIPTION
The option is now enabled by default in the default sudoers of
RHEL 7.4 (and probably soon CentOS 7).

Closes #482