### PR TITLE
Fixes for rsyslog and xorg.conf

### DIFF
--- a/lenses/rsyslog.aug
+++ b/lenses/rsyslog.aug
@@ -53,6 +53,16 @@ let namedpipe = Syslog.pipe . Sep.space . [ label "pipe" . store Syslog.file_r ]
 
 let action = Syslog.action | omusrmsg | file_tmpl | namedpipe
 
+(* Cannot use syslog program because rsyslog does not suppport #! *)
+let program = [ label "program" . Syslog.bang .
+    ( Syslog.opt_plus | [ Build.xchgs "-" "reverse" ] ) .
+    Syslog.programs . Util.eol .  Syslog.entries ]
+
+(* Cannot use syslog hostname because rsyslog does not suppport #+/- *)
+let hostname = [ label "hostname" .
+      ( Syslog.plus | [ Build.xchgs "-" "reverse" ] ) .
+      Syslog.hostnames . Util.eol .  Syslog.entries ]
+
 (* View: entry
    An entry contains selectors and an action
 *)
@@ -70,9 +80,9 @@ let prop_filter =
   in [ label "filter" . prop_name . sep . prop_oper . sep . prop_val .
        Sep.space . prop_act . Util.eol ]
 
-let entries = ( Syslog.empty | Syslog.comment | entry | macro | config_object | prop_filter )*
+let entries = ( Syslog.empty | Util.comment | entry | macro | config_object | prop_filter )*
 
-let lns = entries . ( Syslog.program | Syslog.hostname )*
+let lns = entries . ( program | hostname )*
 
 let filter = incl "/etc/rsyslog.conf"
            . incl "/etc/rsyslog.d/*"

--- a/lenses/tests/test_rsyslog.aug
+++ b/lenses/tests/test_rsyslog.aug
@@ -200,6 +200,11 @@ test Rsyslog.lns get "module(load=\"imuxsock\" 	  # provides support for local s
     { "#comment" = "Turn off message reception via local log socket;" } }
   { "#comment" = "local messages are retrieved through imjournal now." }
 
+(* rsyslog doesn't use bsd-like #! or #+/- specifications *)
+test Rsyslog.lns get "#!prog\n" = { "#comment" = "!prog" }
+test Rsyslog.lns get "#+host\n" = { "#comment" = "+host" }
+test Rsyslog.lns get "#-host\n" = { "#comment" = "-host" }
+
 (* Added in rsyslog 8.33 *)
 test Rsyslog.lns get "include(file=\"/etc/rsyslog.d/*.conf\" mode=\"optional\")\n" =
   { "include"

--- a/lenses/tests/test_xorg.aug
+++ b/lenses/tests/test_xorg.aug
@@ -23,6 +23,7 @@ Section \"Device\"
 	Option 		\"MonitorLayout\" \"LVDS,VGA\"
 	VideoRam	229376
         Option          \"NoAccel\"
+        Option          \"fbdev\" \"\"
         Screen          0
 EndSection
 
@@ -68,7 +69,9 @@ EndSection
         { "Option"     = "MonitorLayout"
              { "value"  = "LVDS,VGA" } }
         { "VideoRam"   = "229376" }
-        { "Option"     = "NoAccel" } 
+        { "Option"     = "NoAccel" }
+        { "Option"     = "fbdev"
+             { "value"  = "" } }
         { "Screen"
           { "num" = "0" } } }
      { }

--- a/lenses/xorg.aug
+++ b/lenses/xorg.aug
@@ -72,8 +72,13 @@ let entries_re  = /([oO]ption|[sS]creen|[iI]nput[dD]evice|[dD]river|[sS]ub[sS]ec
 (* Variable: generic_entry_re *)
 let generic_entry_re = /[^# \t\n\/]+/ - entries_re
 
+(* Variable: quoted_non_empty_string_val *)
+let quoted_non_empty_string_val = del "\"" "\"" . store /[^"\n]+/
+                                  . del "\"" "\""
+                                              (* " relax, emacs *)
+
 (* Variable: quoted_string_val *)
-let quoted_string_val = del "\"" "\"" . store /[^"\n]+/ . del "\"" "\""
+let quoted_string_val = del "\"" "\"" . store /[^"\n]*/ . del "\"" "\""
                                               (* " relax, emacs *)
 
 (* Variable: int *)
@@ -117,7 +122,7 @@ let entry_xy (canon:string) (re:regexp) =
  *)
 let entry_str (canon:string) (re:regexp) =
         [ indent . del re canon . label canon
-          . sep_spc . quoted_string_val . eol ]
+          . sep_spc . quoted_non_empty_string_val . eol ]
 
 (* View: entry_generic
  * An entry without a specific handler. Store everything after the keyword,
@@ -128,7 +133,7 @@ let entry_generic  = [ indent . key generic_entry_re
 
 (* View: option *)
 let option = [ indent . del /[oO]ption/ "Option" . label "Option" . sep_spc
-               . quoted_string_val
+               . quoted_non_empty_string_val
                . [ label "value" . sep_spc . quoted_string_val ]*
                . eol ]
 
@@ -137,14 +142,16 @@ let option = [ indent . del /[oO]ption/ "Option" . label "Option" . sep_spc
  *)
 let screen = [ indent . del /[sS]creen/ "Screen" . label "Screen"
                . [ sep_spc . label "num" . store int ]?
-               . ( sep_spc . quoted_string_val
+               . ( sep_spc . quoted_non_empty_string_val
                . [ sep_spc . label "position" . store to_eol ]? )?
                . eol ]
 
 (* View: input_device *)
 let input_device = [ indent . del /[iI]nput[dD]evice/ "InputDevice"
-                     . label "InputDevice" . sep_spc . quoted_string_val
-                     . [ label "option" . sep_spc . quoted_string_val ]*
+                     . label "InputDevice" . sep_spc
+		     . quoted_non_empty_string_val
+                     . [ label "option" . sep_spc
+		         . quoted_non_empty_string_val ]*
                      . eol ]
 
 (* View: driver *)
@@ -169,7 +176,8 @@ let device = entry_str "Device" /[dD]evice/
 
 (* View: display_modes *)
 let display_modes = [ indent . del /[mM]odes/ "Modes" . label "Modes"
-                      . [ label "mode" . sep_spc . quoted_string_val ]+
+                      . [ label "mode" . sep_spc
+		          . quoted_non_empty_string_val ]+
                       . eol ]
 
 (*************************************************************************


### PR DESCRIPTION
These are two small fixes for the rsyslog and xorg.conf lenses.

In rsyslog.conf, #!, #+ and #- don't have a special meaning as they have in syslog, and therefore the usual Util.comment can and should be used.

 In xorg.conf, values for options can be empty strings. This is seldom used, but there are use cases. In our case, we use an empty fbdev to keep autoprobing drivers, but disabling the fbdev driver. Another use case are Xkb layout options.