### PR TITLE
When saving to nonwritable file fails, make sure we remove the tempfile

### DIFF
--- a/src/transform.c
+++ b/src/transform.c
@@ -1328,6 +1328,7 @@ int transform_save(struct augeas *aug, struct tree *xfm,
 
     r = clone_file(augtemp, augdest, &err_status, copy_if_rename_fails, 0);
     if (r != 0) {
+        unlink(augtemp);
         dyn_err_status = strappend(err_status, "_augtemp");
         goto done;
     }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -264,7 +264,7 @@ check_SCRIPTS = \
   test-save-empty.sh test-bug-1.sh test-idempotent.sh test-preserve.sh \
   test-events-saved.sh test-save-mode.sh test-unlink-error.sh \
   test-augtool-empty-line.sh test-augtool-modify-root.sh \
-  test-span-rec-lens.sh
+  test-span-rec-lens.sh test-nonwritable.sh
 
 EXTRA_DIST = \
   test-augtool root lens-test-1 \

--- a/tests/test-nonwritable.sh
+++ b/tests/test-nonwritable.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+# Test that an attempt to save into a non-writable file does not leave a
+# temporary file behind.
+# See https://github.com/hercules-team/augeas/issues/479
+
+if [ $UID -ne 0 -o "$(uname -s)" != "Linux" ]; then
+    echo "Test can only be run as root on Linux as it uses chattr"
+    exit 77
+fi
+
+root=$abs_top_builddir/build/test-nonwritable
+hosts=$root/etc/hosts
+
+rm -rf $root
+mkdir -p $(dirname $hosts)
+
+cat <<EOF > $hosts
+127.0.0.1 localhost
+EOF
+
+chattr +i $hosts
+
+augtool --nostdinc -r $root -I $abs_top_srcdir/lenses > /dev/null <<EOF
+set /files/etc/hosts/1/ipaddr 127.0.0.2
+save
+EOF
+
+chattr -i $hosts
+
+if stat -t $hosts.* > /dev/null 2>&1
+then
+    echo "found a tempfile" $hosts.*
+    exit 1
+fi


### PR DESCRIPTION
When the file we are trying to save to is not writable, we left the
temporary file we wriote to behind. Now, we make sure we remove it.

Fixes https://github.com/hercules-team/augeas/issues/479