### PR TITLE
Nginx: allow semicolons inside double quoted strings in simple direct…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,9 @@
     * Multipath: accept regular expressions for devnode, wwid, and property
       in blacklist and blacklist_exceptions sections (Issue #564)
     * Nginx: parse /etc/nginx/sites-enabled (plumbeo)
+             allow semicolons inside double quoted strings in
+             simple directives, and allow simple directives without
+             an argument (Issue #566)
     * Rsyslog: support include() directive introduced in rsyslog 8.33
     * Systemd: do not try to treat *.d or *.wants directories as
                configuration files (Issue #548)

--- a/lenses/nginx.aug
+++ b/lenses/nginx.aug
@@ -47,8 +47,11 @@ let block_re_all = block_re | "if" | "location" | "geo" | "map"
 let simple =
      let kw = word - block_re_all
   in let mask = [ label "mask" . Util.del_str "/" . store Rx.integer ]
-  in let sto = store /[^ \t\n;][^;]*/ . Sep.semicolon
-  in [ Util.indent . key kw . mask? . Sep.space . sto . (Util.eol|Util.comment_eol) ]
+  in let sto = store /[^ \t\n;#]([^";#]|"[^"]*\")*/
+  in [ Util.indent .
+       key kw . mask? .
+       (Sep.space . sto)? . Sep.semicolon .
+       (Util.eol|Util.comment_eol) ]
 
 (* View: server
      A simple server entry *)

--- a/lenses/tests/test_nginx.aug
+++ b/lenses/tests/test_nginx.aug
@@ -275,3 +275,16 @@ test lns get "http {
       { "::1" = "2" }
       { "2001:0db8::" = "1"
         { "mask" = "32" } } } }
+
+test lns get "add_header X-XSS-Protection \"1; mode=block\" always;\n" =
+  { "add_header" = "X-XSS-Protection \"1; mode=block\" always" }
+
+test lns get "location /foo {
+  root /var/www/html;
+  internal;  # only valid in location blocks
+}\n" =
+  { "location"
+    { "#uri" = "/foo" }
+    { "root" = "/var/www/html" }
+    { "internal"
+      { "#comment" = "only valid in location blocks" } } }


### PR DESCRIPTION
…ives

The 'argument' to a simple directive can now be made up of any number of
bare words (not containing quotes) and quoted strings. Semicolons are
allowed within quoted strings.

Fixes https://github.com/hercules-team/augeas/issues/566