### PR TITLE
Multipath: accept values enclosed in quotes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+1.12.0 - ????-??-??
+  - Lens changes/additions
+    * Multipath: accept values enclosed in quotes (Issue #583)
+
 1.11.0 - 2018-08-24
   - General changes/additions
     * augmatch: add a --quiet option; make the exit status useful to tell

--- a/lenses/multipath.aug
+++ b/lenses/multipath.aug
@@ -15,13 +15,16 @@ let indent = del /[ \t]*/ ""
 let obr = del /\{([ \t]*)\n/ "{\n"
 let cbr = del /[ \t]*}[ \t]*\n/ "}\n"
 
+(* Like Rx.fspath, but we disallow quotes at the beginning or end *)
+let fspath = /[^" \t\n]|[^" \t\n][^ \t\n]*[^" \t\n]/
+
 let ikey (k:regexp) = indent . key k
 
 let section (n:regexp) (b:lens) =
   [ ikey n . ws . obr . (b|empty|comment)* . cbr ]
 
 let kv (k:regexp) (v:regexp) =
-  [ ikey k . ws . store v . eol ]
+  [ ikey k . ws . del /"?/ "" . store v . del /"?/ "" . eol ]
 
 (* FIXME: it would be much more concise to write                       *)
 (* [ key k . ws . (bare | quoted) ]                                    *)
@@ -56,7 +59,7 @@ let common_setting =
   |qstr /(getuid|prio)_callout/
   (* Settings not documented in `man multipath.conf` *)
   |kv /rr_min_io_rq/ Rx.integer
-  |kv "udev_dir" Rx.fspath
+  |kv "udev_dir" fspath
   |qstr "selector"
   |kv "async_timeout" Rx.integer
   |kv "pg_timeout" Rx.word
@@ -69,7 +72,7 @@ let default_setting =
    common_setting
   |kv "polling_interval" Rx.integer
   |kv "max_polling_interval" Rx.integer
-  |kv "multipath_dir" Rx.fspath
+  |kv "multipath_dir" fspath
   |kv "find_multipaths" /yes|no/
   |kv "verbosity" /[0-6]/
   |kv "reassign_maps" /yes|no/
@@ -79,14 +82,14 @@ let default_setting =
   |kv "fast_io_fail_tmo" (Rx.integer|"off")
   |kv "dev_loss_tmo" (Rx.integer|"infinity")
   |kv "queue_without_daemon" /yes|no/
-  |kv "bindings_file" Rx.fspath
-  |kv "wwids_file" Rx.fspath
+  |kv "bindings_file" fspath
+  |kv "wwids_file" fspath
   |kv "log_checker_err" /once|always/
   |kv "retain_attached_hw_handler" /yes|no/
   |kv "detect_prio" /yes|no/
   |kv "hw_str_match" /yes|no/
   |kv "force_sync" /yes|no/
-  |kv "config_dir" Rx.fspath
+  |kv "config_dir" fspath
   |kv "missing_uev_wait_timeout" Rx.integer
   |kv "ignore_new_boot_devs" /yes|no/
   |kv "retrigger_tries" Rx.integer

--- a/lenses/tests/test_multipath.aug
+++ b/lenses/tests/test_multipath.aug
@@ -217,3 +217,31 @@ test Multipath.lns get "blacklist {
     { "device"
       { "vendor" = "SomeCorp" }
       { "product" = "2.5\"\" SSD" } } }
+
+(* Issue #583 - allow optional quotes around values and strip them *)
+test Multipath.lns get "devices {
+  device {
+    vendor \"COMPELNT\"
+    product \"Compellent Vol\"
+    path_grouping_policy \"multibus\"
+    path_checker \"tur\"
+    features \"0\"
+    hardware_handler \"0\"
+    prio \"const\"
+    failback \"immediate\"
+    rr_weight \"uniform\"
+    no_path_retry \"queue\"
+  }
+}\n" =
+  { "devices"
+    { "device"
+      { "vendor" = "COMPELNT" }
+      { "product" = "Compellent Vol" }
+      { "path_grouping_policy" = "multibus" }
+      { "path_checker" = "tur" }
+      { "features" = "0" }
+      { "hardware_handler" = "0" }
+      { "prio" = "const" }
+      { "failback" = "immediate" }
+      { "rr_weight" = "uniform" }
+      { "no_path_retry" = "queue" } } }


### PR DESCRIPTION
Multipath is happy with values enclosed in quotes, like 'path_checker
"tur"' in addition to the unquoted values. This change accepts such values
and strips the enclosing quotes.

Fixes https://github.com/hercules-team/augeas/issues/583