### PR TITLE
src/syntax.c: Fix whitespace which confuses static checkers

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -134,7 +134,7 @@ void syntax_error(struct info *info, const char *format, ...) {
     if (error->code != AUG_NOERROR && error->code != AUG_ESYNTAX)
         return;
 
-	va_start(ap, format);
+    va_start(ap, format);
     format_error(info, AUG_ESYNTAX, format, ap);
     va_end(ap);
 }
@@ -146,7 +146,7 @@ void fatal_error(struct info *info, const char *format, ...) {
     if (error->code == AUG_EINTERNAL)
         return;
 
-	va_start(ap, format);
+    va_start(ap, format);
     format_error(info, AUG_EINTERNAL, format, ap);
     va_end(ap);
 }


### PR DESCRIPTION
Coverity reports the error below.  (The actual error comes from the
compiler used, rather than Coverity).

This is because the va_start line uses a tab while the line following
uses 4 spaces.  When you view the file in a tool like "less", the tab
appears as 8 spaces, so it appears to be indented confusingly.  When
you open the file in Emacs, the local variables clause at the end
causes tabs to be set to 4 characters so there is no visible
difference.

Anyway the fix is a trivial whitespace change.

Error: COMPILER_WARNING (CWE-483): [#def32]
augeas-1.12.0/src/syntax.c: scope_hint: In function 'syntax_error'
augeas-1.12.0/src/syntax.c:134:5: warning[-Wmisleading-indentation]: this 'if' clause does not guard...
augeas-1.12.0/src/syntax.c:26: included_from: Included from here.
augeas-1.12.0/src/syntax.c:137:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'

Error: COMPILER_WARNING (CWE-483): [#def33]
augeas-1.12.0/src/syntax.c: scope_hint: In function 'fatal_error'
augeas-1.12.0/src/syntax.c:146:5: warning[-Wmisleading-indentation]: this 'if' clause does not guard...
augeas-1.12.0/src/syntax.c:26: included_from: Included from here.
augeas-1.12.0/src/syntax.c:149:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'