### PR TITLE
Make the examples standalone

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,16 +1,12 @@
 
-GNULIB= ../gnulib/lib/libgnu.la
-GNULIB_CFLAGS= -I $(top_srcdir)/gnulib/lib
-
-AM_CFLAGS = @AUGEAS_CFLAGS@ @WARN_CFLAGS@ @LIBXML_CFLAGS@ $(GNULIB_CFLAGS) \
+AM_CFLAGS = @AUGEAS_CFLAGS@ @WARN_CFLAGS@ @LIBXML_CFLAGS@ \
 			-I $(top_srcdir)/src
 
 bin_PROGRAMS = fadot
 noinst_PROGRAMS = dump
 
 fadot_SOURCES = fadot.c
-fadot_LDADD = $(top_builddir)/src/libfa.la $(GNULIB)
+fadot_LDADD = $(top_builddir)/src/libfa.la
 
 dump_sources = dump.c
-dump_LDADD =  $(top_builddir)/src/libaugeas.la $(top_builddir)/src/libfa.la \
-	          $(GNULIB)
+dump_LDADD =  $(top_builddir)/src/libaugeas.la $(top_builddir)/src/libfa.la

--- a/examples/dump.c
+++ b/examples/dump.c
@@ -36,7 +36,6 @@
  *    dump '//descendant::*'
  *
  */
-#define _GNU_SOURCE
 
 #include <augeas.h>
 

--- a/examples/dump.c
+++ b/examples/dump.c
@@ -38,8 +38,7 @@
  */
 #define _GNU_SOURCE
 
-#include "config.h"
-#include "augeas.h"
+#include <augeas.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/fadot.c
+++ b/examples/fadot.c
@@ -28,7 +28,6 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <string.h>
-#include <getopt.h>
 #include <stdlib.h>
 #include <limits.h>
 

--- a/examples/fadot.c
+++ b/examples/fadot.c
@@ -24,7 +24,6 @@
  * The purpose of this example is to show the usage of libfa
  */
 
-#include <config.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <ctype.h>
@@ -33,7 +32,7 @@
 #include <stdlib.h>
 #include <limits.h>
 
-#include "fa.h"
+#include <fa.h>
 
 #define UCHAR_NUM (UCHAR_MAX+1)
 


### PR DESCRIPTION
Make sure the examples can be built standalone, even outside the augeas builds.

See the commit message of the first patch to get more details about this.