### PR TITLE
Fix several memory leaks in augmatch

### DIFF
--- a/src/augmatch.c
+++ b/src/augmatch.c
@@ -131,6 +131,7 @@ static void check_load_error(struct augeas *aug, const char *file) {
     const char *msg, *line, *col;
 
     aug_defvar(aug, "info", info);
+    free(info);
     die(aug_ns_count(aug, "info") == 0, "file %s does not exist\n", file);
 
     aug_defvar(aug, "error", "$info/error");
@@ -240,7 +241,7 @@ static void print_tree(struct augeas *aug, int level,
 static void print(struct augeas *aug, const char *path, const char *match) {
     static const char *const match_var = "match";
 
-    cleanup(freep) struct node *nodes = NULL;
+    struct node *nodes = NULL;
 
     nodes = calloc(max_nodes, sizeof(struct node));
     oom_when(nodes == NULL);
@@ -265,6 +266,10 @@ static void print(struct augeas *aug, const char *path, const char *match) {
         aug_defvar(aug, nodes[0].var, prefix);
         print_tree(aug, 0, prefix + strlen(path) + 1, nodes);
     }
+    for (int i=0; i < max_nodes; i++) {
+        free(nodes[i].var);
+    }
+    free(nodes);
 }
 
 /* Look at the filename and try to guess based on the extension. The
@@ -421,6 +426,7 @@ int main(int argc, char **argv) {
     }
 
     print(aug, path, match);
+    free(path);
 }
 
 /*


### PR DESCRIPTION
Fix memory leaks like following
```
# valgrind --leak-check=summary src/.libs/augmatch /etc/hosts
==18340==
==18340== HEAP SUMMARY:
==18340==     in use at exit: 1,723 bytes in 258 blocks
==18340==   total heap usage: 2,005,764 allocs, 2,005,506 frees, 185,784,857 bytes allocated
==18340==
==18340== LEAK SUMMARY:
==18340==    definitely lost: 1,723 bytes in 258 blocks
==18340==    indirectly lost: 0 bytes in 0 blocks
==18340==      possibly lost: 0 bytes in 0 blocks
==18340==    still reachable: 0 bytes in 0 blocks
==18340==         suppressed: 0 bytes in 0 blocks
==18340== Rerun with --leak-check=full to see details of leaked memory
==18340==
==18340== For counts of detected and suppressed errors, rerun with: -v
==18340== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```