### PR TITLE
Fix #643 - Update of opendkim lens to match current opendkim.conf file format

### DIFF
--- a/lenses/opendkim.aug
+++ b/lenses/opendkim.aug
@@ -31,7 +31,7 @@ module Opendkim =
     | /OversignHeaders|PeerList|POPDBFile|RemoveARFrom|ResignMailTo/
     | /SenderHeaders|SignHeaders|SigningTable|TrustSignaturesFrom/
   let stringkv = key stringkv_rx .
-    del /[ \t]+/ " " . store /[a-zA-Z][^ \t\n#]+/ . eol
+    del /[ \t]+/ " " . store /[0-9a-zA-Z\/][^ \t\n#]+/ . eol
 
   let integerkv_rx = /AutoRestartCount|ClockDrift|DNSTimeout/
     | /LDAPKeepaliveIdle|LDAPKeepaliveInterval|LDAPKeepaliveProbes|LDAPTimeout/
@@ -48,12 +48,13 @@ module Opendkim =
     | /Quarantine|QueryCache|RemoveARAll|RemoveOldSignatures|ResolverTracing/
     | /SelectorHeaderRemove|SendADSPReports|SendReports|SoftwareHeader/
     | /StrictHeaders|StrictTestMode|SubDomains|Syslog|SyslogSuccess/
-    | /VBR-TrustedCertifiersOnly|WeakSyntaxChecks/
+    | /VBR-TrustedCertifiersOnly|WeakSyntaxChecks|LogWhy/
   let booleankv = key booleankv_rx .
-      del /[ \t]+/ " " . store /(true|false|yes|no|1|0)/ . eol
+      del /[ \t]+/ " " . store /([Tt]rue|[Ff]alse|[Yy]es|[Nn]o|1|0)/ . eol
 
   let entry = [ integerkv ] | [ booleankv ] | [ stringkv ]
 
   let lns = (comment | empty | entry)*
 
   let xfm = transform lns (incl "/etc/opendkim.conf")
+

--- a/lenses/tests/test_opendkim.aug
+++ b/lenses/tests/test_opendkim.aug
@@ -30,6 +30,48 @@ module Test_Opendkim =
   test Opendkim.lns put one_boolean_value after
     set "AddAllSignatureResults" "1" = one_boolean_value
 
+  let one_boolean_value_uppercase_yes = "AutoRestart Yes\n"
+  test Opendkim.lns get one_boolean_value_uppercase_yes =
+    { "AutoRestart" = "Yes" }
+  test Opendkim.lns put one_boolean_value_uppercase_yes after
+    set "AutoRestart" "Yes" = one_boolean_value_uppercase_yes
+
+  let one_boolean_value_uppercase_no = "AutoRestart No\n"
+  test Opendkim.lns get one_boolean_value_uppercase_no =
+    { "AutoRestart" = "No" }
+  test Opendkim.lns put one_boolean_value_uppercase_no after
+    set "AutoRestart" "No" = one_boolean_value_uppercase_no
+
+  let one_boolean_value_uppercase_true = "AutoRestart True\n"
+  test Opendkim.lns get one_boolean_value_uppercase_true =
+    { "AutoRestart" = "True" }
+  test Opendkim.lns put one_boolean_value_uppercase_true after
+    set "AutoRestart" "True" = one_boolean_value_uppercase_true
+
+  let one_boolean_value_uppercase_false = "AutoRestart False\n"
+  test Opendkim.lns get one_boolean_value_uppercase_false =
+    { "AutoRestart" = "False" }
+  test Opendkim.lns put one_boolean_value_uppercase_false after
+    set "AutoRestart" "False" = one_boolean_value_uppercase_false
+
+  let string_value_starting_with_number = "AutoRestartRate 10/1h\n"
+  test Opendkim.lns get string_value_starting_with_number =
+    { "AutoRestartRate" = "10/1h" }
+  test Opendkim.lns put string_value_starting_with_number after
+    set "AutoRestartRate" "10/1h" = string_value_starting_with_number
+
+  let string_value_containing_slash = "TrustAnchorFile /usr/share/dns/root.key\n"
+  test Opendkim.lns get string_value_containing_slash =
+    { "TrustAnchorFile" = "/usr/share/dns/root.key" }
+  test Opendkim.lns put string_value_containing_slash after
+    set "TrustAnchorFile" "/usr/share/dns/root.key" = string_value_containing_slash
+
+  let logwhy_keyword_boolean = "LogWhy Yes\n"
+  test Opendkim.lns get logwhy_keyword_boolean =
+    { "LogWhy" = "Yes" }
+  test Opendkim.lns put logwhy_keyword_boolean after
+    set "LogWhy" "Yes" = logwhy_keyword_boolean
+
   let three_type_value = "AddAllSignatureResults false\nADSPAction discard\nAutoRestartCount 2\n"
   test Opendkim.lns get three_type_value =
     { "AddAllSignatureResults" = "false" }


### PR DESCRIPTION
Modification done to match possible format of `/etc/opendkim.conf` file:
- Allow string values to start with numbers [0-9] like in `AutoRestartRate    10/1h`
- Allow string values to contain '/' like in `TrustAnchorFile    /usr/share/dns/root.key`
- Allow boolean values to start with uppercase letter: `False`, `True`, `Yes`, `No`
- Add support of parameter `LogWhy` with boolean value.