### PR TITLE
Cgconfig: allow fperm & dperm in admin & task

### DIFF
--- a/lenses/cgconfig.aug
+++ b/lenses/cgconfig.aug
@@ -30,7 +30,7 @@ module Cgconfig =
    let name      = /[^#= \n\t{}\/]+/
    let cont_name = /(cpuacct|cpu|devices|ns|cpuset|memory|freezer|net_cls|blkio|hugetlb|perf_event)/
    let role_name = /(admin|task)/
-   let id_name   = /(uid|gid)/
+   let id_name   = /(uid|gid|fperm|dperm)/
    let address   = /[^#; \n\t{}]+/
    let qaddress  = address|/"[^#;"\n\t{}]+"/
 

--- a/lenses/tests/test_cgconfig.aug
+++ b/lenses/tests/test_cgconfig.aug
@@ -318,3 +318,48 @@ test Cgconfig.lns get group6 =
     {  }
   }
 
+let group7 ="
+group daemons/www {
+  perm {
+    task {
+      uid = root;
+      gid = root;
+      fperm = 770;
+    }
+    admin {
+      uid = root;
+      gid = root;
+      dperm = 777;
+    }
+  }
+}
+"
+
+test Cgconfig.lns get group7 =
+  {  }
+  { "group" = "daemons/www"
+    {  }
+    { "perm"
+      {  }
+      { "task"
+        {  }
+        { "uid" = "root" }
+        {  }
+        { "gid" = "root" }
+        {  }
+        { "fperm" = "770" }
+        {  } }
+      {  }
+      { "admin"
+        {  }
+        { "uid" = "root" }
+        {  }
+        { "gid" = "root" }
+        {  }
+        { "dperm" = "777" }
+        {  } }
+      {  } }
+    {  }
+  }
+  {  }
+


### PR DESCRIPTION
These keys are used to control the permissions for files and directories.