### PR TITLE
Fixes missing recognition of double quoted filenames.

### DIFF
--- a/lenses/logrotate.aug
+++ b/lenses/logrotate.aug
@@ -19,7 +19,7 @@ module Logrotate =
    let eol = Util.eol
    let num = Rx.relinteger
    let word = /[^,#= \n\t{}]+/
-   let filename = /\/[^,#= \n\t{}]+/
+   let filename = /(\/[^,#= \n\t{}]+|"\/[^,#= \n\t{}]+")/
    let size = num . /[kMG]?/
 
    let indent = del Rx.opt_space "\t"

--- a/lenses/logrotate.aug
+++ b/lenses/logrotate.aug
@@ -19,7 +19,7 @@ module Logrotate =
    let eol = Util.eol
    let num = Rx.relinteger
    let word = /[^,#= \n\t{}]+/
-   let filename = /(\/[^,#= \n\t{}]+|"\/[^,#= \n\t{}]+")/
+   let filename = Quote.do_quote_opt (store /\/[^"',#= \n\t{}]+/)
    let size = num . /[kMG]?/
 
    let indent = del Rx.opt_space "\t"
@@ -112,7 +112,7 @@ module Logrotate =
                  Util.comment
 
    let rule =
-     let filename_entry = [ label "file" . store filename ] in
+     let filename_entry = [ label "file" . filename ] in
      let filename_sep = del /[ \t\n]+/ " " in
      let filenames = Build.opt_list filename_entry filename_sep in
      [ label "rule" . Util.indent . filenames . body . eol ]

--- a/lenses/tests/test_logrotate.aug
+++ b/lenses/tests/test_logrotate.aug
@@ -14,6 +14,11 @@ test Logrotate.rule get "/var/log/foo /var/log/bar\n{\n monthly\n}\n" =
     { "file" = "/var/log/bar" }
     { "schedule" = "monthly" } }
 
+test Logrotate.rule get "\"/var/log/foo\"\n{\n monthly\n}\n" =
+  { "rule"
+    { "file" = "\"/var/log/foo\"" }
+    { "schedule" = "monthly" } }
+
 let conf = "# see man logrotate for details
 # rotate log files weekly
 weekly

--- a/lenses/tests/test_logrotate.aug
+++ b/lenses/tests/test_logrotate.aug
@@ -16,7 +16,7 @@ test Logrotate.rule get "/var/log/foo /var/log/bar\n{\n monthly\n}\n" =
 
 test Logrotate.rule get "\"/var/log/foo\"\n{\n monthly\n}\n" =
   { "rule"
-    { "file" = "\"/var/log/foo\"" }
+    { "file" = "/var/log/foo" }
     { "schedule" = "monthly" } }
 
 let conf = "# see man logrotate for details


### PR DESCRIPTION
Logrotate is able use quote filenames. This by itself is fixed there. Some
distributions files are using that. Logrotate would also be able to use files
with spaces (when quoted), fixing is too complicated for a quick fix and this
should be also uncommon in real life.