### PR TITLE
Fix parsing of append / prepend / default / supersede statements

### DIFF
--- a/lenses/dhclient.aug
+++ b/lenses/dhclient.aug
@@ -93,19 +93,23 @@ let stmt_array        = [ key stmt_array_re
 let stmt_hash_re      = "send"
                       | "option"
 
-let stmt_hash         = [ key stmt_hash_re
-                        . sep_spc
-                        . ( [ key word . sep_spc . sto_to_spc_noeval ]
+let stmt_args         = ( [ key word . sep_spc . sto_to_spc_noeval ]
                           | [ key word . sep_spc . (rfc_code|eval) ] )
                         . sep_scl
-                        . comment_or_eol ]
+                        . comment_or_eol
+
+let stmt_hash         = [ key stmt_hash_re
+                        . sep_spc
+                        . stmt_args ]
 
 let stmt_opt_mod_re   = "append"
                       | "prepend"
                       | "default"
                       | "supersede"
 
-let stmt_opt_mod      = [ key stmt_opt_mod_re . sep_spc . stmt_hash ]
+let stmt_opt_mod      = [ key stmt_opt_mod_re
+                        . sep_spc
+                        . stmt_args ]
 
 (************************************************************************
  *                         BLOCK STATEMENTS

--- a/lenses/tests/test_dhclient.aug
+++ b/lenses/tests/test_dhclient.aug
@@ -133,15 +133,13 @@ lease {
                { "second"  = "01" } } }
 
 
-test Dhclient.lns get "append option domain-name-servers 127.0.0.1;\n" =
+test Dhclient.lns get "append domain-name-servers 127.0.0.1;\n" =
     { "append"
-        { "option"
-            { "domain-name-servers" = "127.0.0.1" }
-        }
+        { "domain-name-servers" = "127.0.0.1" }
     }
 
-test Dhclient.lns put "" after set "/prepend/option/domain-name-servers" "127.0.0.1" = 
-    "prepend option domain-name-servers 127.0.0.1;\n"
+test Dhclient.lns put "" after set "/prepend/domain-name-servers" "127.0.0.1" =
+    "prepend domain-name-servers 127.0.0.1;\n"
 
 (* When = is used before the value, it's an evaluated string, see dhcp-eval *)
 test Dhclient.lns get "send dhcp-client-identifier = hardware;\n" =


### PR DESCRIPTION
#96 added support for append/prepend/default/supersede statements, but reused `stmt_hash`, which includes `stmt_hash_re` in its matching.

This means the lens requires one of the keywords `send` or `option` as the first argument to these statements:

```prepend option domain-name-servers 127.0.0.1;```

instead of the [correct syntax](https://www.isc.org/wp-content/uploads/2017/08/dhcp41clientconf.html), which does not allow them:

```prepend domain-name-servers 127.0.0.1;```