### PR TITLE
Pam: accept continuation lines

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 1.12.0 - ????-??-??
   - Lens changes/additions
     * Multipath: accept values enclosed in quotes (Issue #583)
+    * Pam: accept continuation lines (Issue #590)
     * Syslog: accept 'include' directive (Issue #486)
     * Semanage: new lens to process /etc/selinux/semanage.conf instead of
                 Simplevars (Pino Toscano)

--- a/lenses/tests/test_pam.aug
+++ b/lenses/tests/test_pam.aug
@@ -49,6 +49,25 @@ session    optional     pam_keyinit.so force revoke
       { "argument" = "[motd=/etc/bad example]" }
     }
 
+(* Multiline PAM entries; issue #590 *)
+test Pam.lns get "account \\\ninclude \\\n    system-auth\n" =
+  { "1"
+    { "type" = "account" }
+    { "control" = "include" }
+    { "module" = "system-auth" } }
+
+test Pam.lns get "account\\\n[success=1 default=ignore] \\
+				pam_succeed_if.so\\\nuser\\\n =\\\nvagrant\\\nuse_uid\\\nquiet\n" =
+ { "1"
+    { "type" = "account" }
+    { "control" = "[success=1 default=ignore]" }
+    { "module" = "pam_succeed_if.so" }
+    { "argument" = "user" }
+    { "argument" = "=" }
+    { "argument" = "vagrant" }
+    { "argument" = "use_uid" }
+    { "argument" = "quiet" } }
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)


### PR DESCRIPTION
Make it possible to use '\<LF>' as a whitespace character between tokens

Fixes https://github.com/hercules-team/augeas/issues/590