### PR TITLE
Include all Redis related config files

### DIFF
--- a/lenses/redis.aug
+++ b/lenses/redis.aug
@@ -129,6 +129,6 @@ The Redis lens
 *)
 let lns = (comment | empty | entry )*
 
-let filter = incl "/etc/redis/redis.conf"
+let filter = incl "/etc/redis/*.conf"
 
 let xfm = transform lns filter


### PR DESCRIPTION
Apply Redis lens by default to all config files in /etc/redis dir (including Sentinel config file). Inspired by Cups lens, where a wildcard is also used.