### PR TITLE
Properties: accept DOS line endings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,7 @@
       quoted arguments optional (Issue #435); accept quoted strings as part
       of bare arguments (Issue #470)
     * Oz: New lense for /etc/oz/oz.cnf
+    * Properties: accept DOS line endings (Issue #468)
     * Rsyslog: allow spaces before the # starting a comment; allow comments
       inside config statements like 'module'
     * Sshd: split HostKeyAlgorithms into list of values

--- a/lenses/properties.aug
+++ b/lenses/properties.aug
@@ -13,20 +13,20 @@
 module Properties =
   (* Define some basic primitives *)
   let empty            = Util.empty
-  let eol              = Util.eol
-  let hard_eol         = del "\n" "\n"
+  let eol              = Util.doseol
+  let hard_eol         = del /\r?\n/ "\n"
   let sepch            = del /([ \t]*(=|:)|[ \t])/ "="
   let sepspc           = del /[ \t]/ " "
   let sepch_ns         = del /[ \t]*(=|:)/ "="
   let sepch_opt        = del /[ \t]*(=|:)?[ \t]*/ "="
-  let value_to_eol_ws  = store /(:|=)[^\n]*[^ \t\n\\]/
+  let value_to_eol_ws  = store /(:|=)[^\r\n]*[^ \t\r\n\\]/
   let value_to_bs_ws   = store /(:|=)[^\n]*[^\\\n]/
-  let value_to_eol     = store /([^ \t\n:=][^\n]*[^ \t\n\\]|[^ \t\n\\:=])/
+  let value_to_eol     = store /([^ \t\n:=][^\n]*[^ \t\r\n\\]|[^ \t\r\n\\:=])/
   let value_to_bs      = store /([^ \t\n:=][^\n]*[^\\\n]|[^ \t\n\\:=])/
   let indent           = Util.indent
   let backslash        = del /[\\][ \t]*\n/ "\\\n"
   let opt_backslash    = del /([\\][ \t]*\n)?/ ""
-  let entry            = /([^ \t\n:=\/!#\\]|[\\]:|[\\]=|[\\][\t ]|[\\][^\/\n])+/
+  let entry            = /([^ \t\r\n:=\/!#\\]|[\\]:|[\\]=|[\\][\t ]|[\\][^\/\r\n])+/
 
   let multi_line_entry =
       [ indent . value_to_bs? . backslash ] .
@@ -39,7 +39,7 @@ module Properties =
       [ indent . value_to_eol . eol ] . value " < multi_ws > "
 
   (* define comments and properties*)
-  let bang_comment     = [ label "!comment" . del /[ \t]*![ \t]*/ "! " . store /([^ \t\n].*[^ \t\n]|[^ \t\n])/ . eol ]
+  let bang_comment     = [ label "!comment" . del /[ \t]*![ \t]*/ "! " . store /([^ \t\n].*[^ \t\r\n]|[^ \t\r\n])/ . eol ]
   let comment          = ( Util.comment | bang_comment )
   let property         = [ indent . key entry . sepch . ( multi_line_entry | indent . value_to_eol . eol ) ]
   let property_ws         = [ indent . key entry . sepch_ns . ( multi_line_entry_ws | indent . value_to_eol_ws . eol ) ]

--- a/lenses/tests/test_properties.aug
+++ b/lenses/tests/test_properties.aug
@@ -160,3 +160,8 @@ bootstrap.jar,commons-daemon.jar,tomcat-juli.jar\n" =
     { "tomcat.util.scan.DefaultJarScanner.jarsToSkip" = " < multi > "
       { } { = "bootstrap.jar,commons-daemon.jar,tomcat-juli.jar" } }
 
+
+test lns get "# comment\r\na.b=val\r\nx=\r\n" =
+  { "#comment" = "comment" }
+  { "a.b" = "val" }
+  { "x" }


### PR DESCRIPTION
We now allow /\r?\n/ in line endings. The regular expressions preceding eol
and hard_eol are a little tighter than they really need to be to avoid
ambiguous concatenations as they generally result from removing \r from
allowable values. If that turns out to be a problem, we need to refine them
further.

Fixes https://github.com/hercules-team/augeas/issues/468