### PR TITLE
Allow Creation of Hostname When File is Missing

### DIFF
--- a/lenses/hostname.aug
+++ b/lenses/hostname.aug
@@ -13,7 +13,7 @@ module Hostname =
 autoload xfm
 
 (* View: lns *)
-let lns = [ label "hostname" . store Rx.word . Util.eol ]
+let lns = [ label "hostname" . store Rx.word . Util.eol ] | Util.empty
 
 (* View: filter *)
 let filter = incl "/etc/hostname"


### PR DESCRIPTION
```
$ augtool --version
augtool 1.8.0 <http://augeas.net/>
Copyright (C) 2007-2016 David Lutterkort
License LGPLv2+: GNU LGPL version 2.1 or later
                 <http://www.gnu.org/licenses/lgpl-2.1.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by David Lutterkort
```
---
Within augtool, the current `hostname` lens does not allow you to create a hostname entry under the following circumstances:
* /etc/hostname file is empty
* /etc/hostname file does not exist

### /etc/hostname file is empty

There is no augtool command(s) that will allow you to add a hostname entry to an existing, but empty, file.  Example:
```
$ sudo rm /etc/hostname
$ sudo touch /etc/hostname
$ sudo augtool

augtool> set /files/etc/hostname/hostname myhostname
augtool> save
error: Failed to execute command
saving failed (run 'errors' for details)

augtool> errors

Error in /etc/hostname:1.0 (parse_skel_failed)
  Input string does not match at all
  Lens: /usr/share/augeas/lenses/dist/hostname.aug:16.10-.57:
```

Additionally, you cannot remove the empty file using augtool:
```
$ sudo rm /etc/hostname
$ sudo touch /etc/hostname
$ sudo augtool rm /files/etc/hostname
$ ls -l /etc/hostname
-rw-r--r-- 1 root root 0 Feb 19 12:39 /etc/hostname
```

### /etc/hostname does not exist

Similar to the empty file case, you cannot create a hostname entry if the file does not already exist.

You can, however, create an empty file:
```
$ sudo rm /etc/hostname
# You can create an empty file with clear or touch
$ sudo augtool touch /files/etc/hostname
$ ls -l /etc/hostname
-rw-r--r-- 1 root root 0 Feb 19 12:34 /etc/hostname
```

Of course, now that you have an empty file, you cannot create a hostname entry for it :( 

### Proposed Changes

This proposed change will allow you to at least create a hostname entry when the file does not already exist.

It also enables you to remove file, allowing for a deterministic approach:
```
$ sudo rm /etc/hostname
$ sudo touch /etc/hostname
$ sudo augtool rm /files/etc/hostname
$ ls -l /etc/hostname
ls: cannot access '/etc/hostname': No such file or directory
$ sudo augtool set /files/etc/hostname/hostname myhostname
$ ls -l /etc/hostname
-rw-r--r-- 1 root root 11 Feb 19 12:44 /etc/hostname
$ cat /etc/hostname
myhostname
```

NOTE: Its probably very possible to fix the lens to deal more of the edge cases, but this quick fix at least gives deterministic behavior if a rm/set each time I want to configure the hostname.

Thank you for your consideration.

-David Farrell