### PR TITLE
Allow AD groups in '/etc/sudoers'

### DIFF
--- a/lenses/sudoers.aug
+++ b/lenses/sudoers.aug
@@ -127,7 +127,7 @@ let sto_to_com_host = store /[^,=:#() \t\n\\]+/
 Escaped spaces and NIS domains and allowed*)
 let sto_to_com_user =
       let nis_re = /([A-Z]([-A-Z0-9]|(\\\\[ \t]))*+\\\\\\\\)/
-   in let user_re = /[%+@a-z]([-A-Za-z0-9._+]|(\\\\[ \t]))*/ - /@include(dir)?/
+   in let user_re = /[%+@a-z]([-A-Za-z0-9._+]|(\\\\[ \t])|\\\\\\\\[A-Za-z0-9])*/ - /@include(dir)?/
    in let alias_re = /[A-Z_]+/
    in store ((nis_re? . user_re) | alias_re)
 

--- a/lenses/tests/test_sudoers.aug
+++ b/lenses/tests/test_sudoers.aug
@@ -9,6 +9,7 @@ test test_user get "root
 +secre-taries
 @my\ admin\ group
 EXAMPLE\\\\cslack
+%ad.domain.com\\\\sudo-users
 MY\ EX-AMPLE\ 9\\\\cslack\ group
 " =
   { "user" = "root" }
@@ -16,6 +17,7 @@ MY\ EX-AMPLE\ 9\\\\cslack\ group
   { "user" = "+secre-taries" }
   { "user" = "@my\\ admin\\ group" }
   { "user" = "EXAMPLE\\\\cslack" }
+  { "user" = "%ad.domain.com\\\\sudo-users" }
   { "user" = "MY\\ EX-AMPLE\\ 9\\\\cslack\\ group" }
 
 let conf = "
@@ -302,6 +304,18 @@ test Sudoers.spec get "user.one somehost = ALL\n" =
 test Sudoers.spec get "%sudo_users ALL=(ALL) ALL\n" =
   { "spec"
     { "user" = "%sudo_users" }
+    { "host_group"
+      { "host" = "ALL" }
+      { "command" = "ALL"
+        { "runas_user" = "ALL" } }
+    }
+  }
+
+(* Test: Sudoers.spec
+     allow ad group names with backslashes *)
+test Sudoers.spec get "%ad.domain.com\\\\sudo-users ALL=(ALL) ALL\n" =
+  { "spec"
+    { "user" = "%ad.domain.com\\\\sudo-users" }
     { "host_group"
       { "host" = "ALL" }
       { "command" = "ALL"


### PR DESCRIPTION
Before this commit, `/etc/sudoers` files containing AD users or groups could not be parsed with the sudoers lens because it was containing `\\` in said users/groups name. Running `visudo -c` shows that a sudoers file containing these is valid so this case was added in the affected regex.