### PR TITLE
Implemented fa_export function

### DIFF
--- a/src/fa.c
+++ b/src/fa.c
@@ -4513,6 +4513,93 @@ void fa_dot(FILE *out, struct fa *fa) {
     fprintf(out, "}\n");
 }
 
+void fa_json(FILE *out, struct fa *fa) {
+    int *list_hashes = NULL;
+    int list_size = 100;
+    int num_states = 0;
+    int it;
+    char first = true;
+
+    fprintf(out,"{\n\t\"final\": [");
+
+    F(ALLOC_N(list_hashes, list_size));
+    // list_hashes = (int *)malloc(sizeof(int) * list_size);
+
+    list_for_each(s, fa->initial) {
+        if (num_states == list_size - 1){
+            list_size += list_size;
+            F(REALLOC_N(list_hashes, list_size));
+            // list_hashes = realloc(list_hashes, list_size);
+        }
+        // Store hash value
+        list_hashes[num_states] = s->hash;
+        // We use the hashes to map states to Z_{num_states}
+        s->hash = num_states++;
+        if (s->accept) {
+            if (!first) fprintf(out, ", %ld", s->hash);
+            else fprintf(out,"%ld", s->hash);
+            first = false;
+        }
+    }
+
+    fprintf(out, "],\n\t\"deterministic\": %d,\n\t\"transitions\": [\n", fa->deterministic ? 1 : 0);
+
+    first = true;
+    list_for_each(s, fa->initial) {
+        for_each_trans(t, s) {
+            if (!first) fprintf(out, ",\n");
+            first = false; 
+            fprintf(out, "\t\t{ \"from\": %ld, \"to\": %ld, \"on\": \"",s->hash, t->to->hash);
+            print_char(out, t->min);
+            if (t->min != t->max) {
+                fputc('-', out);
+                print_char(out, t->max);
+            }
+            fprintf(out, "\" }");
+        }
+    }
+
+    fprintf(out,"\n\t]\n}");
+
+error:
+    // Restoring hash values to leave the FA structure untouched
+    it = 0;
+    list_for_each(s, fa->initial) {
+        if (it == num_states) break;
+        s->hash = list_hashes[it++];
+    }
+    free(list_hashes);
+}
+
+int fa_is_deterministic(struct fa *fa) {
+    return fa->deterministic;
+}
+
+struct state *fa_state_initial(struct fa *fa) {
+    return fa->initial;
+}
+
+bool fa_state_is_accepting(struct state *st) {
+    return st->accept;
+}
+
+struct state* fa_state_next(struct state *st) {
+    return st->next;
+}
+
+size_t fa_state_num_trans(struct state *st) {
+    return st->tused;
+}
+
+bool fa_state_trans(struct state *st, size_t i, struct state **to, unsigned char *min, unsigned char *max) {
+    if (st->tused <= i) return -1;
+
+    (*to) = st->trans[i].to;
+    (*min) = st->trans[i].min;
+    (*max) = st->trans[i].max;
+    return 0;
+}
+
 /*
  * Local variables:
  *  indent-tabs-mode: nil

--- a/src/fa.h
+++ b/src/fa.h
@@ -25,9 +25,14 @@
 
 #include <stdio.h>
 #include <regex.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 /* The type for a finite automaton. */
 struct fa;
+
+/* The type of a state of a finite automaton */
+struct state;
 
 /* Denote some basic automata, used by fa_is_basic and fa_make_basic */
 enum fa_basic {
@@ -271,6 +276,34 @@ int fa_expand_nocase(const char *regexp, size_t regexp_len,
  * memory, and -2 if FA has more than LIMIT words.
  */
 int fa_enumerate(struct fa *fa, int limit, char ***words);
+
+/* Print FA to OUT as a JSON file. State 0 is always the initial one */
+void fa_json(FILE *out, struct fa *fa);
+
+/* Returns 1 if the FA is deterministic and 0 otherwise */
+int fa_is_deterministic(struct fa *fa);
+
+/* Return the initial state */
+struct state *fa_state_initial(struct fa *fa);
+
+/* Return true if this is an accepting state */
+bool fa_state_is_accepting(struct state *st);
+
+/* Return the next state; return NULL if there are no more states */
+struct state* fa_state_next(struct state *st);
+
+/* Return the number of transitions for a state */
+size_t fa_state_num_trans(struct state *st);
+
+/* Produce details about the i-th transition. 
+ *
+ * On success, *to points to the destination state of the transition and
+ * the interval [min-max] is the label of the transition.
+ * 
+ * On failure, *to, min and max are not modified.
+ *
+ * Return 0 on success and -1 otherwise */
+bool fa_state_trans(struct state *st, size_t i, struct state **to, unsigned char *min, unsigned char *max);
 
 #endif
 

--- a/src/fa_sym.version
+++ b/src/fa_sym.version
@@ -32,4 +32,11 @@ FA_1.2.0 {
 
 FA_1.4.0 {
       fa_enumerate;
+      fa_json;
+      fa_state_initial;
+      fa_state_is_accepting;
+      fa_state_next;
+      fa_state_num_trans;
+      fa_state_trans;
+      fa_is_deterministic;
 } FA_1.2.0;


### PR DESCRIPTION
I have implemented a function called "fa_export" which basically outputs the FA as an array such that each position corresponds to a possible transitions. Whenever there is a 1, the transitions exists in the FA.

```
v[i * num_states * ALPHABET_SIZE + j *ALPHABET_SIZE + k] = 1 iff transition i→j is labelled with k
```

The goal of this function is to allow a translation from the current FA structure to the one used by any application that uses libfa. Before this change, the only way to export the FA goes through outputting it as a .dot file.