### PR TITLE
set error before return in parse_int

### DIFF
--- a/src/fa.c
+++ b/src/fa.c
@@ -3445,8 +3445,10 @@ static int parse_int(struct re_parse *parse) {
         free(s);
     }
 
-    if (used == 0)
+    if (used == 0) {
+        parse->error = REG_BADBR;
         return -1;
+    }
     parse->rx += used;
     if ((l<0) || (l > INT_MAX)) {
         parse->error = REG_BADBR;


### PR DESCRIPTION
if used==0 in parse_int , parse->error should be set before return