### PR TITLE
Shellvars: exclude more tcsh profile scripts

### DIFF
--- a/lenses/shellvars.aug
+++ b/lenses/shellvars.aug
@@ -297,6 +297,7 @@ module Shellvars =
                      . incl "/etc/profile"
                      . incl "/etc/profile.d/*"
                      . excl "/etc/profile.d/*.csh"
+                     . excl "/etc/profile.d/*.tcsh"
                      . excl "/etc/profile.d/csh.local"
   let filter_misc    = incl "/etc/arno-iptables-firewall/debconf.cfg"
                      . incl "/etc/conf.d/*"


### PR DESCRIPTION
Found tcsh profile scripts also with the `.tcsh` extension, so exclude them too.

Followup of commit b78bbb61282208288f0182ec1a9b3045c1f61e2a.