### PR TITLE
Support negative integers in sudoers lens

### DIFF
--- a/lenses/sudoers.aug
+++ b/lenses/sudoers.aug
@@ -153,7 +153,7 @@ let sto_to_spc = store /[^", \t\n\\]+|"[^", \t\n\\]+"/
 let sto_to_spc_no_dquote = store /[^",# \t\n\\]+/ (* " relax emacs *)
 
 (* Variable: sto_integer *)
-let sto_integer = store /[0-9]+/
+let sto_integer = store /-?[0-9]+/
 
 
 (* Group: Comments and empty lines *)

--- a/lenses/tests/test_sudoers.aug
+++ b/lenses/tests/test_sudoers.aug
@@ -225,6 +225,14 @@ test Sudoers.lns get s =
   { "Defaults"
     { "secure_path" = "/sbin:/bin:/usr/sbin:/usr/bin" } }
 
+(* #724 - check timestamp_timeout is extracted OK if unsigned OR negative (-1) *)
+test Sudoers.lns get "Defaults    timestamp_timeout = 3\n" =
+  { "Defaults"
+    { "timestamp_timeout" = "3" } }
+test Sudoers.lns get "Defaults    timestamp_timeout = -1\n" =
+  { "Defaults"
+    { "timestamp_timeout" = "-1" } }
+
 (* Ticket #206, comments at end of lines *)
 let commenteol = "#
 Defaults targetpw    # ask for


### PR DESCRIPTION
[timestamp_timeout](https://help.ubuntu.com/community/RootSudoTimeout) in `/etc/sudoers` can have a negative value, but current augeas lens definition doesn't support this.

Modify lens regex to also match negative integers.

Issue is similar to https://libvir-list.redhat.narkive.com/gFPonY7Z/libvirt-patch-adapt-augeas-profile-to-handle-negative-int-values