### PR TITLE
Grub: tolerate some invalid entries

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 1.11.0 - ????-??-??
   - Lens changes/additions
     * Chrony: add new options supported in chrony 3.2 and 3.3 (Miroslav Lichvar)
+    * Grub: tolerate some invalid entries. Those invalid entries
+            get mapped to '#error' nodes
     * Json: allow escaped slashes in strings (Issue #557)
     * Nginx: parse /etc/nginx/sites-enabled (plumbeo)
     * Systemd: do not try to treat *.d or *.wants directories as

--- a/lenses/tests/test_grub.aug
+++ b/lenses/tests/test_grub.aug
@@ -257,3 +257,28 @@ password --encrypted ^9^32kwzzX./3WISQ0C /boot/grub/custom.lst
     { "password" = "secret"
       { "md5" }
     } }
+
+  (* Test parsing of invalid entries via menu_error *)
+  test Grub.lns get "default=0\ncrud=no\n" =
+  { "default" = "0" }
+  { "#error" = "crud=no" }
+
+  (* We handle some pretty bizarre bad syntax *)
+  test Grub.lns get "default=0
+crud no
+valid:nope
+nonsense  =   yes
+bad arg1 arg2 arg3=v\n" =
+  { "default" = "0" }
+  { "#error" = "crud no" }
+  { "#error" = "valid:nope" }
+  { "#error" = "nonsense  =   yes" }
+  { "#error" = "bad arg1 arg2 arg3=v" }
+
+  (* Test parsing of invalid entries via boot_error *)
+  test Grub.lns get "title test
+    root (hd0,0)
+    crud foo\n" =
+  { "title" = "test"
+    { "root" = "(hd0,0)" }
+    { "#error" = "crud foo" } }


### PR DESCRIPTION
Refusing to parse an entire file because of invalid entries is too
harsh. Try to make the behavior a little friendlier by just mapping invalid
entries to '#error' nodes but still parsing the rest of the file.