### PR TITLE
Update sshd lens to split additional list keys

### DIFF
--- a/lenses/sshd.aug
+++ b/lenses/sshd.aug
@@ -73,7 +73,7 @@ module Sshd =
    let indent = del /[ \t]*/ "  "
 
    let key_re = /[A-Za-z0-9]+/
-         - /MACs|Match|AcceptEnv|Subsystem|Ciphers|(Kex|HostKey)Algorithms|(Allow|Deny)(Groups|Users)/i
+         - /MACs|Match|AcceptEnv|Subsystem|Ciphers|((GSSAPI|)Kex|HostKey|CASignature)Algorithms|PubkeyAcceptedKeyTypes|(Allow|Deny)(Groups|Users)/i
 
    let comment = Util.comment
    let comment_noindent = Util.comment_noindent
@@ -119,10 +119,17 @@ module Sshd =
 
    let hostkeyalgorithms = list /HostKeyAlgorithms/i "HostKeyAlgorithms"
 
+   let gssapikexalgorithms = list /GSSAPIKexAlgorithms/i "GSSAPIKexAlgorithms"
+
+   let casignaturealgorithms = list /CASignatureAlgorithms/i "CASignatureAlgorithms"
+
+   let pubkeyacceptedkeytypes = list /PubkeyAcceptedKeyTypes/i "PubkeyAcceptedKeyTypes"
+
    let entry = accept_env | allow_groups | allow_users
              | deny_groups | subsystem | deny_users
              | macs | ciphers | kexalgorithms | hostkeyalgorithms
-             | other_entry
+             | gssapikexalgorithms | casignaturealgorithms
+             | pubkeyacceptedkeytypes | other_entry
 
    let condition_entry =
     let k = /[A-Za-z0-9]+/ in

--- a/lenses/sshd.aug
+++ b/lenses/sshd.aug
@@ -151,7 +151,10 @@ module Sshd =
 
   let lns = (entry | comment | empty)* . match*
 
-  let xfm = transform lns (incl "/etc/ssh/sshd_config")
+  let filter = (incl "/etc/ssh/sshd_config" )
+               . ( incl "/etc/ssh/sshd_config.d/*.conf" )
+
+  let xfm = transform lns filter
 
 (* Local Variables: *)
 (* mode: caml       *)

--- a/lenses/tests/test_sshd.aug
+++ b/lenses/tests/test_sshd.aug
@@ -100,10 +100,14 @@ Match Group \"Domain users\"
 
 
 (* Test: Sshd.lns
-     Parse Ciphers, KexAlgorithms, HostKeyAlgorithms as lists (GH issue #69) *)
+     Parse Ciphers, KexAlgorithms, HostKeyAlgorithms as lists (GH issue #69)
+     Parse GSSAPIKexAlgorithms, PubkeyAcceptedKeyTypes, CASignatureAlgorithms as lists (GH PR #721) *)
 test Sshd.lns get "Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr
 KexAlgorithms diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1
-HostKeyAlgorithms ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-ed25519,ssh-rsa\n" =
+HostKeyAlgorithms ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-ed25519,ssh-rsa
+GSSAPIKexAlgorithms gss-curve25519-sha256-,gss-nistp256-sha256-,gss-group14-sha256-
+PubkeyAcceptedKeyTypes ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384
+CASignatureAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521\n" =
   { "Ciphers"
     { "1" = "aes256-gcm@openssh.com" }
     { "2" = "aes128-gcm@openssh.com" }
@@ -120,6 +124,21 @@ HostKeyAlgorithms ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,
     { "2" = "ssh-rsa-cert-v01@openssh.com" }
     { "3" = "ssh-ed25519" }
     { "4" = "ssh-rsa" }
+  }
+  { "GSSAPIKexAlgorithms"
+    { "1" = "gss-curve25519-sha256-" }
+    { "2" = "gss-nistp256-sha256-" }
+    { "3" = "gss-group14-sha256-" }
+  }
+  { "PubkeyAcceptedKeyTypes"
+    { "1" = "ecdsa-sha2-nistp256" }
+    { "2" = "ecdsa-sha2-nistp256-cert-v01@openssh.com" }
+    { "3" = "ecdsa-sha2-nistp384" }
+  }
+  { "CASignatureAlgorithms"
+    { "1" = "ecdsa-sha2-nistp256" }
+    { "2" = "ecdsa-sha2-nistp384" }
+    { "3" = "ecdsa-sha2-nistp521" }
   }
 
 (* Test: Sshd.lns


### PR DESCRIPTION
Several configuration values used for setting crypto policy were being
incorrectly parsed as raw strings when they are in fact lists. Treat
them as such

Specifically:
- GSSAPIKexAlgorithms
- PubkeyAcceptedKeyTypes
- CASignatureAlgorithms