### PR TITLE
Add lens fail2ban

### DIFF
--- a/lenses/fail2ban.aug
+++ b/lenses/fail2ban.aug
@@ -1,0 +1,47 @@
+(* Fail2ban module for Augeas                     *)
+(* Author: Nicolas Gif <ngf18490@pm.me>           *)
+(* Heavily based on DPUT module by Raphael Pinson *)
+(* <raphink@gmail.com>                            *)
+(*                                                *)
+
+module Fail2ban =
+  autoload xfm
+
+
+(************************************************************************
+ * INI File settings
+ *************************************************************************)
+let comment  = IniFile.comment IniFile.comment_re IniFile.comment_default
+
+let sep      = IniFile.sep IniFile.sep_re IniFile.sep_default
+
+
+(************************************************************************
+ * "name: value" entries, with continuations in the style of RFC 822;
+ * "name=value" is also accepted
+ * leading whitespace is removed from values
+ *************************************************************************)
+let entry = IniFile.entry IniFile.entry_re sep comment
+
+
+(************************************************************************
+ * sections, led by a "[section]" header
+ * We can't use titles as node names here since they could contain "/"
+ * We remove #comment from possible keys
+ * since it is used as label for comments
+ * We also remove / as first character
+ * because augeas doesn't like '/' keys (although it is legal in INI Files)
+ *************************************************************************)
+let title   = IniFile.title IniFile.record_re
+let record  = IniFile.record title entry
+
+let lns    = IniFile.lns record comment
+
+let filter = (incl "/etc/fail2ban/fail2ban.conf")
+           . (incl "/etc/fail2ban/jail.conf")
+           . (incl "/etc/fail2ban/jail.local")
+           . (incl "/etc/fail2ban/fail2ban.d/*.conf")
+           . (incl "/etc/fail2ban/jail.d/*.conf")
+
+let xfm = transform lns filter
+

--- a/lenses/tests/test_fail2ban.aug
+++ b/lenses/tests/test_fail2ban.aug
@@ -1,0 +1,24 @@
+module Test_fail2ban =
+
+let conf = "[DEFAULT]
+mta = ssmtp
+bantime = 432000
+destemail = fail2ban@domain.com
+findtime = 3600
+maxretry = 3
+
+[sshd]
+enabled = true
+"
+
+
+test Fail2ban.lns get conf = 
+  { "DEFAULT"
+     { "mta" = "ssmtp" }
+     { "bantime" = "432000" }
+     { "destemail" = "fail2ban@domain.com" }
+     { "findtime" = "3600" }
+     { "maxretry" = "3" }
+     {} }
+  { "sshd"
+     { "enabled" = "true" } }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -73,6 +73,7 @@ lens_tests =			\
   lens-ethers.sh		\
   lens-exports.sh		\
   lens-fai_diskconfig.sh	\
+  lens-fail2ban.sh	\
   lens-fonts.sh	\
   lens-fstab.sh			\
   lens-fuse.sh			\


### PR DESCRIPTION
Add a lens to handle fail2ban configuration files.

These are Ini files.

Configuration is stored in /etc/fail2ban.

Ex on debian 9:
```
augtool print /files/etc/fail2ban/jail.d
/files/etc/fail2ban/jail.d
/files/etc/fail2ban/jail.d/defaults-debian.conf
/files/etc/fail2ban/jail.d/defaults-debian.conf/sshd
/files/etc/fail2ban/jail.d/defaults-debian.conf/sshd/enabled = "true"
```