### PR TITLE
Json: allow escaped slashes in strings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 1.11.0 - ????-??-??
   - Lens changes/additions
     * Chrony: add new options supported in chrony 3.2 and 3.3 (Miroslav Lichvar)
+    * Json: allow escaped slashes in strings (Issue #557)
     * Systemd: do not try to treat *.d or *.wants directories as
                configuration files (Issue #548)
 

--- a/lenses/json.aug
+++ b/lenses/json.aug
@@ -23,7 +23,10 @@ let rbrace = Util.del_str "}"
 let lbrack = Util.del_str "[" . comments
 let rbrack = Util.del_str "]"
 
-let str_store = Quote.dquote . store /([^\\\\"]|\\\\("|n|r|t|\\\\))*/ . Quote.dquote  (* " Emacs, relax *)
+(* This follows the definition of 'string' at https://www.json.org/
+   It's a little wider than what's allowed there as it would accept
+   nonsensical \u escapes *)
+let str_store = Quote.dquote . store /([^\\"]|\\\\["\/bfnrtu\\])*/ . Quote.dquote
 
 let number = [ label "number" . store /-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?/
              . comments ]

--- a/lenses/tests/test_json.aug
+++ b/lenses/tests/test_json.aug
@@ -494,3 +494,19 @@ test lns get "{ \"filesystem\": \"ext3\\\" \\\\ \t \r\n SEC_TYPE=\\\"ext2\" }\n"
     { "entry" = "filesystem"
       { "string" = "ext3\\\" \\\\ \t \r\n SEC_TYPE=\\\"ext2" } }
     {  } }
+
+test Json.str get "\"\\\"\"" = { "string" = "\\\"" }
+
+test Json.str get "\"\\\"" = *
+
+test Json.str get "\"\"\"" = *
+
+test Json.str get "\"\\u1234\"" = { "string" = "\u1234" }
+
+(* Allow spurious backslashes; Issue #557 *)
+test Json.str get "\"\\/\"" = { "string" = "\\/" }
+
+test lns get "{ \"download-dir\": \"\\/var\\/tmp\\/\" }" =
+  { "dict"
+    { "entry" = "download-dir"
+      { "string" = "\/var\/tmp\/" } } }


### PR DESCRIPTION
According to https://www.json.org/, a string like "\/" is legal in Json.

Fixes https://github.com/hercules-team/augeas/issues/557