### PR TITLE
lib: remove extra @LIBS@ from pkg-config file

### DIFF
--- a/augeas.pc.in
+++ b/augeas.pc.in
@@ -7,6 +7,6 @@ Name: augeas
 Version: @VERSION@
 Description: Augeas configuration editing library
 Requires.private: libxml-2.0 @PC_SELINUX@
-Libs: -L${libdir} -laugeas @LIBS@
+Libs: -L${libdir} -laugeas
 Libs.private: -lfa
 Cflags: -I${includedir}


### PR DESCRIPTION
At the moment it is empty, so probably it does not exist. Remove it to avoid adding spurious content to the pkg-config file in case that variable will get a value in the future.