### PR TITLE
Make sure we don't load a module but then later can't find it

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -1962,6 +1962,13 @@ static char *module_filename(struct augeas *aug, const char *modname) {
     char *filename = NULL;
     char *name = module_basename(modname);
 
+    /* Module names that contain slashes can fool us into finding and
+     * loading a module in another directory, but once loaded we won't find
+     * it under MODNAME so that we will later try and load it over and
+     * over */
+    if (index(modname, '/') != NULL)
+        goto error;
+
     while ((dir = argz_next(aug->modpathz, aug->nmodpath, dir)) != NULL) {
         int len = strlen(name) + strlen(dir) + 2;
         struct stat st;

--- a/src/transform.c
+++ b/src/transform.c
@@ -800,6 +800,9 @@ int transform_validate(struct augeas *aug, struct tree *xfm) {
     return 0;
  error:
     xfm_error(xfm, aug->error->details);
+    /* We recorded this error in the tree, clear it so that future
+     * operations report this exact same error (against the wrong lens) */
+    reset_error(aug->error);
     return -1;
 }
 


### PR DESCRIPTION
If a module name contains a '/', it can happen that we find the
module (like 'dist/Fstab.lns'), load it and then later can't find it under
the invalid module name containing the slash, leading to an endless loop of
loding the same module over and over again.

We avoid this by making sure there is no '/' in the module name before
looking for the module file. Other forms of invalid module names should not
cause similar problems as we will simply fail to find the corresponding
file.

Fixes https://github.com/hercules-team/augeas/issues/522