### PR TITLE
Systemd: explicitly exclude *.d and *.wants directories

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 1.11.0 - ????-??-??
   - Lens changes/additions
     * Chrony: add new options supported in chrony 3.2 and 3.3 (Miroslav Lichvar)
+    * Systemd: do not try to treat *.d or *.wants directories as
+               configuration files (Issue #548)
 
 1.10.1 - 2018-01-29
   - API changes

--- a/lenses/systemd.aug
+++ b/lenses/systemd.aug
@@ -172,6 +172,10 @@ let filter = incl "/lib/systemd/system/*"
            . incl "/etc/systemd/system/*/*"
            . incl "/etc/systemd/logind.conf"
            . incl "/etc/sysconfig/*.systemd"
+           . excl "/lib/systemd/system/*.d"
+           . excl "/etc/systemd/system/*.d"
+           . excl "/lib/systemd/system/*.wants"
+           . excl "/etc/systemd/system/*.wants"
            . Util.stdexcl
 
 let xfm = transform lns filter


### PR DESCRIPTION
We used to get confused when writing back systemd changes and tried to
write a whole *.d or *.wants directory as one file, which would fail. By
explicitly not matching them, we make sure that we write to the files in
those directories, not the directories themselves.

Fixes https://github.com/hercules-team/augeas/issues/548