### PR TITLE
Rsyslog: bsd-like #!/+/- are just comments without special meaning

### DIFF
--- a/lenses/rsyslog.aug
+++ b/lenses/rsyslog.aug
@@ -53,6 +53,16 @@ let namedpipe = Syslog.pipe . Sep.space . [ label "pipe" . store Syslog.file_r ]
 
 let action = Syslog.action | omusrmsg | file_tmpl | namedpipe
 
+(* Cannot use syslog program because rsyslog does not suppport #! *)
+let program = [ label "program" . Syslog.bang .
+    ( Syslog.opt_plus | [ Build.xchgs "-" "reverse" ] ) .
+    Syslog.programs . Util.eol .  Syslog.entries ]
+
+(* Cannot use syslog hostname because rsyslog does not suppport #+/- *)
+let hostname = [ label "hostname" .
+      ( Syslog.plus | [ Build.xchgs "-" "reverse" ] ) .
+      Syslog.hostnames . Util.eol .  Syslog.entries ]
+
 (* View: entry
    An entry contains selectors and an action
 *)
@@ -70,9 +80,9 @@ let prop_filter =
   in [ label "filter" . prop_name . sep . prop_oper . sep . prop_val .
        Sep.space . prop_act . Util.eol ]
 
-let entries = ( Syslog.empty | Syslog.comment | entry | macro | config_object | prop_filter )*
+let entries = ( Syslog.empty | Util.comment | entry | macro | config_object | prop_filter )*
 
-let lns = entries . ( Syslog.program | Syslog.hostname )*
+let lns = entries . ( program | hostname )*
 
 let filter = incl "/etc/rsyslog.conf"
            . incl "/etc/rsyslog.d/*"

--- a/lenses/tests/test_rsyslog.aug
+++ b/lenses/tests/test_rsyslog.aug
@@ -200,6 +200,11 @@ test Rsyslog.lns get "module(load=\"imuxsock\" 	  # provides support for local s
     { "#comment" = "Turn off message reception via local log socket;" } }
   { "#comment" = "local messages are retrieved through imjournal now." }
 
+(* rsyslog doesn't use bsd-like #! or #+/- specifications *)
+test Rsyslog.lns get "#!prog\n" = { "#comment" = "!prog" }
+test Rsyslog.lns get "#+host\n" = { "#comment" = "+host" }
+test Rsyslog.lns get "#-host\n" = { "#comment" = "-host" }
+
 (* Added in rsyslog 8.33 *)
 test Rsyslog.lns get "include(file=\"/etc/rsyslog.d/*.conf\" mode=\"optional\")\n" =
   { "include"


### PR DESCRIPTION
In rsyslog.conf, #!, #+ and #- don't have a special meaning as they have in syslog, and therefore the usual Util.comment can and should be used.