### PR TITLE
spelling fixes

### DIFF
--- a/doc/lenses.tex
+++ b/doc/lenses.tex
@@ -76,7 +76,7 @@ in a number of ways:
     that an entry in the tree corresponds to text that was deleted.
   \item the children of a tree node form a list of subtrees, i.e. are
     ordered. In addition, several subtrees in such a list may use the same
-    label. This makes it possible to accomodate concrete files where
+    label. This makes it possible to accommodate concrete files where
     entries that are logically connected are stored scattered between
     unrelated entries like the {\tt AcceptEnv} entries in {\tt
       sshd\_config}.
@@ -253,7 +253,7 @@ Copies a word into a leaf.
 
 Gets the next value from a sequence as the key. We assume there's a
 generator $\mathtt{nextval}: \Sigma^* \to \mathbb{N}$ that returns
-successive numbers on each invocation. \redigits is the regular expresion
+successive numbers on each invocation. \redigits is the regular expression
 {\tt [0-9]+} that matches positive numbers.
 
 \infrule{w\in\Sigma^* \andalso L\in\Dictlangs \andalso n = \mathtt{nextval}(w)}

--- a/doc/naturaldocs/conf/c_api/Topics.txt
+++ b/doc/naturaldocs/conf/c_api/Topics.txt
@@ -24,7 +24,7 @@ Format: 1.52
 # Alter Topic Type: [name]
 #    Creates a new topic type or alters one from the main file.  Each type gets
 #    its own index and behavior settings.  Its name can have letters, numbers,
-#    spaces, and these charaters: - / . '
+#    spaces, and these characters: - / . '
 #
 # Plural: [name]
 #    Sets the plural name of the topic type, if different.

--- a/doc/naturaldocs/conf/lenses/Topics.txt
+++ b/doc/naturaldocs/conf/lenses/Topics.txt
@@ -17,7 +17,7 @@ Ignore Keywords:
 # Alter Topic Type: [name]
 #    Creates a new topic type or alters one from the main file.  Each type gets
 #    its own index and behavior settings.  Its name can have letters, numbers,
-#    spaces, and these charaters: - / . '
+#    spaces, and these characters: - / . '
 #
 # Plural: [name]
 #    Sets the plural name of the topic type, if different.

--- a/lenses/aptconf.aug
+++ b/lenses/aptconf.aug
@@ -73,7 +73,7 @@ let name_re_colons = /[A-Za-z][A-Za-z:-]*/
      since apt.conf allows for both
      APT { Clean-Installed { "true" } }
      and APT::Clean-Installed "true";
-     but we're chosing to map them the same way
+     but we're choosing to map them the same way
 
      The recursive lens doesn't seem
      to care and defaults to the first

--- a/lenses/cobblersettings.aug
+++ b/lenses/cobblersettings.aug
@@ -2,7 +2,7 @@
     Parse the /etc/cobbler/settings file  which is in
     YAML 1.0 format.
 
-    The lens can handle the following contructs
+    The lens can handle the following constructs
     * key: value
     * key: "value"
     * key: 'value'
@@ -23,7 +23,7 @@ module CobblerSettings =
     autoload xfm
 
     let kw = /[a-zA-Z0-9_]+/
-    (* TODO Would be better if this stripped off the "" and '' chracters *)
+    (* TODO Would be better if this stripped off the "" and '' characters *)
     let kv = /([^]['", \t\n#:@-]+|"[^"\n]*"|'[^'\n]*')/
 
     let lbr = del /\[/ "["

--- a/lenses/cron_user.aug
+++ b/lenses/cron_user.aug
@@ -6,7 +6,7 @@ Author: David Lutterkort <lutter@watzmann.net>
 
 About: Reference
  This lens parses the user crontab files in /var/spool/cron. It produces
- almost the same tree as teh Cron.lns, except that it never contains a user
+ almost the same tree as the Cron.lns, except that it never contains a user
  field.
 
 About: License

--- a/lenses/dhclient.aug
+++ b/lenses/dhclient.aug
@@ -6,7 +6,7 @@
    that statements end with a new line, while the reference syntax allows
    new statements to be started right after the trailing ";" of the
    previous statement. This should not be a problem in real-life
-   configuration files as statements get usually splitted across several
+   configuration files as statements get usually split across several
    lines, rather than merged in a single one.
 
 *)

--- a/lenses/dpkg.aug
+++ b/lenses/dpkg.aug
@@ -5,7 +5,7 @@ Module: Dpkg
 Author: Robin Lee Powell <rlpowell@digitalkingdom.org>
 
 About: License
-    This file, and the attendant test_dpgk.aug, are explicitely
+    This file, and the attendant test_dpgk.aug, are explicitly
     placed in the public domain.
 
 About: Description
@@ -77,7 +77,7 @@ module Dpkg =
       by EOL.
 
       The actual file specification doesn't require EOL, but the
-      likelyhood of the file not having one is pretty slim, and
+      likelihood of the file not having one is pretty slim, and
       this way things we add have EOL.
   *)
 

--- a/lenses/mdadm_conf.aug
+++ b/lenses/mdadm_conf.aug
@@ -149,7 +149,7 @@ let array  = [ del array_re "ARRAY" . label "array" . arr_options . eol ]
 
 let mailaddr_re = /mai(l(a(d(dr?)?)?)?)?/i
 
-(* We intentially allow multiple mailaddr values here, even though this is
+(* We intentionally allow multiple mailaddr values here, even though this is
 invalid and would produce a warning. This is better than not parsing the file.
 *)
 let mailaddr = simplevalue mailaddr_re "mailaddr" "MAILADDR"

--- a/lenses/quote.aug
+++ b/lenses/quote.aug
@@ -173,7 +173,7 @@ let double =
 let double_opt_re = /[^\n\t "]([^\n"]*[^\n\t "])?/
 
 (* View: double_opt
-     An optionaly double-quoted value
+     An optionally double-quoted value
      Double quotes are not allowed in value
      Value cannot begin or end with spaces *)
 let double_opt =
@@ -192,7 +192,7 @@ let single =
 let single_opt_re = /[^\n\t ']([^\n']*[^\n\t '])?/
 
 (* View: single_opt
-     An optionaly single-quoted value
+     An optionally single-quoted value
      Single quotes are not allowed in value
      Value cannot begin or end with spaces *)
 let single_opt =
@@ -211,7 +211,7 @@ let any =
 let any_opt_re = /[^\n\t "']([^\n"']*[^\n\t "'])?/
 
 (* View: any_opt
-     An optionaly quoted value
+     An optionally quoted value
      Double or single quotes are not allowed in value
      Value cannot begin or end with spaces *)
 let any_opt =

--- a/lenses/redis.aug
+++ b/lenses/redis.aug
@@ -99,7 +99,7 @@ let soft_limit = [ label "soft_limit" . Quote.do_quote_opt_nil (store Rx.word) ]
 let soft_seconds = [ label "soft_seconds" . Quote.do_quote_opt_nil (store Rx.integer) ]
 (* View: client_output_buffer_limit_entry
 Entries identified by the "client-output-buffer-limit" keyword can be found
-more than once. They have four mandatory paramters, of which the first is a
+more than once. They have four mandatory parameters, of which the first is a
 string, the last one is an integer and the others are either integers or words,
 although redis is very liberal and takes "4242yadayadabytes" as a valid limit.
 The same rules as standard_entry apply for quoting, comments and whitespaces.

--- a/lenses/shellvars_list.aug
+++ b/lenses/shellvars_list.aug
@@ -32,7 +32,7 @@ module Shellvars_list =
   let squote_arr = [ label "quote" . store /'/ ]
                    . (list sqword space_or_nl)? . del /'/ "'"
 
-  (* similarly handle double qouted lists *)
+  (* similarly handle double quoted lists *)
   let dquote_arr = [ label "quote" . store /"/ ]
                    . (list dqword space_or_cl)? . del /"/ "\""
 

--- a/lenses/sudoers.aug
+++ b/lenses/sudoers.aug
@@ -29,7 +29,7 @@ About: Lens Usage
 
     * Set first Defaults to apply to the "LOCALNET" network alias
       > set /files/etc/sudoers/Defaults[1]/type "@LOCALNET"
-    * List all user specifications applying explicitely to the "admin" Unix group
+    * List all user specifications applying explicitly to the "admin" Unix group
       > match /files/etc/sudoers/spec/user "%admin"
     * Remove the full 3rd user specification
       > rm /files/etc/sudoers/spec[3]

--- a/lenses/syslog.aug
+++ b/lenses/syslog.aug
@@ -101,7 +101,7 @@ module Syslog =
 	let word      = /[A-Za-z0-9][A-Za-z0-9_.-]*/
 
 	(* Variable: comparison
-	  a comparison is an optional ! with optionaly some of [<=>]
+	  a comparison is an optional ! with optionally some of [<=>]
 	  *)
         let comparison = /(!|[<=>]+|![<=>]+)/
 

--- a/lenses/tests/test_afs_cellalias.aug
+++ b/lenses/tests/test_afs_cellalias.aug
@@ -12,7 +12,7 @@ let conf = "# Cell Aliases are meant to act like symlinks like '/afs/openafs.org
 # These aliases are set with 'fs newalias', or read from
 # /usr/vice/etc/CellAlias
 #
-# Formating for /usr/vice/etc/CellAlias is in the form
+# Formatting for /usr/vice/etc/CellAlias is in the form
 # <target> <alias>
 # an example would be
 # fnal.gov/common/usr usr
@@ -28,7 +28,7 @@ test AFS_cellalias.lns get conf = { "#comment" = "Cell Aliases are meant to act 
   { "#comment" = "These aliases are set with 'fs newalias', or read from" }
   { "#comment" = "/usr/vice/etc/CellAlias" }
   {  }
-  { "#comment" = "Formating for /usr/vice/etc/CellAlias is in the form" }
+  { "#comment" = "Formatting for /usr/vice/etc/CellAlias is in the form" }
   { "#comment" = "<target> <alias>" }
   { "#comment" = "an example would be" }
   { "#comment" = "fnal.gov/common/usr usr" }

--- a/lenses/tests/test_opendkim.aug
+++ b/lenses/tests/test_opendkim.aug
@@ -95,7 +95,7 @@ UMask     002
 
 # Always oversign From (sign using actual From and a null From to prevent
 # malicious signatures header fields (From and/or others) between the signer
-# and the verifier.  From is oversigned by default in the Debian pacakge
+# and the verifier.  From is oversigned by default in the Debian package
 # because it is often the identity key used by reputation systems and thus
 # somewhat security sensitive.
 OversignHeaders   From
@@ -130,7 +130,7 @@ OversignHeaders   From
   {  }
   { "#comment" = "Always oversign From (sign using actual From and a null From to prevent" }
   { "#comment" = "malicious signatures header fields (From and/or others) between the signer" }
-  { "#comment" = "and the verifier.  From is oversigned by default in the Debian pacakge" }
+  { "#comment" = "and the verifier.  From is oversigned by default in the Debian package" }
   { "#comment" = "because it is often the identity key used by reputation systems and thus" }
   { "#comment" = "somewhat security sensitive." }
   { "OversignHeaders" = "From" }

--- a/lenses/tests/test_redis.aug
+++ b/lenses/tests/test_redis.aug
@@ -76,7 +76,7 @@ test Redis.lns get extra_whitespace_comment = { "#comment" = "another comment" }
 
 let redis_conf = "# Redis configuration file example
 
-# Note on units: when memory size is needed, it is possible to specifiy
+# Note on units: when memory size is needed, it is possible to specify
 # it in the usual form of 1k 5GB 4M and so forth:
 #
 # 1k => 1000 bytes
@@ -123,7 +123,7 @@ include /path/to/other.conf
 test Redis.lns get redis_conf =
   { "#comment" = "Redis configuration file example" }
   { }
-  { "#comment" = "Note on units: when memory size is needed, it is possible to specifiy" }
+  { "#comment" = "Note on units: when memory size is needed, it is possible to specify" }
   { "#comment" = "it in the usual form of 1k 5GB 4M and so forth:" }
   { }
   { "#comment" = "1k => 1000 bytes" }

--- a/lenses/tests/test_shellvars_list.aug
+++ b/lenses/tests/test_shellvars_list.aug
@@ -75,7 +75,7 @@ FAILSAVE_APPEND=\"console=ttyS0\"
       { "value" = "test\"1" }
       { "value" = "test2" } }
 
-  (* emtpy list with quotes *)
+  (* empty list with quotes *)
   test Shellvars_list.lns get "VAR=''\n" =
     { "VAR"
       { "quote" = "'" } }

--- a/man/augtool.1
+++ b/man/augtool.1
@@ -184,7 +184,7 @@ Add a file transform; uses the 'transform' command syntax,
 e.g. \f(CW\*(C`\-t \*(AqFstab incl /etc/fstab.bak\*(Aq\*(C'\fR.
 .IP "\fB\-l\fR, \fB\-\-load\-file\fR=\fI\s-1FILE\s0\fR" 4
 .IX Item "-l, --load-file=FILE"
-Load an invididual \s-1FILE\s0 into the tree. The lens to use is determined
+Load an individual \s-1FILE\s0 into the tree. The lens to use is determined
 automatically (based on autoload information in the lenses) and will be the
 same that is used for this file when the entire tree is loaded. The option
 can be specified multiple times to load several files, e.g. \f(CW\*(C`\-l /etc/fstab

--- a/man/augtool.pod
+++ b/man/augtool.pod
@@ -56,7 +56,7 @@ e.g. C<-t 'Fstab incl /etc/fstab.bak'>.
 
 =item B<-l>, B<--load-file>=I<FILE>
 
-Load an invididual FILE into the tree. The lens to use is determined
+Load an individual FILE into the tree. The lens to use is determined
 automatically (based on autoload information in the lenses) and will be the
 same that is used for this file when the entire tree is loaded. The option
 can be specified multiple times to load several files, e.g. C<-l /etc/fstab

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -518,7 +518,7 @@ typedef enum {
     AUG_ENOSPAN,        /* No span for this node */
     AUG_EMVDESC,        /* Cannot move node into its descendant */
     AUG_ECMDRUN,        /* Failed to execute command */
-    AUG_EBADARG,        /* Invalid argument in funcion call */
+    AUG_EBADARG,        /* Invalid argument in function call */
     AUG_ELABEL,         /* Invalid label */
     AUG_ECPDESC         /* Cannot copy node into its descendant */
 } aug_errcode_t;

--- a/src/augparse.c
+++ b/src/augparse.c
@@ -37,7 +37,7 @@ static void usage(void) {
     fprintf(stderr, "Usage: %s [OPTIONS] MODULE\n", progname);
     fprintf(stderr, "Evaluate MODULE. Generally, MODULE should contain unit tests.\n");
     fprintf(stderr, "\nOptions:\n\n");
-    fprintf(stderr, "  -I, --include DIR  search DIR for modules; can be given mutiple times\n");
+    fprintf(stderr, "  -I, --include DIR  search DIR for modules; can be given multiple times\n");
     fprintf(stderr, "  -t, --trace        trace module loading\n");
     fprintf(stderr, "  --nostdinc         do not search the builtin default directories for modules\n");
     fprintf(stderr, "  --notypecheck      do not typecheck lenses\n");

--- a/src/fa.c
+++ b/src/fa.c
@@ -1672,7 +1672,7 @@ static int minimize_hopcroft(struct fa *fa) {
             struct state *qs = partn->states[q];
             int qnum = state_set_index(states, qs);
             if (qs == fa->initial)
-                s->live = 1;     /* Abuse live to flag the new intial state */
+                s->live = 1;     /* Abuse live to flag the new initial state */
             nsnum[n] = qnum;     /* select representative */
             nsind[qnum] = n;     /* and point from partition to new state */
         }

--- a/src/fa.h
+++ b/src/fa.h
@@ -171,7 +171,7 @@ struct fa *fa_overlap(struct fa *fa1, struct fa *fa2);
 
 /* Produce an example for the language of FA. The example is not
  * necessarily the shortest possible. The implementation works very hard to
- * have printable characters (preferrably alphanumeric) in the example, and
+ * have printable characters (preferably alphanumeric) in the example, and
  * to avoid just an empty word.
  *
  * *EXAMPLE will be the example, which may be NULL. If it is non-NULL,

--- a/src/hash.h
+++ b/src/hash.h
@@ -98,7 +98,7 @@ typedef int (*hash_comp_t)(const void *, const void *);
  * particular, the most significant bits of hash_val_t are most significant to
  * the hash module. Only as the hash table expands are less significant bits
  * examined. Thus a function that has good distribution in its upper bits but
- * not lower is preferrable to one that has poor distribution in the upper bits
+ * not lower is preferable to one that has poor distribution in the upper bits
  * but not the lower ones.
  */
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -610,7 +610,7 @@ int pathx_parse(const struct tree *origin,
 struct error *err_of_pathx(struct pathx *px);
 struct tree *pathx_first(struct pathx *path);
 struct tree *pathx_next(struct pathx *path);
-/* Return -1 if evalutating PATH runs into trouble, otherwise return the
+/* Return -1 if evaluating PATH runs into trouble, otherwise return the
  * number of nodes matching PATH and set MATCH to the first matching
  * node */
 int pathx_find_one(struct pathx *path, struct tree **match);

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -308,7 +308,7 @@ void free_value(struct value *v) {
 
 /*
  * Creation of (some) terms. Others are in parser.y
- * Refernce counted arguments are now owned by the returned object, i.e.
+ * Reference counted arguments are now owned by the returned object, i.e.
  * the make_* functions do not increment the count.
  * Returned objects have a referece count of 1.
  */

--- a/src/transform.c
+++ b/src/transform.c
@@ -55,7 +55,7 @@ static const int glob_flags = GLOB_NOSORT;
  *   lens/id   : unique hexadecimal id of the lens
  *   error     : indication of errors during processing FNAME, or NULL
  *               if processing succeeded
- *   error/pos : position in file where error occured (for get errors)
+ *   error/pos : position in file where error occurred (for get errors)
  *   error/path: path to tree node where error occurred (for put errors)
  *   error/message : human-readable error message
  */

--- a/tests/root/etc/samba/smb.conf
+++ b/tests/root/etc/samba/smb.conf
@@ -69,7 +69,7 @@
 # you want to listen on (never omit localhost)
 #
 # Hosts Allow/Hosts Deny lets you restrict who can connect, and you can
-# specifiy it as a per share option as well
+# specify it as a per share option as well
 #
 	workgroup = MYGROUP
 	server string = Samba Server Version %v
@@ -160,7 +160,7 @@
 	# the login script name depends on the unix user used
 ;	logon script = %u.bat
 ;	logon path = \\%L\Profiles\%u
-	# disables profiles support by specifing an empty path
+	# disables profiles support by specifying an empty path
 ;	logon path =
 
 ;	add user script = /usr/sbin/useradd "%u" -n -g users

--- a/tests/root/etc/squid/squid.conf
+++ b/tests/root/etc/squid/squid.conf
@@ -100,7 +100,7 @@
 #	The default of 0 is used for helpers who only supports
 #	one request at a time. Setting this changes the protocol used to
 #	include a channel number first on the request/response line, allowing
-#	multiple requests to be sent to the same helper in parallell without
+#	multiple requests to be sent to the same helper in parallel without
 #	wating for the response.
 #	Must not be set unless it's known the helper supports this.
 #	auth_param basic concurrency 0
@@ -2354,7 +2354,7 @@ refresh_pattern .		0	20%	4320
 #	downloads.
 #
 #	When the user aborts a request, Squid will check the
-#	quick_abort values to the amount of data transfered until
+#	quick_abort values to the amount of data transferred until
 #	then.
 #
 #	If the transfer has less than 'quick_abort_min' KB remaining,
@@ -2393,7 +2393,7 @@ refresh_pattern .		0	20%	4320
 #	negative caching of DNS lookups.
 #
 #	WARNING: This setting VIOLATES RFC 2616 when non-zero.
-#	If you have problems with eror pages caching, set to '0 seconds'
+#	If you have problems with error pages caching, set to '0 seconds'
 #
 #Default:
 # negative_ttl 5 minutes
@@ -3842,7 +3842,7 @@ icp_port 3130
 #
 #	The squid developers are interested in making squid available in
 #	a wide variety of languages. If you are making translations for a
-#	langauge that Squid does not currently provide please consider
+#	language that Squid does not currently provide please consider
 #	contributing your translation back to the project.
 #	see http://wiki.squid-cache.org/Translations
 #

--- a/tests/root/etc/sysconfig/atd
+++ b/tests/root/etc/sysconfig/atd
@@ -3,7 +3,7 @@
 # -l Specifies  a  limiting  load  factor,  over which batch jobs should not be run, instead of the compile-time
 #    choice of 0.8.  For an SMP system with n CPUs, you will probably want to set this higher than n-1.
 # 
-#  -b Specifiy the minimum interval in seconds between the start of two batch jobs (60 default).
+#  -b Specify the minimum interval in seconds between the start of two batch jobs (60 default).
 
 #example: 
 #OPTS="-l 4 -b 120"

--- a/tests/root/etc/sysconfig/autofs
+++ b/tests/root/etc/sysconfig/autofs
@@ -30,7 +30,7 @@ BROWSE_MODE="yes"
 #
 # Define server URIs
 #
-# LDAP_URI - space seperated list of server uris of the form
+# LDAP_URI - space separated list of server uris of the form
 # 	     <proto>://<server>[/] where <proto> can be ldap
 # 	     or ldaps. The option can be given multiple times.
 # 	     Map entries that include a server name override

--- a/tests/root/etc/sysconfig/hsqldb
+++ b/tests/root/etc/sysconfig/hsqldb
@@ -119,7 +119,7 @@ AUTH_FILE=${HSQLDB_HOME}/sqltool.rc
 # HSQLDB) are as follows:
 #     If [it] is not set, then static methods of all available Java classes
 #     can be accessed as functions in HSQLDB. If the property is set, then
-#     only the list of semicolon seperated method names becomes accessible.
+#     only the list of semicolon separated method names becomes accessible.
 #     An empty property value means no class is accessible.
 # Regardless of the value of hsqldb.method_class_names, methods in
 # org.hsqldb.Library will be accessible.

--- a/tests/root/etc/sysconfig/nfs
+++ b/tests/root/etc/sysconfig/nfs
@@ -18,7 +18,7 @@ MOUNTD_PORT=892
 #RQUOTAD="/usr/sbin/rpc.rquotad"
 # Port rquotad should listen on.
 #RQUOTAD_PORT=875
-# Optinal options passed to rquotad
+# Optional options passed to rquotad
 #RPCRQUOTADOPTS=""
 #
 #

--- a/tests/root/etc/sysconfig/readonly-root
+++ b/tests/root/etc/sysconfig/readonly-root
@@ -13,5 +13,5 @@ RW_OPTIONS=
 STATE_LABEL=stateless-state
 # Where to mount to the persistent data
 STATE_MOUNT=/var/lib/stateless/state
-# Options to use for peristent mount
+# Options to use for persistent mount
 STATE_OPTIONS=

--- a/tests/root/etc/sysconfig/rsyslog
+++ b/tests/root/etc/sysconfig/rsyslog
@@ -1,7 +1,7 @@
 # Options to syslogd
 # -m 0 disables 'MARK' messages.
 # -r enables logging from remote machines
-# -x disables DNS lookups on messages recieved with -r
+# -x disables DNS lookups on messages received with -r
 # See syslogd(8) for more details
 SYSLOGD_OPTIONS="-m 0"
 # Options to klogd

--- a/tests/run.tests
+++ b/tests/run.tests
@@ -16,7 +16,7 @@
 #              of aug_srun
 #   ERRCODE  - one of the error codes defined in enum errcode_t in augeas.h
 #              without the AUG_ prefix, i.e. NOERROR, EMMATCH etc. If ERRCODE
-#              is ommitted, it defaults to NOERROR
+#              is omitted, it defaults to NOERROR
 #   MODULE   - the name of a module that should be loaded before the test
 #   COMMANDS - the commands to hand to aug_srun; can be multiple lines,
 #              which are passed as one string.

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -705,7 +705,7 @@ static void testLoadFile(CuTest *tc) {
     CuAssertIntEquals(tc, AUG_ENOLENS, aug_error(aug));
 
     /* augeas should return without an error when trying to load a
-       nonexistant file that would be handled by a lens */
+       nonexistent file that would be handled by a lens */
     r = aug_load_file(aug, "/etc/mtab");
     CuAssertRetSuccess(tc, r);
     r = aug_match(aug, "/files/etc/mtab", NULL);

--- a/tests/test-save-empty.sh
+++ b/tests/test-save-empty.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Test that we report an error when writing to nonexistant dirs
+# Test that we report an error when writing to nonexistent dirs
 # but that we do create new files correctly
 
 save_hosts() {


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). 

( I fixed also the `man/augtool.1` which might be in dispute, as it's supposed to be re-generated from the .pod. But as it's already hanging around here... )
