### PR TITLE
Fstab: allow leading whitespace in lines with spec

### DIFF
--- a/lenses/fstab.aug
+++ b/lenses/fstab.aug
@@ -23,6 +23,7 @@ module Fstab =
          Build.opt_list lns comma
 
   let record = [ seq "mntent" .
+                   Util.indent .
                    [ label "spec" . store spec ] . sep_tab .
                    [ label "file" . store file ] . sep_tab .
                    comma_sep_list "vfstype" .

--- a/lenses/tests/test_fstab.aug
+++ b/lenses/tests/test_fstab.aug
@@ -11,6 +11,8 @@ module Test_fstab =
         { "dump" = "1" }
         { "passno" = "1" } }
 
+  let leading_ws = "   /dev/vg00/lv00\t /\t ext3\t    defaults        1 1\n"
+
   let trailing_ws = "/dev/vg00/lv00\t /\t ext3\t    defaults        1 1  \t\n"
 
   let gen_no_passno(passno:string) =
@@ -59,6 +61,8 @@ module Test_fstab =
         { "passno" = "0" } }
 
   test Fstab.lns get simple = simple_tree
+
+  test Fstab.lns get leading_ws = simple_tree
 
   test Fstab.lns get trailing_ws = simple_tree
 


### PR DESCRIPTION
The documentation does not explicitly mention this possibility, but tooling that parses `fstab` actually supports this: hence, allow leading whitespace in lines with filesystem specification.