### PR TITLE
Tmpfiles: few improvements to the types specification

### DIFF
--- a/lenses/tests/test_tmpfiles.aug
+++ b/lenses/tests/test_tmpfiles.aug
@@ -333,7 +333,7 @@ Invalid example that contain invalid age  *)
 
   (* Variable: invalid_type
 Invalid example that contain invalid type (bad letter) *)
-  let invalid_type = "e /var/tmp/js 0000 jonhsmith 60 1s foo\n"
+  let invalid_type = "i /var/tmp/js 0000 jonhsmith 60 1s foo\n"
 
   (* Variable: invalid_type_num
  Invalid example that contain invalid type (numeric) *)

--- a/lenses/tests/test_tmpfiles.aug
+++ b/lenses/tests/test_tmpfiles.aug
@@ -79,6 +79,24 @@ Tree for <exclamation_mark> *)
         { "argument" = "-" }
     }
 
+  (* Variable: minus
+Example with an minus mark in the type *)
+  let minus = "D- /tmp/foo - - - - -\n"
+
+  (* Variable: minus_tree
+Tree for <minus_tree> *)
+  let minus_tree =
+    {
+        "1"
+        { "type" = "D-" }
+        { "path" = "/tmp/foo" }
+        { "mode" = "-" }
+        { "uid" = "-" }
+        { "gid" = "-" }
+        { "age" = "-" }
+        { "argument" = "-" }
+    }
+
   (* Variable: short
 Example with only type and path *)
   let short = "A+ /tmp/foo\n"
@@ -356,6 +374,8 @@ Invalid example that contain invalid mode (letter) *)
   test Tmpfiles.lns get empty = {}{}{}
 
   test Tmpfiles.lns get exclamation_mark = exclamation_mark_tree
+
+  test Tmpfiles.lns get minus = minus_tree
 
   test Tmpfiles.lns get short = short_tree
 

--- a/lenses/tmpfiles.aug
+++ b/lenses/tmpfiles.aug
@@ -49,11 +49,12 @@ Empty lines *)
 (* Group: Lense-specific primitives *)
 
   (* View: type
-One letter. Some of them can have a "+" and all can have a "!".
+One letter. Some of them can have a "+" and all can have an
+exclamation mark ("!") and/or minus sign ("-").
 
 Not all letters are valid.
 *)
-  let type     = /([fFwdDevqQpLcbCxXrRzZtThHaAm]|[fFwpLcbaA]\+)!?/
+  let type     = /([fFwdDevqQpLcbCxXrRzZtThHaAm]|[fFwpLcbaA]\+)!?-?/
 
   (* View: mode
 "-", or 3-4 bytes. Optionally starts with a "~". *)

--- a/lenses/tmpfiles.aug
+++ b/lenses/tmpfiles.aug
@@ -53,7 +53,7 @@ One letter. Some of them can have a "+" and all can have a "!".
 
 Not all letters are valid.
 *)
-  let type     = /([fFwdDvqQpLcbCxXrRzZtThHaAm]|[AabcLp]\+)!?/
+  let type     = /([fFwdDevqQpLcbCxXrRzZtThHaAm]|[fFwpLcbaA]\+)!?/
 
   (* View: mode
 "-", or 3-4 bytes. Optionally starts with a "~". *)


### PR DESCRIPTION
- handle more type letters, according to what systemd-tmpfiles supports
- handle `-` characters for non-fatal rules