### PR TITLE
Improvements of syslog and rsyslog

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@
       performance gains.
   - Lens changes/additions
     * Oz: New lense for /etc/oz/oz.cnf
+    * Rsyslog: allow spaces before the # starting a comment; allow comments
+      inside config statements like 'module'
     * Sshd: split HostKeyAlgorithms into list of values
     * Syslog: allow spaces before the # starting a comment
 

--- a/NEWS
+++ b/NEWS
@@ -13,8 +13,9 @@
       instead of aug_get, aug_label etc. and for a way to measure
       performance gains.
   - Lens changes/additions
-    * Sshd: split HostKeyAlgorithms into list of values
     * Oz: New lense for /etc/oz/oz.cnf
+    * Sshd: split HostKeyAlgorithms into list of values
+    * Syslog: allow spaces before the # starting a comment
 
 1.8.1 - 2017-08-17
   - General changes/addition

--- a/lenses/rsyslog.aug
+++ b/lenses/rsyslog.aug
@@ -27,9 +27,16 @@ let macro_rx = /[^,# \n\t][^#\n]*[^,# \n\t]|[^,# \n\t]/
 let macro = [ key /$[A-Za-z0-9]+/ . Sep.space . store macro_rx . Util.comment_or_eol ]
 
 let config_object_param = [ key /[A-Za-z.]+/ . Sep.equal . Quote.dquote
-                          . store /[^"]+/ . Quote.dquote ]
-let config_object = [ key /action|global|input|module|parser|timezone/ . Sep.lbracket
-                    . config_object_param . ( Sep.space . config_object_param )* . Sep.rbracket . Util.comment_or_eol ]
+                            . store /[^"]+/ . Quote.dquote ]
+(* Inside config objects, we allow embedded comments; we don't surface them
+ * in the tree though *)
+let config_sep = del /[ \t]+|[ \t]*#.*\n[ \t]*/ " "
+
+let config_object =
+  [ key /action|global|input|module|parser|timezone/ .
+    Sep.lbracket .
+    config_object_param . ( config_sep . config_object_param )* .
+    Sep.rbracket . Util.comment_or_eol ]
 
 (* View: users
    Map :omusrmsg: and a list of users, or a single *
@@ -72,4 +79,3 @@ let filter = incl "/etc/rsyslog.conf"
            . Util.stdexcl
 
 let xfm = transform lns filter
-

--- a/lenses/syslog.aug
+++ b/lenses/syslog.aug
@@ -45,7 +45,8 @@ module Syslog =
      *)
 
 	let comment_gen (space:regexp) (sto:regexp) =
-          [ label "#comment" . del ("#" . space) "# " . store sto . eol ]
+      [ label "#comment" . del (Rx.opt_space . "#" . space) "# "
+        . store sto . eol ]
 
 	let comment =
 		let comment_withsign = comment_gen Rx.space /([!+-].*[^ \t\n]|[!+-])/
@@ -263,4 +264,3 @@ module Syslog =
         let filter = incl "/etc/syslog.conf"
 
         let xfm = transform lns filter
-

--- a/lenses/tests/test_rsyslog.aug
+++ b/lenses/tests/test_rsyslog.aug
@@ -189,3 +189,13 @@ test Rsyslog.lns put "" after
   set "/module[1]/SysSock.RateLimit.Interval" "0" ;
   set "/module[1]/SysSock.RateLimit.Burst" "1"
   = "module(load=\"imuxsock\" SysSock.RateLimit.Interval=\"0\" SysSock.RateLimit.Burst=\"1\")\n"
+
+(* On Fedora 26, there are comments in module statements *)
+test Rsyslog.lns get "module(load=\"imuxsock\" 	  # provides support for local system logging (e.g. via logger command)
+       SysSock.Use=\"off\") # Turn off message reception via local log socket;
+			  # local messages are retrieved through imjournal now.\n" =
+  { "module"
+    { "load" = "imuxsock" }
+    { "SysSock.Use" = "off" }
+    { "#comment" = "Turn off message reception via local log socket;" } }
+  { "#comment" = "local messages are retrieved through imjournal now." }

--- a/lenses/tests/test_syslog.aug
+++ b/lenses/tests/test_syslog.aug
@@ -1,7 +1,7 @@
 module Test_syslog =
 
 	let conf="# $FreeBSD: src/etc/syslog.conf,v 1.30.2.1 2009/08/03 08:13:06 kensmith Exp $
-# 
+#
 
 daemon.info                                     /var/log/cvsupd.log
 security.*					-/var/log/security
@@ -347,3 +347,7 @@ daemon.info                                     /var/log/cvsupd.log
     (* test for commented out statements *)
     test Syslog.lns put "" after
        set "#comment" "!pppd" = "# !pppd\n"
+
+    (* allow space before comments *)
+    test Syslog.lns get "  \t# space comment\n" =
+      { "#comment" = "space comment" }


### PR DESCRIPTION
These changes allow augeas to parse the default `/etc/rsyslog.conf` on Fedora 26