### PR TITLE
Httpd: accept whitespace comment after tag opening a section

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,8 @@
                 (John Morrissey)
     * Grub: tolerate some invalid entries. Those invalid entries
             get mapped to '#error' nodes
+    * Httpd: accept comments with whitespace right after a tag
+             opening a section (Issue #577)
     * Json: allow escaped slashes in strings (Issue #557)
     * Multipath: accept regular expressions for devnode, wwid, and property
       in blacklist and blacklist_exceptions sections (Issue #564)

--- a/lenses/httpd.aug
+++ b/lenses/httpd.aug
@@ -171,7 +171,7 @@ let arg_sec = [ label "arg" . store (char_arg_sec+|comp|dquot|squot) ]
 
 let section (body:lens) =
     (* opt_eol includes empty lines *)
-    let opt_eol = del /([ \t]*#?\r?\n)*/ "\n" in
+    let opt_eol = del /([ \t]*#?[ \t]*\r?\n)*/ "\n" in
     let inner = (sep_spc . argv arg_sec)? . sep_osp .
              dels ">" . opt_eol . ((body|comment) . (body|empty|comment)*)? .
              indent . dels "</" in

--- a/lenses/tests/test_httpd.aug
+++ b/lenses/tests/test_httpd.aug
@@ -627,3 +627,22 @@ test Httpd.directive get
     { "arg" = "X-Forwarded-Proto" }
     { "arg" = "https" }
     { "arg" = "expr=(%{HTTP:CF-Visitor}='{\"scheme\":\"https\"}')" } }
+
+(* Issue #577: we make the newline starting a section optional, including
+   an empty comment at the end of the line. This used to miss empty comments
+   with whitespace *)
+test Httpd.lns get "<If cond>#\n</If>\n" = { "If" { "arg" = "cond" } }
+
+test Httpd.lns get "<If cond># \n</If>\n" = { "If" { "arg" = "cond" } }
+
+test Httpd.lns get "<If cond>\n# \n</If>\n" =  { "If" { "arg" = "cond" } }
+
+test Httpd.lns get "<If cond># text\n</If>\n" =
+  { "If"
+    { "arg" = "cond" }
+    { "#comment" = "text" } }
+
+test Httpd.lns get "<If cond>\n\t# text\n</If>\n" =
+  { "If"
+    { "arg" = "cond" }
+    { "#comment" = "text" } }


### PR DESCRIPTION
We used to only deal with completely empty comments after a tag opening a
section, for example '<If cond>#\n', but not with a comment that consisted
only of whitespace like '<If cond># \n'. We now accept both cases,
resulting in the same tree.

Fixes https://github.com/hercules-team/augeas/issues/577