### PR TITLE
Mke2fs: support quoted values

### DIFF
--- a/lenses/mke2fs.aug
+++ b/lenses/mke2fs.aug
@@ -39,6 +39,9 @@ let empty = IniFile.empty
     for booleans, so list all the recognized values *)
 let boolean = ("y"|"yes"|"true"|"t"|"1"|"on"|"n"|"no"|"false"|"nil"|"0"|"off")
 
+(* View: fspath *)
+let fspath = /[^ \t\n"]+/
+
 
 (************************************************************************
  * Group:                 RECORD TYPES
@@ -52,15 +55,14 @@ let entry (kw:regexp) (lns:lens) = Build.key_value_line kw sep lns
 
 (* View: list_sto
     A list of values with given lens *)
-let list_sto (kw:regexp) (lns:lens) = counter "item" .
-                                          entry kw
-                                            (Build.opt_list 
-                                              [lns]
-                                              Sep.comma)
+let list_sto (kw:regexp) (lns:lens) =
+  entry kw (Quote.do_dquote_opt_nil (Build.opt_list [lns] Sep.comma))
 
 (* View: entry_sto
     Store a regexp as entry value *)
-let entry_sto (kw:regexp) (val:regexp) = entry kw (store val)
+let entry_sto (kw:regexp) (val:regexp) =
+  entry kw (Quote.do_dquote_opt_nil (store val))
+  | entry kw (Util.del_str "\"\"")
 
 
 (************************************************************************
@@ -114,7 +116,7 @@ let common_entry   = list_sto common_entries_list (key Rx.word)
 (* View: defaults_entry
     Possible entries under the <defaults> section *)
 let defaults_entry = entry_sto "fs_type" Rx.word
-                   | entry_sto "undo_dir" Rx.fspath
+                   | entry_sto "undo_dir" fspath
                    
 (* View: defaults_title
     Title for the <defaults> section *)

--- a/lenses/tests/test_mke2fs.aug
+++ b/lenses/tests/test_mke2fs.aug
@@ -85,6 +85,40 @@ module Test_mke2fs =
         { "sync_kludge" = "1" } }
 
 
+   let quoted_conf = "[defaults]
+	base_features = \"sparse_super,filetype,resize_inode,dir_index,ext_attr\"
+
+[fs_types]
+	ext4dev = {
+		features = \"has_journal,^extent\"
+		default_mntopts = \"user_xattr\"
+		encoding = \"utf8\"
+		encoding = \"\"
+	}
+"
+
+   test Mke2fs.lns get quoted_conf =
+     { "defaults"
+        { "base_features"
+             { "sparse_super" }
+             { "filetype" }
+             { "resize_inode" }
+             { "dir_index" }
+             { "ext_attr" } }
+        {} }
+     { "fs_types"
+        { "filesystem" = "ext4dev"
+             { "features"
+                { "has_journal" }
+                { "extent"
+                   { "disable" } } }
+             { "default_mntopts"
+                { "user_xattr" } }
+             { "encoding" = "utf8" }
+             { "encoding" }
+             } }
+
+
 test Mke2fs.common_entry
    put "features = has_journal,^extent\n"
    after set "/features/has_journal/disable" "";


### PR DESCRIPTION
`mke2fs.conf(5)` says that both tag names and values can be quoted using double quotes, in case they contain spaces. Sadly, the current Mke2fs lens does not support that.

In order to support this, introduce an helper `fspath` value to replace `Rx.fspath`, as the latter allows `"` as possible character (which we do not want in quoted strings).

Then change the helper `list_sto` and `entry_sto` functions to allow optionally double quoted values, with no changes in how the tree looks like.

Moreover, try to support also empty values, although only for lists at the moment.