### PR TITLE
Add CLI command 'preview' and API 'aug_preview' to preview file contents

### DIFF
--- a/src/augeas.c
+++ b/src/augeas.c
@@ -1968,6 +1968,77 @@ int aug_source(const augeas *aug, const char *path, char **file_path) {
     return result;
 }
 
+int aug_preview(struct augeas *aug, const char *path, char **out) {
+    struct tree *tree = NULL;
+    struct pathx *p;
+    int r;
+    char *lens_path = NULL;
+    char *lens_name = NULL;
+    char *file_path = NULL;
+    char *source_filename = NULL;
+    char *source_text = NULL;
+
+    *out = NULL;
+
+    api_entry(aug);
+
+    p = pathx_aug_parse(aug, aug->origin, tree_root_ctx(aug), path, true);
+    ERR_BAIL(aug);
+
+    tree = pathx_first(p);
+    ERR_BAIL(aug);
+    ERR_THROW(tree == NULL, aug, AUG_ENOMATCH, "No node matching %s", path);
+
+    file_path = tree_source(aug, tree);
+
+    ERR_THROW(file_path == NULL, aug, AUG_EBADARG, "Path %s is not associated with a file", path);
+
+    if ( file_path == NULL ) {
+        file_path = strdup(path);
+        ERR_NOMEM(file_path == NULL, aug);
+    } else {
+        tree = tree_find(aug, file_path);
+    }
+
+    r = xasprintf(&lens_path, "%s%s/%s", AUGEAS_META_TREE, file_path, s_lens);
+    if ( r>= 0 ) {
+        r = aug_get(aug,lens_path,(const char **) &lens_name);
+        ERR_BAIL(aug);
+    }
+
+    ERR_THROW(lens_name == NULL, aug, AUG_ENOLENS, "No lens found for path %s", path);
+
+    if ( STREQLEN(file_path, AUGEAS_FILES_TREE, strlen(AUGEAS_FILES_TREE) ) ) {
+        xasprintf(&source_filename, "%s%s",aug->root, file_path + strlen(AUGEAS_FILES_TREE));
+        ERR_NOMEM(source_filename == NULL, aug);
+        source_text = xread_file(source_filename);
+    }
+    if ( source_text == NULL ) {
+        source_text = strdup("");
+    }
+
+    r = text_retrieve(aug, lens_name, file_path, tree, source_text, out);
+    if (r < 0)
+        goto error;
+
+
+    free(p);
+    free(file_path);
+    free(lens_path);
+    free(source_filename);
+    free(source_text);
+    api_exit(aug);
+    return 0;
+ error:
+    free(p);
+    free(file_path);
+    free(lens_path);
+    free(source_filename);
+    free(source_text);
+    api_exit(aug);
+    return -1;
+}
+
 void aug_close(struct augeas *aug) {
     if (aug == NULL)
         return;

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -412,6 +412,17 @@ int aug_print(const augeas *aug, FILE *out, const char *path);
  */
 int aug_source(const augeas *aug, const char *path, char **file_path);
 
+/* Function: aug_preview
+ *
+ * Return the contents of the file that would be written for the file associated with path
+ * If there is no file corresponfing to PATH, *OUT will be NULL.
+ * The caller is responsible for freeing *OUT
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int aug_preview(augeas *aug, const char *path, char **out);
+
 /* Function: aug_to_xml
  *
  * Turn the Augeas tree(s) matching PATH into an XML tree XMLDOC. The

--- a/src/augeas.h
+++ b/src/augeas.h
@@ -599,7 +599,8 @@ typedef enum {
     AUG_ECMDRUN,        /* Failed to execute command */
     AUG_EBADARG,        /* Invalid argument in function call */
     AUG_ELABEL,         /* Invalid label */
-    AUG_ECPDESC         /* Cannot copy node into its descendant */
+    AUG_ECPDESC,        /* Cannot copy node into its descendant */
+    AUG_EFILEACCESS     /* Cannot open or read a file */
 } aug_errcode_t;
 
 /* Return the error code from the last API call */

--- a/src/augeas_sym.version
+++ b/src/augeas_sym.version
@@ -93,3 +93,8 @@ AUGEAS_0.24.0 {
       aug_ns_count;
       aug_ns_path;
 } AUGEAS_0.23.0;
+
+AUGEAS_0.25.0 {
+    global:
+      aug_preview;
+} AUGEAS_0.24.0;

--- a/src/augrun.c
+++ b/src/augrun.c
@@ -1006,6 +1006,35 @@ static const struct command_def cmd_source_def = {
     .help = "Print the file to which the node for PATH belongs. PATH must match\n a single node coming from some file. In particular, that means\n it must be underneath /files."
 };
 
+static void cmd_preview(struct command *cmd) {
+    const char *path = arg_value(cmd, "path");
+    char *out = NULL;
+    int r;
+
+    r = aug_preview(cmd->aug, path, &out);
+    if (r < 0 || out == NULL)
+        ERR_REPORT(cmd, AUG_ECMDRUN, "Preview of file for path %s failed", path);
+    else {
+        fprintf(cmd->out, "%s", out);
+    }
+    free(out);
+}
+
+static const struct command_opt_def cmd_preview_opts[] = {
+    { .type = CMD_PATH, .name = "path", .optional = false,
+      .help = "preview the file output which corresponds to path" },
+    CMD_OPT_DEF_LAST
+};
+
+static const struct command_def cmd_preview_def = {
+    .name = "preview",
+    .opts = cmd_preview_opts,
+    .handler = cmd_preview,
+    .synopsis = "preview the file contents for the path specified",
+    .help = "Print the file that would be written, for the file that corresponds to a path."
+    "\n The path must be within the " AUGEAS_FILES_TREE " tree."
+};
+
 static void cmd_context(struct command *cmd) {
     const char *path = arg_value(cmd, "path");
 
@@ -1494,6 +1523,7 @@ static const struct command_grp_def cmd_grp_info_def = {
         &cmd_info_def,
         &cmd_help_def,
         &cmd_source_def,
+        &cmd_preview_def,
         &cmd_def_last
     }
 };

--- a/src/augtool.c
+++ b/src/augtool.c
@@ -180,7 +180,7 @@ static char *readline_command_generator(const char *text, int state) {
         "mv", "cp", "rename", "print", "dump-xml", "rm", "save", "set", "setm",
         "clearm", "span", "store", "retrieve", "transform", "load-file",
         "help", "touch", "insert", "move", "copy", "errors", "source", "context",
-        "info", "count",
+        "info", "count", "preview",
         NULL };
 
     static int current = 0;

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -866,7 +866,7 @@ static void testAugPreview(CuTest *tc) {
         if ( hosts_fp ) {
             hosts_txt = calloc(sizeof(char),4096);
             if ( hosts_txt ) {
-							  readsz = fread(hosts_txt,sizeof(char),4096,hosts_fp);
+                readsz = fread(hosts_txt,sizeof(char),4096,hosts_fp);
                 *(hosts_txt+readsz) = '\0';
             }
             fclose(hosts_fp);

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -851,6 +851,45 @@ static void testAugSource(CuTest *tc) {
 
 }
 
+static void testAugPreview(CuTest *tc) {
+    struct augeas *aug;
+    int r;
+    char *s;
+    char *etc_hosts_fn = NULL;
+    FILE *hosts_fp = NULL;
+    char *hosts_txt = NULL;
+    int readsz = 0;
+
+    /* Read the original contents of the etc/hosts file */
+    if (asprintf(&etc_hosts_fn,"%s/etc/hosts",root) >=0 ) {
+        hosts_fp = fopen(etc_hosts_fn,"r");
+        if ( hosts_fp ) {
+            hosts_txt = calloc(sizeof(char),4096);
+            if ( hosts_txt ) {
+							  readsz = fread(hosts_txt,sizeof(char),4096,hosts_fp);
+                *(hosts_txt+readsz) = '\0';
+            }
+            fclose(hosts_fp);
+        }
+        free(etc_hosts_fn);
+    }
+
+    aug = aug_init(root, loadpath, AUG_NO_STDINC|AUG_NO_LOAD);
+    CuAssertPtrNotNull(tc, aug);
+    CuAssertIntEquals(tc, AUG_NOERROR, aug_error(aug));
+
+    r = aug_load_file(aug, "/etc/hosts");
+    CuAssertIntEquals(tc, 0, r);
+
+    r = aug_preview(aug, "/files/etc/hosts/1", &s);
+    CuAssertIntEquals(tc, 0, r);
+    CuAssertStrEquals(tc, hosts_txt, s);
+
+    free(hosts_txt);
+    free(s);
+    aug_close(aug);
+}
+
 int main(void) {
     char *output = NULL;
     CuSuite* suite = CuSuiteNew();
@@ -876,6 +915,7 @@ int main(void) {
     SUITE_ADD_TEST(suite, testLoadBadLens);
     SUITE_ADD_TEST(suite, testAugNs);
     SUITE_ADD_TEST(suite, testAugSource);
+    SUITE_ADD_TEST(suite, testAugPreview);
 
     abs_top_srcdir = getenv("abs_top_srcdir");
     if (abs_top_srcdir == NULL)


### PR DESCRIPTION
This Pull Requests adds a new command `preview` to augtool, and a new function `aug_preview()` to the API.

The `preview` command accepts a path-name as an argument.

For the file corresponding to the path-name, the contents of the file are written to stdout, with the current
nodes and values from the `/files` tree applied.

This corresponds to the contents of the file that would be written by a subsequent `save` operation.

The path-expression must evaluate to a single node only, and the source-file is determined from this node.

The API call `aug_preview()` places the resulting file-contents into `char *OUT`, allocating the required memory.

        int aug_preview(augeas *aug, const char *path, char **out);
