### PR TITLE
augtool: fix access to invalid memory

### DIFF
--- a/src/augtool.c
+++ b/src/augtool.c
@@ -152,15 +152,13 @@ static char *readline_path_generator(const char *text, int state) {
 
             /* strip off context if the user didn't give it */
             if (ctx != NULL) {
-                char *c = realloc(child, strlen(child)-strlen(ctx)+1);
-                if (c == NULL) {
-                    free(child);
-                    return NULL;
-                }
                 int ctxidx = strlen(ctx);
                 if (child[ctxidx] == SEP)
                     ctxidx++;
-                strcpy(c, &child[ctxidx]);
+                char *c = strdup(&child[ctxidx]);
+                free(child);
+                if (c == NULL)
+                    return NULL;
                 child = c;
             }
 


### PR DESCRIPTION
When stripping the context from the result, `readline_path_generator` used to realloc the string to a shorter size, copying only the content after the prefix.  This resulted in reading with `strcpy` from the previous memory, which is freed already.  Avoid the issue, and simplify the code by using `strdup`, freeing the old string.

This issue could be reproduced in `augtool`, trying to autocomplete files without the `/files` prefix, e.g.:
``
augtool> ls <TAB><TAB>
``