### PR TITLE
Cleaner error message on regex /

### DIFF
--- a/src/lens.c
+++ b/src/lens.c
@@ -583,7 +583,7 @@ typecheck_prim(enum lens_tag tag, struct info *info,
         fa_isect = fa_intersect(fa_slash, fa_key);
         if (! fa_is_basic(fa_isect, FA_EMPTY)) {
             exn = make_exn_value(info,
-                  "The key regexp /%s/ matches a '/'", regexp->pattern->str);
+                  "The key regexp /%s/ matches a '/' which is used to separate nodes.", regexp->pattern->str);
             goto error;
         }
         fa_free(fa_isect);


### PR DESCRIPTION
Since a key can't have an '/' in it due to use as a value seperator for tree elements, I've added that to the error message so folks are fully aware.