### PR TITLE
Modified NetworkManager lense

### DIFF
--- a/lenses/networkmanager.aug
+++ b/lenses/networkmanager.aug
@@ -34,13 +34,17 @@ let eol        = Util.eol
  *                        ENTRY
  * GLib entries can contain semicolons, entry names can contain spaces and
  * brackets
+ *
+ * At least entry for WPA-PSK definition can contain all printable ASCII
+ * characters including '#', ' ' and others. Comments following the entry
+ * are no option for this reason.
  *************************************************************************)
 (* Variable: entry_re *)
 let entry_re   = /[A-Za-z][A-Za-z0-9:._\(\) \t-]+/
 
 (* Lens: entry *)
 let entry   = [ key entry_re . sep
-                . Quote.double_opt? . eol ]
+                . IniFile.sto_to_eol? . eol ]
               | comment
 
 (************************************************************************

--- a/lenses/tests/test_networkmanager.aug
+++ b/lenses/tests/test_networkmanager.aug
@@ -32,6 +32,8 @@ method=auto
 NAT Traversal Mode=natt
 DPD idle timeout (our side)=0\n"
 
+let conf_empty = ""
+
 (* Test: NetworkManager.lns *)
 test NetworkManager.lns get conf =
   { "connection"
@@ -66,3 +68,8 @@ test NetworkManager.lns get conf =
     { "DPD idle timeout (our side)" = "0" }
   }
 
+test NetworkManager.lns put conf_empty after
+    insa "wifi-security" "/";
+    set "wifi-security/psk" "#the key"
+  = "[wifi-security]
+psk=#the key\n"

--- a/lenses/tests/test_networkmanager.aug
+++ b/lenses/tests/test_networkmanager.aug
@@ -32,6 +32,15 @@ method=auto
 NAT Traversal Mode=natt
 DPD idle timeout (our side)=0\n"
 
+let conf_psk = "[wifi]
+ssid=TEST
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=wpa-psk
+auth-alg=open
+psk=\"#weird but valid psk!\"\n"
+
 let conf_empty = ""
 
 (* Test: NetworkManager.lns *)
@@ -66,6 +75,19 @@ test NetworkManager.lns get conf =
   { "vpn"
     { "NAT Traversal Mode" = "natt" }
     { "DPD idle timeout (our side)" = "0" }
+  }
+
+(* Test: NetworkManager.lns - nontrivial WPA-PSK *)
+test NetworkManager.lns get conf_psk =
+  { "wifi"
+    { "ssid" = "TEST" }
+    { "mode" = "infrastructure" }
+    {  }
+  }
+  { "wifi-security"
+    { "key-mgmt" = "wpa-psk" }
+    { "auth-alg" = "open" }
+    { "psk" = "\"#weird but valid psk!\"" }
   }
 
 test NetworkManager.lns put conf_empty after

--- a/lenses/tests/test_networkmanager.aug
+++ b/lenses/tests/test_networkmanager.aug
@@ -90,6 +90,7 @@ test NetworkManager.lns get conf_psk =
     { "psk" = "\"#weird but valid psk!\"" }
   }
 
+(* Test: NetworkManager.lns - write new values unquoted *)
 test NetworkManager.lns put conf_empty after
     insa "wifi-security" "/";
     set "wifi-security/psk" "#the key"


### PR DESCRIPTION
The lense will not encapsulate value of a newly created entry by quotes.
Values containing # are accepted (allowed character e.g. for WPA-PSK)

## Details ##

* For WPA-PSK each character in the pass-phrase must have an encoding in the range of 32 to 126 (decimal), inclusive. (IEEE Std. 802.11i-2004, Annex H.4.1)

E.g. # and space character are included in this range.

* adresses https://github.com/hercules-team/augeas/issues/719
