### PR TITLE
Fix memory leak when checking version of augparse

### DIFF
--- a/src/augparse.c
+++ b/src/augparse.c
@@ -130,6 +130,7 @@ int main(int argc, char **argv) {
 
     if (print_version) {
         print_version_info(aug);
+        aug_close(aug);
         return EXIT_SUCCESS;
     }
 


### PR DESCRIPTION
Add aug_close() before exit to fix memory leak when printing
version information of augparse.