### PR TITLE
Add "else" operator to augeas path-filter expressions (priority selector)

### DIFF
--- a/tests/run.tests
+++ b/tests/run.tests
@@ -296,6 +296,36 @@ test set-args 2
   get /files
 prints
   /files (none)
+
+test set-union-not-there -1 EMMATCH
+  set (/files/left|/files/right) 1
+
+test set-union-existing -1 EMMATCH
+  set /files/left value1
+  set /files/right value2
+  set (/files/left|/files/right) 1
+
+test set-else-not-there 2
+  set '(/files/not-there else /files/not-there-yet)' value
+  get /files/not-there-yet
+prints
+  /files/not-there-yet = value
+
+test set-else-existing 3
+  set /files/existing value
+  set '(/files/existing else /files/not-there)' new_value
+  get /files/existing
+prints
+  /files/existing = new_value
+
+test set-else-update 3
+  set /files/existing value
+  set '(/files/not-there else /files/existing)' value3
+  get /files/existing
+prints
+  /files/existing = value3
+
+
 #
 # test clear
 #

--- a/tests/xpath.tests
+++ b/tests/xpath.tests
@@ -278,6 +278,16 @@ test union (/files/etc/yum.conf | /files/etc/yum.repos.d/*)/*/gpgcheck
      /files/etc/yum.repos.d/remi.repo/remi/gpgcheck = 1
      /files/etc/yum.repos.d/remi.repo/remi-test/gpgcheck = 1
 
+test else_nodeset_lhs (/files/etc/yum.conf else /files/etc/yum.repos.d/*)/*/gpgcheck
+     /files/etc/yum.conf/main/gpgcheck = 1
+
+test else_nodeset_rhs (/files/etc/yum.conf.missing else /files/etc/yum.repos.d/fedora.repo)/*/gpgcheck
+     /files/etc/yum.repos.d/fedora.repo/fedora/gpgcheck = 1
+     /files/etc/yum.repos.d/fedora.repo/fedora-debuginfo/gpgcheck = 1
+     /files/etc/yum.repos.d/fedora.repo/fedora-source/gpgcheck = 1
+
+test else_nodeset_nomatch (/files/left else /files/right)
+
 # Paths with whitespace in them
 test php1 $php/mail function
      /files/etc/php.ini/mail\ function

--- a/tests/xpath.tests
+++ b/tests/xpath.tests
@@ -348,3 +348,35 @@ test seqaxismatchlabel /files/etc/hosts/seq::2
 
 test seqaxismatchregexp /files/etc/hosts/seq::*[canonical =~ regexp('.*orange.*')]
      /files/etc/hosts/2
+
+test else_simple_lhs /files/etc/fstab/*[passno='1' else passno='2']/file
+     /files/etc/fstab/1/file = /
+
+test else_simple_rhs /files/etc/fstab/*[passno='9' else passno='2']/file
+     /files/etc/fstab/2/file = /boot
+     /files/etc/fstab/5/file = /home
+     /files/etc/fstab/8/file = /local
+     /files/etc/fstab/9/file = /var/lib/xen/images
+
+test else_haschild_lhs /files/etc/hosts/*[alias else alias='orange']/canonical
+     /files/etc/hosts/1/canonical = localhost.localdomain
+     /files/etc/hosts/2/canonical = orange.watzmann.net
+
+test else_chain1 /files/etc/fstab/*[passno='9' else passno='1' else passno='2']/file
+     /files/etc/fstab/1/file = /
+
+test else_chain2 /files/etc/fstab/*[passno='9' else passno='8' else passno='2']/file
+     /files/etc/fstab/2/file = /boot
+     /files/etc/fstab/5/file = /home
+     /files/etc/fstab/8/file = /local
+     /files/etc/fstab/9/file = /var/lib/xen/images
+
+# Although there are nodes matching passno=2 and nodes matching dump=0
+# there is no node with both
+test_and_else_lhs /files/etc/fstab/*[passno='2' and ( dump='0' else dump='1')]/file
+
+test_and_else_rhs /files/etc/fstab/*[passno='2' and ( dump='nemo' else dump='1')]/file
+     /files/etc/fstab/2/file = /boot
+     /files/etc/fstab/5/file = /home
+     /files/etc/fstab/8/file = /local
+     /files/etc/fstab/9/file = /var/lib/xen/images


### PR DESCRIPTION
This Pull Request adds a new binary operator to path-filter expressions.

The new operator is currently called `else`.

The existing binary operators `and` and `or` effectively act on 'sets' of nodes.

Given a filter-expression of the form:

    *[nodeset_a or nodeset_b]

eg.

    /files/etc/hosts/*[alias=~glob('local*') or ipaddr=~glob('192.168.*')]

nodeset_a and nodeset_b refer to a subset of `*` 
`*` represents all nodes at this level of the tree.
The `or` operator forms a union of nodeset_a and nodeset_b

Given a filter-expression:

    *[nodeset_a and nodeset_b]

The `and` operator forms an intersection of nodeset_a and nodeset_b

The new binary operator `else` also deals with nodesets.

Given a filter-expression:

    *[nodeset_a else nodeset_b]

The `else` operator acts as a 'selector' or 'order-of-priority' between alternate nodesets.
nodeset_a will be selected as long as it is not empty. If nodeset_a is empty, nodeset_b is selected.

A typical application for this would be in a command such as `set` that requires exactly one node to match.

For the case where both nodeset_a and nodeset_b exist, contain a single node, and are not the same node:
* If the `or` operator is used this will result in a nodeset with 2 nodes.
* If the `else` operator is used, only nodeset_a will be selected, which results in a nodeset with 1 node.
