### PR TITLE
Add function modified() to select nodes which are marked as dirty

### DIFF
--- a/src/pathx.c
+++ b/src/pathx.c
@@ -300,6 +300,7 @@ static void func_regexp_flag(struct state *state, int nargs);
 static void func_glob(struct state *state, int nargs);
 static void func_int(struct state *state, int nargs);
 static void func_not(struct state *state, int nargs);
+static void func_modified(struct state *state, int nargs);
 
 static const enum type arg_types_nodeset[] = { T_NODESET };
 static const enum type arg_types_string[] = { T_STRING };
@@ -341,6 +342,8 @@ static const struct func builtin_funcs[] = {
       .arg_types = arg_types_nodeset, .impl = func_int, .pure = false },
     { .name = "int", .arity = 1, .type = T_NUMBER,
       .arg_types = arg_types_bool, .impl = func_int, .pure = false },
+    { .name = "modified", .arity = 0, .type = T_BOOLEAN,
+      .arg_types = NULL, .impl = func_modified, .pure = false },
     { .name = "not", .arity = 1, .type = T_BOOLEAN,
       .arg_types = arg_types_bool, .impl = func_not, .pure = true }
 };
@@ -722,6 +725,12 @@ static void func_int(struct state *state, int nargs) {
     }
     state->value_pool[vind].number = i;
     push_value(vind, state);
+}
+
+static void func_modified(struct state *state, int nargs) {
+    ensure_arity(0, 0);
+
+    push_boolean_value(state->ctx->dirty , state);
 }
 
 static void func_not(struct state *state, int nargs) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -280,7 +280,8 @@ check_SCRIPTS = \
   test-save-empty.sh test-bug-1.sh test-idempotent.sh test-preserve.sh \
   test-events-saved.sh test-save-mode.sh test-unlink-error.sh \
   test-augtool-empty-line.sh test-augtool-modify-root.sh \
-  test-span-rec-lens.sh test-nonwritable.sh test-augmatch.sh
+  test-span-rec-lens.sh test-nonwritable.sh test-augmatch.sh \
+  test-function-modified.sh
 
 EXTRA_DIST = \
   test-augtool root lens-test-1 \

--- a/tests/test-function-modified.sh
+++ b/tests/test-function-modified.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Test that changing the value of a node causes the function modified() to return true
+
+root=$abs_top_builddir/build/test-function-modified
+hosts=$root/etc/hosts
+
+rm -rf $root
+mkdir -p $(dirname $hosts)
+
+cat <<EOF > $hosts
+127.0.0.1 localhost
+::1       localhost6
+EOF
+
+touch -r $0 $hosts
+
+augtool --nostdinc -r $root -I $abs_top_srcdir/lenses > /dev/null <<EOF >$root/output.1
+set /files/etc/hosts/1/ipaddr 127.0.0.4
+match /files/etc/hosts//*[modified()]
+EOF
+
+[ "$(cat $root/output.1)" = '/files/etc/hosts/1/ipaddr = 127.0.0.4' ] || exit 1
+
+# An empty value should return true, even if none of the child nodes are modified
+augtool --nostdinc -r $root -I $abs_top_srcdir/lenses > /dev/null <<EOF >$root/output.2
+set /files/etc/hosts/1 x
+set /files/etc/hosts/1
+match /files/etc/hosts//*[modified()]
+EOF
+
+[ "$(cat $root/output.2)" = '/files/etc/hosts/1 = (none)' ] || exit 1
+
+# Test that changing a value does not change the parent node
+# Test that adding a new node also marks the (new) parent node.
+augtool --nostdinc -r $root -I $abs_top_srcdir/lenses > /dev/null <<EOF >$root/output.3
+set /files/etc/hosts/1/ipaddr 127.1.1.1
+set /files/etc/hosts/3/ipaddr 127.3.3.3
+match /files/etc/hosts//*[modified()]
+EOF
+
+diff -q $root/output.3  -  <<EOF || exit 1
+/files/etc/hosts/3 = (none)
+/files/etc/hosts/1/ipaddr = 127.1.1.1
+/files/etc/hosts/3/ipaddr = 127.3.3.3
+EOF
+


### PR DESCRIPTION
This Pull Request adds a new boolean function `modified()` to path-expressions.

The function `modified()` reads the status if the `dirty` flag of the context node,
and returns this as a boolean value.

The allows the current tree to be interrogated, showing which nodes have been modified 
since they where loaded.

eg:

```
augtool> set /files/etc/hosts/00/ipaddr 1.2.3.4
augtool> match /files//*[modified()]
/files/etc/hosts = (none)
/files/etc/hosts/00 = (none)
/files/etc/hosts/00/ipaddr = 1.2.3.4
augtool> 
```

This Pull Request alters the existing logic around the `dirty` flag in the tree, so that:
* only the actual nodes modified are marked 'dirty`, and _not_ the parent nodes of the modified node(s).
* the file-node of the modified node(s) is still marked `dirty`, as before
* all existing functionality controlled by the `dirty` flag has been preserved by adjusting the logic as required.

eg

```
augtool> print /files/etc/hosts/1
/files/etc/hosts/1
/files/etc/hosts/1/ipaddr = "127.0.0.1"
/files/etc/hosts/1/canonical = "localhost"
/files/etc/hosts/1/alias[1] = "localhost4"
/files/etc/hosts/1/alias[2] = "localhost.localdomain"
/files/etc/hosts/1/#comment = "ipv4"
augtool> set /files/etc/hosts/1/ipaddr "127.0.0.1"
augtool> set /files/etc/hosts/1/alias[2] "myhost.localdomain"
augtool> match /files//*[modified()]
/files/etc/hosts = (none)
/files/etc/hosts/1/alias[2] = myhost.localdomain
augtool> 
```

The 1st set command does not change the existing value, so the node is not marked as `dirty`
The 2nd set command changes the node `alias[2]` and only this node and it's corresponding file-node `/files/etc/hosts` are marked as `dirty`

Only nodes with the `dirty` flag set are selected by the function `modified()`
