### PR TITLE
Systemd: fix parsing of envvars with spaces

### DIFF
--- a/lenses/systemd.aug
+++ b/lenses/systemd.aug
@@ -132,8 +132,8 @@ let entry_env =
      let envkv (env_val:lens) = key env_key . Util.del_str "=" . env_val
      (* bare has no spaces, and is optionally quoted *)
   in let bare = Quote.do_quote_opt (envkv (store /[^#'" \t\n]*[^#'" \t\n\\]/)?)
-  in let bare_dqval = envkv (store /"[^#" \t\n]*[^#" \t\n\\]"/)
-  in let bare_sqval = envkv (store /'[^#' \t\n]*[^#' \t\n\\]'/)
+  in let bare_dqval = envkv (store /"[^#"\t\n]*[^#"\t\n\\]"/)
+  in let bare_sqval = envkv (store /'[^#'\t\n]*[^#'\t\n\\]'/)
      (* quoted has at least one space, and must be quoted *)
   in let quoted = Quote.do_quote (envkv (store /[^#"'\n]*[ \t]+[^#"'\n]*/))
   in let envkv_quoted = [ bare ] | [ bare_dqval ] | [ bare_sqval ] | [ quoted ]

--- a/lenses/tests/test_systemd.aug
+++ b/lenses/tests/test_systemd.aug
@@ -206,6 +206,8 @@ FOO=BAR
 Environment=\"LANG=foo bar\" FOO=BAR
 Environment=OPTIONS=\"-LS0-6d\"
 Environment=OPTIONS='-LS0-6d'
+Environment=VAR=\"with some spaces\" VAR2='more spaces'
+Environment=VAR='with some spaces'
 "
 (* Test: Systemd.lns *)
 test Systemd.lns get env =
@@ -246,6 +248,13 @@ test Systemd.lns get env =
     }
     { "Environment"
       { "OPTIONS" = "'-LS0-6d'" }
+    }
+    { "Environment"
+      { "VAR" = "\"with some spaces\"" }
+      { "VAR2" = "'more spaces'" }
+    }
+    { "Environment"
+      { "VAR" = "'with some spaces'" }
     }
   }
 


### PR DESCRIPTION
Allow spaces inside of values quoted with single or double quotes.

This amends commit f64d8bc7a7670f3af2549fdcefb64c2b5f22cd0d that added support for quoted values.

TBH I'm not totally sure about it -- @raphink @domcleal can you please take a look whether it makes sense?