### PR TITLE
mongodb (bug): Fix paths for MongoDB assets

### DIFF
--- a/lenses/mongodbserver.aug
+++ b/lenses/mongodbserver.aug
@@ -1,6 +1,6 @@
 (*
 Module: MongoDBServer
-  Parses /etc/mongodb.conf
+  Parses /etc/mongod.conf
 
 Author: Brian Redbeard <redbeard@dead-city.org>
 
@@ -19,18 +19,18 @@ About: Lens Usage
   Sample usage of this lens in augtool:
 
     * Get your current setup
-      > print /files/etc/mongodb.conf
+      > print /files/etc/mongod.conf
       ...
 
     * Change MongoDB port
-      > set /files/etc/mongodb.conf/port 27117
+      > set /files/etc/mongod.conf/port 27117
 
   Saving your file:
 
       > save
 
 About: Configuration files
-   This lens applies to /etc/mongodb.conf. See <filter>.
+   This lens applies to /etc/mongod.conf. See <filter>.
 
 About: Examples
    The <Test_MongoDBServer> file contains various examples and tests.
@@ -48,6 +48,6 @@ let lns = (Util.empty | Util.comment | entry)*
 
 
 (* Variable: filter *)
-let filter = incl "/etc/mongodb.conf"
+let filter = incl "/etc/mongod.conf"
 
 let xfm = transform lns filter

--- a/lenses/tests/test_mongodbserver.aug
+++ b/lenses/tests/test_mongodbserver.aug
@@ -8,8 +8,8 @@ module Test_MongoDBServer =
 (* Variable: conf *)
 let conf = "port = 27017
 fork = true
-pidfilepath = /var/run/mongodb/mongodb.pid
-logpath = /var/log/mongodb/mongodb.log
+pidfilepath = /var/run/mongodb/mongod.pid
+logpath = /var/log/mongodb/mongod.log
 dbpath =/var/lib/mongodb
 journal = true
 nohttpinterface = true
@@ -19,8 +19,8 @@ nohttpinterface = true
 test MongoDBServer.lns get conf =
   { "port" = "27017" }
   { "fork" = "true" }
-  { "pidfilepath" = "/var/run/mongodb/mongodb.pid" }
-  { "logpath" = "/var/log/mongodb/mongodb.log" }
+  { "pidfilepath" = "/var/run/mongodb/mongod.pid" }
+  { "logpath" = "/var/log/mongodb/mongod.log" }
   { "dbpath" = "/var/lib/mongodb" }
   { "journal" = "true" }
   { "nohttpinterface" = "true" }


### PR DESCRIPTION
A number of files used by MongoDB had path changes, moving from the name
`mongodb.<extension>` to `mongod.<extension>` (changing "db" -> "d").

This updates those files (and their corresponding tests) to reflect the
correct paths, as of MongoDB v4.4.

Special thanks to Frank Büttner of Max-Delbrück-Centrum für Molekulare
Medizin for bringing this to my attention and noting the change.
As the idiom goes: "Many hands make light work"