### PR TITLE
Support colons in the domain pattern of the limits lens

### DIFF
--- a/lenses/limits.aug
+++ b/lenses/limits.aug
@@ -25,7 +25,7 @@ let sto_to_eol = store /([^ \t\n].*[^ \t\n]|[^ \t\n])/
  *                               ENTRIES
  *************************************************************************)
 
-let domain     = label "domain" . store /[%@]?[A-Za-z0-9_.-]+|\*/
+let domain     = label "domain" . store /[%@]?[A-Za-z0-9_.:-]+|\*/
 
 let type_re    = "soft"
                | "hard"

--- a/lenses/tests/test_limits.aug
+++ b/lenses/tests/test_limits.aug
@@ -2,6 +2,7 @@ module Test_limits =
 
   let conf = "@audio - rtprio 99
 ftp hard nproc /ftp
+1200:2000 - as 1024
 * soft core 0
 "
 
@@ -31,6 +32,7 @@ ftp hard nproc /ftp
     set "domain[last()]/value" "4096"
   = "@audio - rtprio 99
 ftp hard nproc /ftp
+1200:2000 - as 1024
 * soft core 0
 * - nofile 4096\n"
 

--- a/lenses/tests/test_limits.aug
+++ b/lenses/tests/test_limits.aug
@@ -14,6 +14,10 @@ ftp hard nproc /ftp
       { "type" = "hard" }
       { "item" = "nproc" }
       { "value" = "/ftp" } }
+    { "domain" = "1200:2000"
+      { "type" = "-" }
+      { "item" = "as" }
+      { "value" = "1024" } }
     { "domain" = "*"
       { "type" = "soft" }
       { "item" = "core" }


### PR DESCRIPTION
As the manpage for limits.conf describes, the domain field may contain colons ":" as part of either UID or GID ranges:

> * an uid range specified as <min_uid>:<max_uid>. If min_uid is omitted, the match is exact for the max_uid. If max_uid is omitted, all uids greater than or equal min_uid match.
> * a gid range specified as @<min_gid>:<max_gid>. If min_gid is omitted, the match is exact for the max_gid. If max_gid is omitted, all gids greater than or equal min_gid match. For the exact match all groups including the user's supplementary groups are examined. For the range matches only the user's primary group is examined.

--- quote `man limits.conf` on a Scientific Linus 7.5 machine with pam-1.1.8-22 installed

With this pull request, the colon is added to the domain pattern of Limits.lns and an additional test case is defined for verification.

/cc @freeekanayaka