### PR TITLE
modify augtool execute error

### DIFF
--- a/src/get.c
+++ b/src/get.c
@@ -455,6 +455,7 @@ static int match(struct state *state, struct lens *lens,
     if (count < -1) {
         regexp_match_error(state, lens, count, re);
         FREE(regs);
+        FREE(re->re);
         return -1;
     }
     state->regs = regs;


### PR DESCRIPTION
meet a problem when execute "augtool print /file/etc/hosts" , will be segment fault;

so , I search and found when call `re_compile_pattern` function failed, maybe a very complex regular expression; the `regexp_match `function will return -3, means "Syntax error in regexp" and it's normal;

but the next call `regexp_match `function, the program will skip `regexp_compile `and directly to `re_match`; the input parameters is re->re, last time `regexp_compile` failed, so the input parameters  is not legal;  I think this is the root cause to segment fault;

I made some changes, like this:
```
//augeas/src/get.c
count = regexp_match(re, state->text, size, start, regs);
if (count < -1) {
        regexp_match_error(state, lens, count, re);
        FREE(regs);
        // add this line
        FREE(re->re);
        return -1;
}
```
and the problem is gone.