### PR TITLE
Few improvements to the Mke2fs lens

### DIFF
--- a/lenses/mke2fs.aug
+++ b/lenses/mke2fs.aug
@@ -73,20 +73,33 @@ let common_entries_list = ("base_features"|"default_features"|"default_mntopts")
 
 (* View: common_entries_int
     Entries with an integer value *)
-let common_entries_int = ("enable_periodic_fsck"|"flex_bg_size"|"force_undo"
-                         |"inode_ratio"|"inode_size")
+let common_entries_int = ("cluster_size"|"flex_bg_size"|"force_undo"
+                         |"inode_ratio"|"inode_size"|"num_backup_sb")
 
 (* View: common_entries_bool
     Entries with a boolean value *)
-let common_entries_bool = ("lazy_itable_init"|"auto_64-bit_support")
+let common_entries_bool = ("auto_64-bit_support"|"discard"
+                          |"enable_periodic_fsck"|"lazy_itable_init"
+                          |"lazy_journal_init"|"packed_meta_blocks")
+
+(* View: common_entries_string
+    Entries with a string value *)
+let common_entries_string = ("encoding"|"journal_location")
+
+(* View: common_entries_double
+    Entries with a double value *)
+let common_entries_double = ("reserved_ratio")
 
 (* View: common_entry
      Entries shared between <defaults> and <fs_types> sections *)
 let common_entry   = list_sto common_entries_list (key Rx.word)
                    | entry_sto common_entries_int Rx.integer
                    | entry_sto common_entries_bool boolean
+                   | entry_sto common_entries_string Rx.word
+                   | entry_sto common_entries_double Rx.decimal
                    | entry_sto "blocksize" ("-"? . Rx.integer)
                    | entry_sto "hash_alg" ("legacy"|"half_md4"|"tea")
+                   | entry_sto "errors" ("continue"|"remount-ro"|"panic")
                    | list_sto "features"
                         ([del /\^/ "^" . label "disable"]?
                                            . key Rx.word)

--- a/lenses/mke2fs.aug
+++ b/lenses/mke2fs.aug
@@ -34,6 +34,11 @@ let sep = IniFile.sep /=[ \t]*/ "="
 (* View: empty *)
 let empty = IniFile.empty
 
+(* View: boolean
+    The configuration parser of e2fsprogs recognizes different values
+    for booleans, so list all the recognized values *)
+let boolean = ("y"|"yes"|"true"|"t"|"1"|"on"|"n"|"no"|"false"|"nil"|"0"|"off")
+
 
 (************************************************************************
  * Group:                 RECORD TYPES
@@ -103,8 +108,9 @@ let fs_types_entry =list_sto "features"
                    | list_sto "options"
                         (key Rx.word . Util.del_str "="
                        . store Rx.word)
-                   | entry_sto "lazy_itable_init" ("true"|"false")
-                   | entry_sto ("flex_bg_size"|"auto_64-bit_support")
+                   | entry_sto ("lazy_itable_init"|"auto_64-bit_support")
+                      boolean
+                   | entry_sto "flex_bg_size"
                        Rx.integer
 
 (* View: fs_types_record

--- a/lenses/mke2fs.aug
+++ b/lenses/mke2fs.aug
@@ -149,13 +149,35 @@ let fs_types = IniFile.record fs_types_title
 
 
 (************************************************************************
+ * Group:                 OPTIONS SECTION
+ *************************************************************************)
+
+(* View: options_entries_int
+    Entries with an integer value *)
+let options_entries_int = ("proceed_delay"|"sync_kludge")
+
+(* View: options_entry
+    Possible entries under the <options> section *)
+let options_entry = entry_sto options_entries_int Rx.integer
+
+(* View: defaults_title
+    Title for the <options> section *)
+let options_title  = IniFile.title "options"
+
+(* View: options
+    A options section *)
+let options = IniFile.record options_title
+                  ((Util.indent . options_entry) | comment)
+
+
+(************************************************************************
  * Group:                 LENS AND FILTER
  *************************************************************************)
 
 (* View: lns
      The mke2fs lens
 *)
-let lns = (empty|comment)* . (defaults|fs_types)*
+let lns = (empty|comment)* . (defaults|fs_types|options)*
 
 (* Variable: filter *)
 let filter = incl "/etc/mke2fs.conf"

--- a/lenses/tests/test_mke2fs.aug
+++ b/lenses/tests/test_mke2fs.aug
@@ -77,7 +77,7 @@ module Test_mke2fs =
              { "blocksize" = "-1" } } }
 
 
-test Mke2fs.fs_types_entry
+test Mke2fs.common_entry
    put "features = has_journal,^extent\n"
    after set "/features/has_journal/disable" "";
    rm "/features/extent/disable" = "features = ^has_journal,extent\n"

--- a/lenses/tests/test_mke2fs.aug
+++ b/lenses/tests/test_mke2fs.aug
@@ -33,6 +33,10 @@ module Test_mke2fs =
 		inode_ratio = 1048576
 		blocksize = -1
 	}
+
+[options]
+	proceed_delay = 1
+	sync_kludge = 1
 "
 
    test Mke2fs.lns get conf =
@@ -74,7 +78,11 @@ module Test_mke2fs =
              { "inode_ratio" = "4096" } }
         { "filesystem" = "largefile"
              { "inode_ratio" = "1048576" }
-             { "blocksize" = "-1" } } }
+             { "blocksize" = "-1" } }
+        {} }
+     { "options"
+        { "proceed_delay" = "1" }
+        { "sync_kludge" = "1" } }
 
 
 test Mke2fs.common_entry


### PR DESCRIPTION
- parse more common entries between `[defaults]` and the tags in `[fs_types]`
- fix the type of few entries
- handle the `[options]` stanza