### PR TITLE
New command line tool 'augmatch' for grepping through files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ ylwrap
 src/datadir.h
 src/parser.[ch]
 src/lexer.[ch]
+src/augmatch
 src/augtool
 src/augparse
 src/callgrind.*

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@
   - General changes/additions
     * New command 'count' in augtool
     * New function 'not(bool) -> bool' for path expressions
+    * The path expression 'label[. = "value"]' can now be written more
+      concisely as 'label["value"]'
   - API changes
     * libfa has now a function fa_json to export an FA as a JSON file, and
       fa_state_* functions that make it possible to iterate over the FA's

--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,10 @@
     * libfa has now a function fa_json to export an FA as a JSON file, and
       fa_state_* functions that make it possible to iterate over the FA's
       states and transitions. (Pedro Valero Mejia)
+    * Add functions aug_ns_label, aug_ns_value, aug_ns_count, and
+      aug_ns_path to get the label (with index), the value, the number of
+      nodes, and the fully qualified path for nodes stored in a nodeset in
+      a variable efficiently
   - Lens changes/additions
     * Nsswitch: allow comments at the end of a line (Philip Hahn) (Issue #517)
     * Ntp: accept 'ntpsigndsocket' statement (Philip Hahn) (Issue #516)

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 1.10.0 - ????-??-??
   - General changes/additions
+    * New CLI utility 'augmatch' to print the tree for a file and select
+      some of its contents
     * New command 'count' in augtool
     * New function 'not(bool) -> bool' for path expressions
     * The path expression 'label[. = "value"]' can now be written more

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,7 +1,7 @@
 
 EXTRA_DIST=$(wildcard *.pod) $(wildcard *.[0-9])
 
-man1_MANS=augtool.1 augparse.1
+man1_MANS=augtool.1 augparse.1 augmatch.1
 
 %.1: %.pod
 	pod2man -c "Augeas" -r "Augeas $(VERSION)" $< > $@

--- a/man/augmatch.pod
+++ b/man/augmatch.pod
@@ -1,0 +1,119 @@
+=head1 NAME
+
+augmatch - inspect and match contents of configuration files
+
+=head1 SYNOPSIS
+
+augmatch [OPTIONS] FILE
+
+=head1 DESCRIPTION
+
+B<augmatch> prints the tree that Augeas generates by parsing a
+configuration file, or only those parts of the tree that match a certain
+path expression. Parsing is controlled by lenses, many of which ship with
+Augeas. B<augmatch> to select the correct lens for a given file
+automatically unless one is specified with the B<--lens> option.
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<-a>, B<--all>
+
+Print all tree nodes, even ones without an associated value. Without this
+flag, augmatch omits these nodes from the output as they are usually
+uninteresting.
+
+=item B<-e>, B<--exact>
+
+Only print the parts of the tree that exactly match the expression provided
+with B<--match> and not any of the descendants of matching nodes.
+
+=item B<-I>, B<--include>=I<DIR>
+
+Add DIR to the module loadpath. Can be given multiple times. The
+directories set here are searched before any directories specified in the
+AUGEAS_LENS_LIB environment variable, and before the default directories
+F</usr/share/augeas/lenses> and F</usr/share/augeas/lenses/dist>.
+
+=item B<-l>, B<--lens>=I<LENS>
+
+Use LENS for the given file; without this option, B<augmatch> tries to
+guess the lens for the file based on the file's name and path which only
+works for files in standard locations.
+
+=item B<-L>, B<--print-lens>
+
+Print the name of the lens that will be used with the given file and exit.
+
+=item B<-m>, B<--match>=I<EXPR>
+
+Only print the parts of the tree that match the path expression EXPR. All
+nodes that match EXPR and their descendants will be printed. Use L<--exact>
+to print only matching nodes but no descendants.
+
+=item B<-r>, B<--root>=I<ROOT>
+
+Use directory ROOT as the root of the filesystem. Takes precedence over a
+root set with the AUGEAS_ROOT environment variable.
+
+=item B<-S>, B<--nostdinc>
+
+Do not search any of the default directories for lenses. When this option
+is set, only directories specified explicitly with B<-I> or specified in
+B<AUGEAS_LENS_LIB> will be searched for modules.
+
+=item B<-o>, B<--only-value>
+
+Print only the value and not the label or the path of nodes.
+
+=back
+
+=head1 ENVIRONMENT VARIABLES
+
+=over 4
+
+=item B<AUGEAS_ROOT>
+
+The file system root, defaults to '/'. Can be overridden with
+the B<-r> command line option
+
+=item B<AUGEAS_LENS_LIB>
+
+Colon separated list of directories with lenses. Directories specified here
+are searched after any directories set with the B<-I> command line option,
+but before the default directories F</usr/share/augeas/lenses> and
+F</usr/share/augeas/lenses/dist>
+
+=back
+
+=head1 EXAMPLES
+
+  # print the tree for /etc/exports
+  augmatch /etc/exports
+
+  # show only the entry for a specific mount
+  augmatch -m 'dir["/home"]' /etc/exports
+
+  # show all the clients to which we are exporting /home
+  augmatch -eom 'dir["/home"]/client' /etc/exports
+
+=head1 FILES
+
+Lenses and schema definitions in F</usr/share/augeas/lenses> and
+F</usr/share/augeas/lenses/dist>
+
+=head1 AUTHOR
+
+David Lutterkort <lutter@watzmann.net>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright 2007-2018 David Lutterkort
+
+Augeas (and augmatch) are distributed under the GNU Lesser General Public
+License (LGPL)
+
+=head1 SEE ALSO
+
+B<Augeas> project homepage L<http://www.augeas.net/>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,7 @@ DISTCLEANFILES = datadir.h
 lib_LTLIBRARIES = libfa.la libaugeas.la
 noinst_LTLIBRARIES = liblexer.la
 
-bin_PROGRAMS = augtool augparse
+bin_PROGRAMS = augtool augparse augmatch
 
 include_HEADERS = augeas.h fa.h
 
@@ -42,6 +42,9 @@ augtool_LDADD = libaugeas.la $(READLINE_LIBS) $(LIBXML_LIBS) $(GNULIB)
 
 augparse_SOURCES = augparse.c
 augparse_LDADD = libaugeas.la $(LIBXML_LIBS) $(GNULIB)
+
+augmatch_SOURCES = augmatch.c
+augmatch_LDADD = libaugeas.la $(LIBXML_LIBS) $(GNULIB)
 
 libfa_la_SOURCES = fa.c fa.h hash.c hash.h memory.c memory.h ref.h ref.c
 libfa_la_LIBADD = $(LIB_SELINUX) $(GNULIB)

--- a/src/augeas.c
+++ b/src/augeas.c
@@ -2047,6 +2047,91 @@ int aug_ns_attr(const augeas* aug, const char *var, int i,
     return result;
 }
 
+int aug_ns_label(const augeas* aug, const char *var, int i,
+                 const char **label, int *index) {
+    int result = -1;
+
+    if (label != NULL)
+        *label = NULL;
+
+    if (index != NULL)
+        *index = -1;
+
+    api_entry(aug);
+
+    struct tree *tree = pathx_symtab_get_tree(aug->symtab, var, i);
+    ERR_THROW(tree == NULL, aug, AUG_ENOMATCH,
+              "Node %s[%d] does not exist", var, i);
+
+    if (label != NULL)
+        *label = tree->label;
+
+    if (index != NULL) {
+        *index = tree_sibling_index(tree);
+    }
+
+    result = 1;
+
+ error:
+    api_exit(aug);
+    return result;
+}
+
+int aug_ns_value(const augeas* aug, const char *var, int i,
+                 const char **value) {
+    int result = -1;
+
+    if (value != NULL)
+        *value = NULL;
+
+    api_entry(aug);
+
+    struct tree *tree = pathx_symtab_get_tree(aug->symtab, var, i);
+    ERR_THROW(tree == NULL, aug, AUG_ENOMATCH,
+              "Node %s[%d] does not exist", var, i);
+
+    if (value != NULL)
+        *value = tree->value;
+
+    result = 1;
+
+ error:
+    api_exit(aug);
+    return result;
+}
+
+int aug_ns_count(const augeas *aug, const char *var) {
+    int result = -1;
+
+    api_entry(aug);
+
+    result = pathx_symtab_count(aug->symtab, var);
+
+    api_exit(aug);
+
+    return result;
+}
+
+int aug_ns_path(const augeas *aug, const char *var, int i, char **path) {
+    int result = -1;
+
+    *path = NULL;
+
+    api_entry(aug);
+
+    struct tree *tree = pathx_symtab_get_tree(aug->symtab, var, i);
+    ERR_THROW(tree == NULL, aug, AUG_ENOMATCH,
+              "Node %s[%d] does not exist", var, i);
+
+    *path = path_of_tree(tree);
+
+    result = 0;
+
+ error:
+    api_exit(aug);
+    return result;
+}
+
 /*
  * Error reporting API
  */

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -478,7 +478,7 @@ void aug_close(augeas *aug);
 // more wordy notation /descendant::*
 
 /*
- * Function: aug_ns_get
+ * Function: aug_ns_attr
  *
  * Look up the ith node in the variable VAR and retrieve information about
  * it. Set *VALUE to the value of the node, *LABEL to its label, and
@@ -486,20 +486,85 @@ void aug_close(augeas *aug);
  * node does not belong to a file. It is permissible to pass NULL for any
  * of these variables to indicate that the caller is not interested in that
  * attribute.
-
+ *
  * It is assumed that VAR was defined with a path expression evaluating to
  * a nodeset, like '/files/etc/hosts/descendant::*'. This function is
- * equivalent to, but faster than, aug_get(aug, "$VAR[I]", value),
- * respectively the corresponding calls to aug_label and aug_source.
+ * equivalent to, but faster than, aug_get(aug, "$VAR[I+1]", value),
+ * respectively the corresponding calls to aug_label and aug_source. Note
+ * that the index is 0-based, not 1-based.
  *
  * If VAR does not exist, or is not a nodeset, or if it has fewer than I
  * nodes, this call fails.
+ *
+ * The caller is responsible for freeing *FILE_PATH, but must not free
+ * *VALUE or *LABEL. Those pointers are only valid up to the next call to a
+ * function in this API that might modify the tree.
  *
  * Returns:
  * 1 on success (for consistency with aug_get), a negative value on failure
  */
 int aug_ns_attr(const augeas* aug, const char *var, int i,
                 const char **value, const char **label, char **file_path);
+
+/*
+ * Function: aug_ns_label
+ *
+ * Look up the LABEL and its INDEX amongst its siblings for the ith node in
+ * variable VAR. (See aug_ns_attr for details of what is expected of VAR)
+ *
+ * Either of LABEL and INDEX may be NULL. The *INDEX will be set to the
+ * number of siblings + 1 of the node $VAR[I+1] that precede it and have
+ * the same label if there are at least two siblings with that label. If
+ * the node $VAR[I+1] does not have any siblings with the same label as
+ * itself, *INDEX will be set to 0.
+ *
+ * The caller must not free *LABEL. The pointer is only valid up to the
+ * next call to a function in this API that might modify the tree.
+ *
+ * Returns:
+ * 1 on success (for consistency with aug_get), a negative value on failure
+ */
+int aug_ns_label(const augeas *aug, const char *var, int i,
+                 const char **label, int *index);
+
+/*
+ * Function: aug_ns_value
+ *
+ * Look up the VALUE of the ith node in variable VAR. (See aug_ns_attr for
+ * details of what is expected of VAR)
+ *
+ * The caller must not free *VALUE. The pointer is only valid up to the
+ * next call to a function in this API that might modify the tree.
+ *
+ * Returns:
+ * 1 on success (for consistency with aug_get), a negative value on failure
+ */
+int aug_ns_value(const augeas *aug, const char *var, int i,
+                 const char **value);
+
+/*
+ * Function: aug_ns_count
+ *
+ * Return the number of nodes in variable VAR. (See aug_ns_attr for details
+ * of what is expected of VAR)
+ *
+ * Returns: the number of nodes in VAR, or a negative value on failure
+ */
+int aug_ns_count(const augeas *aug, const char *var);
+
+/*
+ * Function: aug_ns_count
+ *
+ * Put the fully qualified path to the ith node in VAR into *PATH. (See
+ * aug_ns_attr for details of what is expected of VAR)
+ *
+ * The caller is responsible for freeing *PATH, which is allocated by this
+ * function.
+ *
+ * Returns: 1 on success (for consistency with aug_get), a negative value
+ * on failure
+ */
+int aug_ns_path(const augeas *aug, const char *var, int i, char **path);
 
 /*
  * Error reporting

--- a/src/augeas_sym.version
+++ b/src/augeas_sym.version
@@ -85,3 +85,11 @@ AUGEAS_0.23.0 {
     global:
       aug_ns_attr;
 } AUGEAS_0.22.0;
+
+AUGEAS_0.24.0 {
+    global:
+      aug_ns_label;
+      aug_ns_value;
+      aug_ns_count;
+      aug_ns_path;
+} AUGEAS_0.23.0;

--- a/src/augmatch.c
+++ b/src/augmatch.c
@@ -1,0 +1,433 @@
+/*
+ * augrp.c: utility for printing and reading files as parsed by Augeas
+ *
+ * Copyright (C) 2007-2016 David Lutterkort
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+ *
+ * Author: David Lutterkort <dlutter@redhat.com>
+ */
+
+#include <config.h>
+#include <argz.h>
+#include <getopt.h>
+#include <stdbool.h>
+#include <ctype.h>
+
+#include "memory.h"
+#include "augeas.h"
+#include <locale.h>
+
+#define cleanup(_x) __attribute__((__cleanup__(_x)))
+
+const char *progname;
+bool print_all = false;
+bool print_only_values = false;
+bool print_exact = false;
+
+static void freep(void *p) {
+    free(*(void **)p);
+}
+
+static void aug_closep(struct augeas **p) {
+    aug_close(*p);
+}
+
+__attribute__((noreturn))
+static void usage(void) {
+    fprintf(stderr, "Usage: %s [OPTIONS] FILE\n", progname);
+    fprintf(stderr,
+"Print the contents of a file as parsed by augeas.\n\n"
+"Options:\n\n"
+"  -l, --lens LENS    use LENS to transform the file\n"
+"  -L, --print-lens   print the lens that will be used for a file an exit\n"
+"  -a, --all          print all nodes, even ones without a value\n"
+"  -m, --match EXPR   start printing where nodes match EXPR\n"
+"  -e, --exact        print only exact matches instead of the entire tree\n"
+"                     starting at a match\n"
+"  -o, --only-value   print only the values of tree nodes, but no path\n"
+"  -r, --root ROOT    use ROOT as the root of the filesystem\n"
+"  -I, --include DIR  search DIR for modules; can be given mutiple times\n"
+"  -S, --nostdinc     do not search the builtin default directories\n"
+"                     for modules\n\n"
+"Examples:\n\n"
+"  Print how augeas sees /etc/exports:\n"
+"    augmatch /etc/exports\n\n"
+"  Show only the entry for a specific mount:\n"
+"    augmatch -m 'dir[\"/home\"]' /etc/exports\n\n"
+"  Show all the clients to which we are exporting /home:\n"
+"    augmatch -eom 'dir[\"/home\"]/client' /etc/exports\n\n");
+    exit(EXIT_SUCCESS);
+}
+
+/* Exit with a failure if COND is true. Use FORMAT and the remaining
+ * arguments like printf to print an error message on stderr before
+ * exiting */
+static void die(bool cond, const char *format, ...) {
+    if (cond) {
+        fputs("error: ", stderr);
+        va_list args;
+        va_start(args, format);
+        vfprintf(stderr, format, args);
+        va_end(args);
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void oom_when(bool cond) {
+    die(cond, "out of memory.\n");
+}
+
+/* Format a string with vasprintf and return it. The caller is responsible
+ * for freeing the result. */
+static char *format(const char *format, ...) {
+  va_list args;
+  char *result;
+  int r;
+
+  va_start(args, format);
+  r = vasprintf(&result, format, args);
+  va_end(args);
+  oom_when(r < 0);
+  return result;
+}
+
+/* Check for an Augeas error. If there is one, print it and all its detail
+ * and exit with failure. If there is no error, do nothing */
+static void check_error(struct augeas *aug) {
+    die(aug == NULL, "could not initialize augeas\n");
+    oom_when(aug_error(aug) == AUG_ENOMEM);
+    if (aug_error(aug) != AUG_NOERROR) {
+        fprintf(stderr, "error: %s\n", aug_error_message(aug));
+        const char *msg = aug_error_minor_message(aug);
+        if (msg != NULL) {
+            fprintf(stderr, "%s\n", msg);
+        }
+        msg = aug_error_details(aug);
+        if (msg != NULL) {
+            fprintf(stderr, "%s\n", msg);
+        }
+        exit(EXIT_FAILURE);
+    }
+}
+
+/* Check for an error trying to load FILE (e.g., a parse error) If there
+ * was one, print details and exit with failure. If there was none, do
+ * nothing. */
+static void check_load_error(struct augeas *aug, const char *file) {
+    char *info = format("/augeas/files%s", file);
+    const char *msg, *line, *col;
+
+    aug_defvar(aug, "info", info);
+    die(aug_ns_count(aug, "info") == 0, "file %s does not exist\n", file);
+
+    aug_defvar(aug, "error", "$info/error");
+    if (aug_ns_count(aug, "error") == 0)
+        return;
+
+    aug_get(aug, "$error", &msg);
+    aug_get(aug, "$error/line", &line);
+    aug_get(aug, "$error/char", &col);
+
+    if (streqv(msg, "parse_failed")) {
+        msg = "parsing failed";
+    } else if (streqv(msg, "read_failed")) {
+        aug_get(aug, "$error/message", &msg);
+    }
+
+    if ((line != NULL) && (col != NULL)) {
+        fprintf(stderr, "error reading %s: %s on line %s, column %s\n",
+                file, msg, line, col);
+    } else {
+        fprintf(stderr, "error reading %s: %s\n", file, msg);
+    }
+    exit(EXIT_FAILURE);
+}
+
+/* We keep track of where we are in the tree when we are printing it by
+ * assigning to augeas variables and using one struct node for each level
+ * in the tree. To keep things simple, we just preallocate a lot of them
+ * (up to max_nodes many). If we ever have a tree deeper than this, we are
+ * in trouble and will simply abort the program. */
+static const size_t max_nodes = 256;
+
+struct node {
+    char *var;         /* The variable where we store the nodes for this level */
+    const char *label; /* The label, index, and value of the current node */
+    int   index;       /* at the level that this struct node is for */
+    const char *value;
+};
+
+/* Print information about NODES[LEVEL] by printing the path to it going
+ * from NODES[0] to NODES[LEVEL]. PREFIX is the path from the start of the
+ * file to the current match (if the user specified --match) or the empty
+ * string (if we are printing the entire file. */
+static void print_one(int level, const char *prefix, struct node *nodes) {
+    if (nodes[level].value == NULL && ! print_all)
+        return;
+
+    if (print_only_values && nodes[level].value != NULL) {
+        printf("%s\n", nodes[level].value);
+        return;
+    }
+
+    if (*prefix) {
+        if (level > 0)
+            printf("%s/", prefix);
+        else
+            printf("%s", prefix);
+    }
+
+    for (int i=1; i <= level; i++) {
+        if (nodes[i].index > 0) {
+            printf("%s[%d]", nodes[i].label, nodes[i].index);
+        } else {
+            printf("%s", nodes[i].label);
+        }
+        if (i < level) {
+            printf("/");
+        }
+    }
+
+    if (nodes[level].value) {
+        printf(" = %s\n", nodes[level].value);
+    } else {
+        printf("\n");
+    }
+}
+
+/* Recursively print the tree starting at NODES[LEVEL] */
+static void print_tree(struct augeas *aug, int level,
+                       const char *prefix, struct node *nodes) {
+    die(level + 1 >= max_nodes,
+        "tree has more than %d levels, which is more than we can handle\n",
+        max_nodes);
+
+    struct node *cur = nodes + level;
+    struct node *next = cur + 1;
+
+    int count = aug_ns_count(aug, cur->var);
+    for (int i=0; i < count; i++) {
+        cleanup(freep) char *pattern = NULL;
+
+        aug_ns_label(aug, cur->var, i, &(cur->label), &(cur->index));
+        aug_ns_value(aug, cur->var, i, &(cur->value));
+        print_one(level, prefix, nodes);
+
+        if (! print_exact) {
+            pattern = format("$%s[%d]/*", cur->var, i+1);
+            aug_defvar(aug, next->var, pattern);
+            check_error(aug);
+            print_tree(aug, level+1, prefix, nodes);
+        }
+    }
+}
+
+/* Print the tree for file PATH (which must already start with /files), but
+ * only the nodes matching MATCH */
+static void print(struct augeas *aug, const char *path, const char *match) {
+    static const char *const match_var = "match";
+
+    cleanup(freep) struct node *nodes = NULL;
+
+    nodes = calloc(max_nodes, sizeof(struct node));
+    oom_when(nodes == NULL);
+
+    aug_set(aug, "/augeas/context", path);
+
+    for (int i=0; i < max_nodes; i++) {
+        nodes[i].var = format("var%d", i);
+    }
+
+    /* Set $match to the nodes matching the user's match expression */
+    aug_defvar(aug, match_var, match);
+    check_error(aug);
+
+    /* Go through the matches in MATCH_VAR one by one. We need to do it
+     * this way, since the prefix we need to print for each entry in
+     * MATCH_VAR is different for each entry. */
+    int count = aug_ns_count(aug, match_var);
+    for (int i=0; i < count; i++) {
+        cleanup(freep) char *prefix = NULL;
+        aug_ns_path(aug, match_var, i, &prefix);
+        aug_defvar(aug, nodes[0].var, prefix);
+        print_tree(aug, 0, prefix + strlen(path) + 1, nodes);
+    }
+}
+
+/* Look at the filename and try to guess based on the extension. The
+ * builtin filters for lenses do not do that, as that would force augtool
+ * to scan everything on start
+ */
+static char *guess_lens_name(const char *file) {
+    const char *ext = strrchr(file, '.');
+
+    if (ext == NULL)
+        return NULL;
+
+    if (streqv(ext, ".json")) {
+        return strdup("Json.lns");
+    } else if (streqv(ext, ".xml")) {
+        return strdup("Xml.lns");
+    }
+
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    int opt;
+    cleanup(aug_closep) struct augeas *aug;
+    cleanup(freep) char *loadpath = NULL;
+    size_t loadpath_len = 0;
+    cleanup(freep) char *root = NULL;
+    cleanup(freep) char *lens = NULL;
+    cleanup(freep) char *matches = NULL;
+    size_t matches_len = 0;
+    const char *match = "*";
+    bool print_lens = false;
+
+    struct option options[] = {
+        { "help",       0, 0, 'h' },
+        { "include",    1, 0, 'I' },
+        { "lens",       1, 0, 'l' },
+        { "all",        0, 0, 'a' },
+        { "index",      0, 0, 'i' },
+        { "match",      1, 0, 'm' },
+        { "only-value", 0, 0, 'o' },
+        { "nostdinc",   0, 0, 'S' },
+        { "root",       1, 0, 'r' },
+        { "print-lens", 0, 0, 'L' },
+        { "exact",      0, 0, 'e' },
+        { 0, 0, 0, 0}
+    };
+    unsigned int flags = AUG_NO_LOAD|AUG_NO_ERR_CLOSE;
+    progname = basename(argv[0]);
+
+    setlocale(LC_ALL, "");
+    while ((opt = getopt_long(argc, argv, "ahI:l:m:oSr:eL", options, NULL)) != -1) {
+        switch(opt) {
+        case 'I':
+            argz_add(&loadpath, &loadpath_len, optarg);
+            break;
+        case 'l':
+            lens = strdup(optarg);
+            break;
+        case 'L':
+            print_lens = true;
+            break;
+        case 'h':
+            usage();
+            break;
+        case 'a':
+            print_all = true;
+            break;
+        case 'm':
+            // If optarg is a numeric string like '1', it is not a legal
+            // part of a path by itself, and so we need to prefix it with
+            // an explicit axis
+            die(optarg[0] == '/',
+                "matches can only be relative paths, not %s\n", optarg);
+            argz_add(&matches, &matches_len, format("child::%s", optarg));
+            break;
+        case 'o':
+            print_only_values = true;
+            break;
+        case 'r':
+            root = strdup(optarg);
+            break;
+        case 'S':
+            flags |= AUG_NO_STDINC;
+            break;
+        case 'e':
+            print_exact = true;
+            break;
+        default:
+            fprintf(stderr, "Try '%s --help' for more information.\n",
+                    progname);
+            exit(EXIT_FAILURE);
+            break;
+        }
+    }
+
+    if (optind >= argc) {
+        fprintf(stderr, "Expected an input file\n");
+        fprintf(stderr, "Try '%s --help' for more information.\n",
+                progname);
+        exit(EXIT_FAILURE);
+    }
+
+    const char *file = argv[optind];
+
+    argz_stringify(loadpath, loadpath_len, ':');
+
+    if (lens == NULL) {
+        lens = guess_lens_name(file);
+    }
+
+    if (lens != NULL) {
+        /* We know which lens we want, we do not need to load all of them */
+        flags |= AUG_NO_MODL_AUTOLOAD;
+    }
+
+    aug = aug_init(root, loadpath, flags|AUG_NO_ERR_CLOSE);
+    check_error(aug);
+
+    if (lens == NULL) {
+        aug_load_file(aug, file);
+    } else {
+        aug_transform(aug, lens, file, false);
+        aug_load(aug);
+    }
+    check_error(aug);
+
+    /* The user just wants the lens name */
+    if (print_lens) {
+        char *info = format("/augeas/files%s", file);
+        const char *lens_name;
+        aug_defvar(aug, "info", info);
+        die(aug_ns_count(aug, "info") == 0,
+            "file %s does not exist\n", file);
+        aug_get(aug, "$info/lens", &lens_name);
+        /* We are being extra careful here - the check_error above would
+           have already aborted the program if we could not determine a
+           lens; dieing here indicates some sort of bug */
+        die(lens_name == NULL, "could not find lens for %s\n",
+            file);
+        if (lens_name[0] == '@')
+            lens_name += 1;
+        printf("%s\n", lens_name);
+        exit(EXIT_SUCCESS);
+    }
+
+    check_load_error(aug, file);
+
+    char *path = format("/files%s", file);
+
+    if (matches_len > 0) {
+        argz_stringify(matches, matches_len, '|');
+        match = matches;
+    }
+
+    print(aug, path, match);
+}
+
+/*
+ * Local variables:
+ *  indent-tabs-mode: nil
+ *  c-indent-level: 4
+ *  c-basic-offset: 4
+ *  tab-width: 4
+ * End:
+ */

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -92,7 +92,7 @@ static struct value *lns_square(struct info *info, struct value *l1,
     assert(l1->tag == V_LENS);
     assert(l2->tag == V_LENS);
     assert(l3->tag == V_LENS);
-    int check = info->error->aug->flags & AUG_TYPE_CHECK;
+    int check = typecheck_p(info);
 
     return lns_make_square(ref(info), ref(l1->lens), ref(l2->lens), ref(l3->lens), check);
 }
@@ -467,7 +467,7 @@ static struct value *lns_check_rec_glue(struct info *info,
                                         struct value *l, struct value *r) {
     assert(l->tag == V_LENS);
     assert(r->tag == V_LENS);
-    int check = info->error->aug->flags & AUG_TYPE_CHECK;
+    int check = typecheck_p(info);
 
     return lns_check_rec(info, l->lens, r->lens, check);
 }

--- a/src/info.c
+++ b/src/info.c
@@ -21,10 +21,13 @@
  */
 
 #include <config.h>
+#include <stdbool.h>
+
 #include "info.h"
 #include "internal.h"
 #include "memory.h"
 #include "ref.h"
+#include "errcode.h"
 
 /*
  * struct string
@@ -109,6 +112,10 @@ void print_info(FILE *out, struct info *info) {
                     info->last_line, info->last_column);
         }
     }
+}
+
+bool typecheck_p(const struct info *info) {
+    return (info->error->aug->flags & AUG_TYPE_CHECK) != 0;
 }
 
 void free_info(struct info *info) {

--- a/src/info.h
+++ b/src/info.h
@@ -68,6 +68,10 @@ char *format_info(struct info *info);
 
 void print_info(FILE *out, struct info *info);
 
+/* Return true if typechecking is turned on. (This uses the somewhat gross
+ * fact that we can get at the augeas flags through error->aug) */
+bool typecheck_p(const struct info *info);
+
 /* Do not call directly, use UNREF instead */
 void free_info(struct info *info);
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -334,14 +334,10 @@ int __aug_close_memstream(struct memstream *ms) {
     return 0;
 }
 
-char *path_expand(struct tree *tree, const char *ppath) {
+int tree_sibling_index(struct tree *tree) {
     struct tree *siblings = tree->parent->children;
 
-    char *path;
-    const char *label;
-    char *escaped = NULL;
-
-    int cnt = 0, ind = 0, r;
+    int cnt = 0, ind = 0;
 
     list_for_each(t, siblings) {
         if (streqv(t->label, tree->label)) {
@@ -350,6 +346,21 @@ char *path_expand(struct tree *tree, const char *ppath) {
                 ind = cnt;
         }
     }
+
+    if (cnt > 1) {
+        return ind;
+    } else {
+        return 0;
+    }
+}
+
+char *path_expand(struct tree *tree, const char *ppath) {
+    char *path;
+    const char *label;
+    char *escaped = NULL;
+    int r;
+
+    int ind = tree_sibling_index(tree);
 
     if (ppath == NULL)
         ppath = "";
@@ -366,7 +377,7 @@ char *path_expand(struct tree *tree, const char *ppath) {
     if (escaped != NULL)
         label = escaped;
 
-    if (cnt > 1) {
+    if (ind > 0) {
         r = asprintf(&path, "%s/%s[%d]", ppath, label, ind);
     } else {
         r = asprintf(&path, "%s/%s", ppath, label);

--- a/src/internal.h
+++ b/src/internal.h
@@ -463,6 +463,9 @@ int tree_insert(struct pathx *p, const char *label, int before);
 int free_tree(struct tree *tree);
 int dump_tree(FILE *out, struct tree *tree);
 int tree_equal(const struct tree *t1, const struct tree *t2);
+/* Return the 1-based index of TREE amongst its siblings with the same
+ * label or 0 if none of TREE's siblings have the same label */
+int tree_sibling_index(struct tree *tree);
 char *path_expand(struct tree *tree, const char *ppath);
 char *path_of_tree(struct tree *tree);
 /* Clear the dirty flag in the whole TREE */

--- a/src/internal.h
+++ b/src/internal.h
@@ -629,6 +629,11 @@ int pathx_symtab_assign_tree(struct pathx_symtab **symtab, const char *name,
 int pathx_symtab_undefine(struct pathx_symtab **symtab, const char *name);
 void pathx_symtab_remove_descendants(struct pathx_symtab *symtab,
                                      const struct tree *tree);
+
+/* Return the number of nodes in the nodeset NAME. If the variable NAME
+ * does not exist, or is not a nodeset, return -1 */
+int pathx_symtab_count(const struct pathx_symtab *symtab, const char *name);
+
 /* Return the tree stored in the variable NAME at position I, which is the
    same as evaluating the path expression '$NAME[I]'. If the variable NAME
    does not exist, or does not contain a nodeset, or if I is bigger than

--- a/src/lens.c
+++ b/src/lens.c
@@ -572,25 +572,27 @@ struct value *lns_make_prim(enum lens_tag tag, struct info *info,
 
     /* Typecheck */
     if (tag == L_KEY) {
-        exn = str_to_fa(info, "(.|\n)*/(.|\n)*", &fa_slash, regexp->nocase);
-        if (exn != NULL)
-            goto error;
+        if (typecheck_p(info)) {
+            exn = str_to_fa(info, "(.|\n)*/(.|\n)*", &fa_slash, regexp->nocase);
+            if (exn != NULL)
+                goto error;
 
-        exn = regexp_to_fa(regexp, &fa_key);
-        if (exn != NULL)
-            goto error;
+            exn = regexp_to_fa(regexp, &fa_key);
+            if (exn != NULL)
+                goto error;
 
-        fa_isect = fa_intersect(fa_slash, fa_key);
-        if (! fa_is_basic(fa_isect, FA_EMPTY)) {
-            exn = make_exn_value(info,
-                                 "The key regexp /%s/ matches a '/'",
-                                 regexp->pattern->str);
-            goto error;
+            fa_isect = fa_intersect(fa_slash, fa_key);
+            if (! fa_is_basic(fa_isect, FA_EMPTY)) {
+                exn = make_exn_value(info,
+                    "The key regexp /%s/ matches a '/'",
+                    regexp->pattern->str);
+                goto error;
+            }
+            fa_free(fa_isect);
+            fa_free(fa_key);
+            fa_free(fa_slash);
+            fa_isect = fa_key = fa_slash = NULL;
         }
-        fa_free(fa_isect);
-        fa_free(fa_key);
-        fa_free(fa_slash);
-        fa_isect = fa_key = fa_slash = NULL;
     } else if (tag == L_LABEL) {
         if (strchr(string->str, SEP) != NULL) {
             exn = make_exn_value(info,

--- a/src/pathx.c
+++ b/src/pathx.c
@@ -1153,6 +1153,8 @@ static bool eval_pred(struct expr *expr, struct state *state) {
         return (state->ctx_pos == v->number);
     case T_NODESET:
         return v->nodeset->used > 0;
+    case T_STRING:
+        return streqv(state->ctx->value, v->string);
     default:
         assert(0);
         return false;
@@ -1434,7 +1436,7 @@ static void check_preds(struct pred *pred, struct state *state) {
         check_expr(e, state);
         RET_ON_ERROR;
         if (e->type != T_NODESET && e->type != T_NUMBER &&
-            e->type != T_BOOLEAN) {
+            e->type != T_BOOLEAN && e->type != T_STRING) {
             STATE_ERROR(state, PATHX_ETYPE);
             return;
         }

--- a/src/pathx.c
+++ b/src/pathx.c
@@ -1377,7 +1377,7 @@ static void eval_filter(struct expr *expr, struct state *state) {
 }
 
 static struct value *lookup_var(const char *ident,
-                                struct pathx_symtab *symtab) {
+                                const struct pathx_symtab *symtab) {
     list_for_each(tab, symtab) {
         if (STREQ(ident, tab->name))
             return tab->value;
@@ -3031,6 +3031,16 @@ int pathx_symtab_assign_tree(struct pathx_symtab **symtab,
     release_value(v);
     free(v);
     return -1;
+}
+
+int
+pathx_symtab_count(const struct pathx_symtab *symtab, const char *name) {
+    struct value *v = lookup_var(name, symtab);
+
+    if (v == NULL || v->tag != T_NODESET)
+        return -1;
+
+    return v->nodeset->used;
 }
 
 struct tree *


### PR DESCRIPTION
### Trying it out

There's a self-contained [static build](http://download.augeas.net/tmp/augmatch.tar.gz) with `augmatch`, lenses, and a sample root that will work on x86_64 Linux machines. After downloading and untarring, simply run `<dir>/augmatch`.

A container containing `augmatch` is also available on Docker Hub via `docker pull lutter/augmatch`. Running the container will put you into a shell with `augmatch` already set up.

### What it does

Augeas so far has been very focused on making changes to configuration files, and making them safely. A side effect of how Augeas does what it does is that it provides a lot of structure for the files it parses. While it has always been possible to use that structure to query files via `augtool`, `augtool` is not really specialized for that use and makes it awkward for simple querying. The new command `augmatch` is tailored to this use. At its simplest, it just prints out the way it sees files:

```
    > augmatch /etc/passwd
    root/password = x
    root/uid = 0
    root/gid = 0
    root/name = root
    root/home = /root
    root/shell = /bin/bash
    bin/password = x
    bin/uid = 1
    bin/gid = 1
    bin/name = bin
    bin/home = /bin
    bin/shell = /sbin/nologin
    ...
```

It also makes it easy to focus on a specific user, or a specific field:

```
    > augmatch --match root /etc/passwd
    root/password = x
    root/uid = 0
    root/gid = 0
    root/name = root
    root/home = /root
    root/shell = /bin/bash

    > augmatch --match root/shell /etc/passwd
    root/shell = /bin/bash
```

That can also be used to print all the shells in use on a system:

```
    > augmatch --match */shell /etc/passwd
    root/shell = /bin/bash
    bin/shell = /sbin/nologin
```

If we are only interested in the shells themselves, we can use the `--only-value` to drop the tree paths:

```
    > augmatch --only-value --match */shell /etc/passwd
    /bin/bash
    /sbin/nologin
    ...
```

We have now successfully replicated `cut -d : -f 7 /etc/passwd` ! What makes this worthwhile is that these things also work with files that are a little more complicated to deal with, like `/etc/exports`:

```
    > augmatch /etc/exports
    dir[1] = /local
    dir[1]/client = 207.46.0.0/16
    dir[1]/client/option[1] = rw
    dir[1]/client/option[2] = sync
    ...
```

We can now do something that's quite a bit more awkward with standard shell tools, like list all the clients to which we export any filesystem with

```
    > augmatch --only-value --exact --match dir/client /etc/exports
    207.46.0.0/16
    207.46.0.0/16
    192.168.50.2/32
    207.46.0.0/16
    *

    # Do the same, but only for one export
    > augmatch -eom dir["/home"]/client /etc/exports
    207.46.0.0/16
    192.168.50.2/32
```

Similarly, we can easily generate a line-by-line list of all the environment variables accepted in our `sshd_config`, again, something that's a little more complicated with standard shell tools:

```
    > augmatch --only-value --match AcceptEnv /etc/ssh/sshd_config
    LANG
    LC_CTYPE
    LC_NUMERIC
    ...
```

Finally, `augmatch` does not get confused by entries in comments, for example to find what `PermitRootLogin` is set to in our `sshd_config`:

```
    > grep PermitRootLogin /etc/ssh/sshd_config
    PermitRootLogin yes
    # the setting of "PermitRootLogin without-password".

    > grep -v '#' /etc/ssh/sshd_config | grep PermitRootLogin | cut -d ' ' -f 2
    yes

    > augmatch -o -m PermitRootLogin /etc/ssh/sshd_config
    yes
```
