### PR TITLE
Add Cmdline lens

### DIFF
--- a/lenses/cmdline.aug
+++ b/lenses/cmdline.aug
@@ -1,0 +1,21 @@
+(*
+Module: Cmdline
+  Parses /proc/cmdline and /etc/kernel/cmdline
+
+Author: Thomas Weißschuh <thomas.weissschuh@amadeus.com>
+
+About: License
+  This file is licensed under the LGPL v2+, like the rest of Augeas.
+*)
+
+module Cmdline =
+  autoload xfm
+
+let entry = [ key Rx.word . Util.del_str "=" . store Rx.no_spaces ] | [ key Rx.word ]
+
+let lns = (Build.opt_list entry Sep.space)? . del /\n?/ ""
+
+let filter = incl "/etc/kernel/cmdline"
+           . incl "/proc/cmdline"
+
+let xfm = transform lns filter

--- a/lenses/tests/test_cmdline.aug
+++ b/lenses/tests/test_cmdline.aug
@@ -1,0 +1,22 @@
+module Test_cmdline =
+
+let lns = Cmdline.lns
+
+test lns get "foo\nbar" = *
+test lns get "foo\n" = { "foo" }
+test lns get "foo" = { "foo" }
+test lns get "foo bar" = { "foo" } { "bar" }
+test lns get "foo    bar" = { "foo" } { "bar" }
+test lns get "foo=bar" = { "foo" = "bar" }
+test lns get "foo=bar foo=baz" = { "foo" = "bar" } { "foo" = "baz" }
+test lns get "foo bar=bar      quux baz=x" =
+        { "foo" } { "bar" = "bar" } { "quux" } { "baz" = "x" }
+test lns get "initrd=\linux\initrd.img-4.19.0-6-amd64 root=UUID=SOME_UUID rw" =
+        { "initrd" = "\linux\initrd.img-4.19.0-6-amd64" } { "root" = "UUID=SOME_UUID" } { "rw" }
+
+test lns put "" after set "foo" "bar" = "foo=bar"
+test lns put "foo=bar" after rm "foo" = ""
+test lns put "x=y foo=bar" after set "foo" "baz" = "x=y foo=baz"
+test lns put "foo=bar foo=baz" after set "foo[. = 'bar']" "quux" = "foo=quux foo=baz"
+test lns put "foo=bar foo=baz" after set "foo[. = 'baz']" "quux" = "foo=bar foo=quux"
+test lns put "" after set "foo" "" = "foo"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -47,6 +47,7 @@ lens_tests =			\
   lens-chrony.sh  		\
   lens-ceph.sh  		\
   lens-clamav.sh        \
+  lens-cmdline.sh	\
   lens-cobblersettings.sh	\
   lens-cobblermodules.sh	\
   lens-collectd.sh	\


### PR DESCRIPTION
Add lens to add linux cmdline files.

It is mostly to modify `/etc/kernel/cmdline` used by systemds kernel-install(8) command.
While `/proc/cmdline` can't be written, the lens allows structured introspection.