### PR TITLE
Exports: allow paths in quotes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@
       instead of aug_get, aug_label etc. and for a way to measure
       performance gains.
   - Lens changes/additions
+    * Exports: relax the rules for the path at the beginning of a line so
+      that double-quoted paths are legal, too
     * Oz: New lense for /etc/oz/oz.cnf
     * Rsyslog: allow spaces before the # starting a comment; allow comments
       inside config statements like 'module'

--- a/lenses/exports.aug
+++ b/lenses/exports.aug
@@ -90,7 +90,7 @@ module Exports =
                     ( Build.brackets lbracket rbracket
                          ( Build.opt_list option sep_com ) )? ]
 
-  let entry = [ label "dir" . store /\/[^ \t]*/
+  let entry = [ label "dir" . store /[^ \t\n#]*/
                 . sep_spc . Build.opt_list client sep_spc . eol ]
 
   let lns = (Util.empty | Util.comment | entry)*

--- a/lenses/tests/test_exports.aug
+++ b/lenses/tests/test_exports.aug
@@ -51,3 +51,9 @@ test Exports.lns get s =
   { "dir" = "/local5"
       { "client" = "somehost-[01]"
           { "option" = "rw" } } }
+
+test Exports.lns get "\"/path/in/quotes\" 192.168.0.1(rw,all_squash)\n" =
+  { "dir" = "\"/path/in/quotes\""
+    { "client" = "192.168.0.1"
+      { "option" = "rw" }
+      { "option" = "all_squash" } } }


### PR DESCRIPTION
We used to insist that paths start with a /, but things like
"/path/in/quotes" is legal, too. The lens now accepts pretty much anything
for the path now.