### PR TITLE
New lens: Semanage

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@
   - Lens changes/additions
     * Multipath: accept values enclosed in quotes (Issue #583)
     * Syslog: accept 'include' directive (Issue #486)
+    * Semanage: new lens to process /etc/selinux/semanage.conf instead of
+                Simplevars (Pino Toscano)
 
 1.11.0 - 2018-08-24
   - General changes/additions

--- a/lenses/semanage.aug
+++ b/lenses/semanage.aug
@@ -1,0 +1,37 @@
+(*
+Module: Semanage
+   Parses /etc/selinux/semanage.conf
+
+Author:
+   Pino Toscano <ptoscano@redhat.com>
+
+About: License
+   This file is licenced under the LGPL v2+, like the rest of Augeas.
+
+About: Configuration files
+   This lens applies to /etc/selinux/semanage.conf. See <filter>.
+
+About: Examples
+   The <Test_Semanage> file contains various examples and tests.
+*)
+
+module Semanage =
+  autoload xfm
+
+let comment = IniFile.comment "#" "#"
+let sep = IniFile.sep "=" "="
+let empty = IniFile.empty
+let eol = IniFile.eol
+
+let entry = IniFile.entry IniFile.entry_re sep comment
+          | empty
+
+let title = IniFile.title_label "@group" (IniFile.record_re - /^end$/)
+let record = [ title . entry+ . Util.del_str "[end]" . eol ]
+
+let lns = (entry | record)*
+
+(* Variable: filter *)
+let filter = incl "/etc/selinux/semanage.conf"
+
+let xfm = transform lns filter

--- a/lenses/simplevars.aug
+++ b/lenses/simplevars.aug
@@ -46,6 +46,5 @@ let filter = incl "/etc/kernel-img.conf"
            . incl "/etc/audit/auditd.conf"
            . incl "/etc/mixerctl.conf"
            . incl "/etc/wsconsctlctl.conf"
-           . incl "/etc/selinux/semanage.conf"
 
 let xfm = transform lns filter

--- a/lenses/tests/test_semanage.aug
+++ b/lenses/tests/test_semanage.aug
@@ -1,0 +1,81 @@
+(*
+Module: Test_Semanage
+  Provides unit tests and examples for the <Semanage> lens.
+*)
+
+module Test_Semanage =
+
+(* Variable: phony_conf *)
+let phony_conf = "# this is a comment
+
+mykey = myvalue # eol comment
+anotherkey = another value
+"
+
+(* Test: Semanage.lns *)
+test Semanage.lns get phony_conf =
+   { "#comment" = "this is a comment" }
+   { }
+   { "mykey" = "myvalue"
+     { "#comment" = "eol comment" } }
+   { "anotherkey" = "another value" }
+
+(* Test: Semanage.lns
+   Quotes are OK in variables that do not begin with a quote *)
+test Semanage.lns get "UserParameter=custom.vfs.dev.read.ops[*],cat /proc/diskstats | grep $1 | head -1 | awk '{print $$4}'\n" =
+     { "UserParameter" = "custom.vfs.dev.read.ops[*],cat /proc/diskstats | grep $1 | head -1 | awk '{print $$4}'" }
+
+(* Test: Semanage.lns
+     Support empty values *)
+test Semanage.lns get "foo =\n" =
+  { "foo" }
+
+(* Variable: conf *)
+let conf = "module-store = direct
+module-store = \"source\"
+
+#policy-version = 19
+
+expand-check=0
+
+usepasswd=False
+bzip-small=true
+bzip-blocksize=5
+ignoredirs=/root
+
+[sefcontext_compile]
+path = /usr/sbin/sefcontext_compile
+args = -r $@
+
+[end]
+
+config=test
+
+[verify module]
+test=value
+[end]
+"
+
+(* Test: Semanage.lns *)
+test Semanage.lns get conf =
+   { "module-store" = "direct" }
+   { "module-store" = "source" }
+   { }
+   { "#comment" = "policy-version = 19" }
+   { }
+   { "expand-check" = "0" }
+   { }
+   { "usepasswd" = "False" }
+   { "bzip-small" = "true" }
+   { "bzip-blocksize" = "5" }
+   { "ignoredirs" = "/root" }
+   { }
+   { "@group" = "sefcontext_compile"
+     { "path" = "/usr/sbin/sefcontext_compile" }
+     { "args" = "-r $@" }
+     { } }
+   { }
+   { "config" = "test" }
+   { }
+   { "@group" = "verify module"
+     { "test" = "value" } }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -186,6 +186,7 @@ lens_tests =			\
   lens-rx.sh			\
   lens-samba.sh			\
   lens-securetty.sh     \
+  lens-semanage.sh		\
   lens-services.sh		\
   lens-shadow.sh		\
   lens-shells.sh		\


### PR DESCRIPTION
Introduce a new lens to parse `/etc/selinux/semanage.conf` instead of using `Simplevars`: the latter cannot handle the more complex syntax of groups introduced in newer versions of libsemanage.