### PR TITLE
Replace pure function invocations in path expressions with their result

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@
   - General changes/additions
     * augmatch: add a --quiet option; make the exit status useful to tell
                 whether there was a match or not
+    * Drastically reduce the amount of memory needed to evaluate complex
+      path expressions against large files (Issue #569)
   - API changes
     * aug_source did not in fact return the source; and always returned
       NULL for that. That has been fixed.


### PR DESCRIPTION
In path expressions, we generally need to evaluate functions against every
node that we consider for the result set. For example, in the path
expression /files/etc/hosts/*[ipaddr =~ regexp('127\\.')], the regexp
function was evaluated against every entry in /etc/hosts. Evaluating that
function requires the construction and compilation of a new regexp. Because
of how memory is managed during evaluation of path expressions, the memory
used by all these copies of the same regexp is only freed after we are done
evaluating the path expression. This causes unacceptable memory usage in
large files (see https://github.com/hercules-team/augeas/issues/569)

To avoid these issues, we now distinguish between pure and impure functions
in the path expression interpreter. When we encounter a pure function, we
change the AST for the path expression so that the function invocation is
replaced with the result of invoking the function. With the example above,
that means we only construct and compile the regexp '127\\.' once,
regardless of how many nodes it gets checked against. That leads to a
dramatic reduction in the memory required to evaluate path expressions with
such constructs against large files.

Fixes https://github.com/hercules-team/augeas/issues/569