### PR TITLE
* src/put.c (split_concat): initialize regs earlier

### DIFF
--- a/src/put.c
+++ b/src/put.c
@@ -212,6 +212,8 @@ static struct split *split_concat(struct state *state, struct lens *lens) {
     struct split *split = NULL, *tail = NULL;
     struct regexp *atype = lens->atype;
 
+    MEMZERO(&regs, 1);
+
     /* Fast path for leaf nodes, which will always lead to an empty split */
     // FIXME: This doesn't match the empty encoding
     if (outer->tree == NULL && strlen(outer->enc) == 0
@@ -225,7 +227,6 @@ static struct split *split_concat(struct state *state, struct lens *lens) {
         return split;
     }
 
-    MEMZERO(&regs, 1);
     count = regexp_match(atype, outer->enc, outer->end,
                          outer->start, &regs);
     if (count >= 0 && count != outer->end - outer->start)


### PR DESCRIPTION
Recent changes (commit 4702d306fe01391af82dc1c7e2e1d50f571fda86) in this helper function cause the code after the `error` label to be used earlier than when `regs` is initialized; since the code in `error` frees a couple of the fields of the `regs` variable, then initialize `regs` earlier to avoid potential freeing uninitialized memory.

Found by Coverity.