### PR TITLE
fa: check result of fopen

### DIFF
--- a/src/fa.c
+++ b/src/fa.c
@@ -286,6 +286,11 @@ static void fa_dot_debug(struct fa *fa, const char *tag) {
         return;
 
     fp = fopen(fname, "w");
+    if (fp == NULL) {
+        free(fname);
+        return;
+    }
+
     fa_dot(fp, fa);
     fclose(fp);
     free(fname);


### PR DESCRIPTION
Return earlier if `fopen` fails, otherwise `fa_dot` will dereference a null pointer.