### PR TITLE
lexer: disable 'input' and 'yyunput' functions

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -4,6 +4,7 @@
 %option reentrant noyywrap
 %option warn nodefault
 %option outfile="lex.yy.c" prefix="augl_"
+%option noinput nounput
 
 %top{
 /* config.h must precede flex's inclusion of <stdio.h>


### PR DESCRIPTION
flex by default generates the `input`, and `yyunput` functions; OTOH, augeas does not use them, so add the right options to suppress their generation.