### PR TITLE
httpd: include  /etc/httpd/conf.modules.d

### DIFF
--- a/lenses/httpd.aug
+++ b/lenses/httpd.aug
@@ -200,6 +200,7 @@ let filter = (incl "/etc/apache2/apache2.conf") .
              (incl "/etc/httpd/conf.d/*.conf") .
              (incl "/etc/httpd/httpd.conf") .
              (incl "/etc/httpd/conf/httpd.conf") .
+             (incl "/etc/httpd/conf.modules.d/*.conf") .
              Util.stdexcl
 
 let xfm = transform lns filter


### PR DESCRIPTION
Fedora/RHEL uses this directory for modules config.