### PR TITLE
* src/lens.c: Do not require that keys and labels not match '/'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@
     * Add Dockerfile (Nicolas Gif) (Issue #650)
     * augtool: Improved readline integration to handle quoting issues
                (Pino Toscano)
+    * typechecker: Allow including '/' in keys and labels. Thanks to
+                   felixdoerre for pointing out that this restriction was
+                   unnecessary. See issue #668 for the discussion.
   - Lens changes/additions
     * Authinfo2: new lens to parse Authinfo2 format (Nicolas Gif) (Issue #649)
     * Cmdline: New lens to parse /proc/cmdline (Thomas Weißschuh)

--- a/src/lens.c
+++ b/src/lens.c
@@ -571,32 +571,7 @@ typecheck_prim(enum lens_tag tag, struct info *info,
     struct value *exn = NULL;
 
     /* Typecheck */
-    if (tag == L_KEY) {
-        exn = str_to_fa(info, "(.|\n)*/(.|\n)*", &fa_slash, regexp->nocase);
-        if (exn != NULL)
-            goto error;
-
-        exn = regexp_to_fa(regexp, &fa_key);
-        if (exn != NULL)
-            goto error;
-
-        fa_isect = fa_intersect(fa_slash, fa_key);
-        if (! fa_is_basic(fa_isect, FA_EMPTY)) {
-            exn = make_exn_value(info,
-                  "The key regexp /%s/ matches a '/' which is used to separate nodes.", regexp->pattern->str);
-            goto error;
-        }
-        fa_free(fa_isect);
-        fa_free(fa_key);
-        fa_free(fa_slash);
-        fa_isect = fa_key = fa_slash = NULL;
-    } else if (tag == L_LABEL) {
-        if (strchr(string->str, SEP) != NULL) {
-            exn = make_exn_value(info,
-                  "The label string \"%s\" contains a '/'", string->str);
-            goto error;
-        }
-    } else if (tag == L_DEL && string != NULL) {
+    if (tag == L_DEL && string != NULL) {
         int cnt;
         const char *dflt = string->str;
         cnt = regexp_match(regexp, dflt, strlen(dflt), 0, NULL);

--- a/tests/modules/fail_key_slash.aug
+++ b/tests/modules/fail_key_slash.aug
@@ -1,6 +1,0 @@
-module Fail_key_slash =
-  let lns = key /[^]]+/
-
-(* Local Variables: *)
-(* mode: caml       *)
-(* End:             *)

--- a/tests/modules/fail_label_slash.aug
+++ b/tests/modules/fail_label_slash.aug
@@ -1,6 +1,0 @@
-module Fail_label_slash =
-  let lns = label "a/b"
-
-(* Local Variables: *)
-(* mode: caml       *)
-(* End:             *)


### PR DESCRIPTION
The '/' is only important in translating a string containing a path expression to the internal data structure we use to match it against a tree. It has no special meaning in the lens language

See https://github.com/hercules-team/augeas/issues/668 for more detail