### PR TITLE
 * .travis.yml: install libtool-bin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
       - libxml2-dev
       - libreadline-dev
       - valgrind
+      - libtool-bin
 install:
   - ./autogen.sh
   - sed -i '41s/ENOENT/ENOENT || errno == EINVAL/' gnulib/tests/test-readlink.h


### PR DESCRIPTION
This was already used to build, and apparently it is not automatically available anymore.