### PR TITLE
Allow Redis lens to set `SAVE ""` as a valid option

### DIFF
--- a/lenses/redis.aug
+++ b/lenses/redis.aug
@@ -65,12 +65,17 @@ let standard_entry =
 let save = /save/
 let seconds = [ label "seconds" . Quote.do_quote_opt_nil (store Rx.integer) ]
 let keys = [ label "keys" . Quote.do_quote_opt_nil (store Rx.integer) ]
+let save_val =
+     let save_val_empty = del_ws_spc . dquote . store "" . dquote
+  in let save_val_sec_keys = del_ws_spc . seconds . del_ws_spc . keys
+  in save_val_sec_keys | save_val_empty
+
 (* View: save_entry
 Entries identified by the "save" keyword can be found more than once. They have
-2 mandatory parameters, both integers. The same rules as standard_entry apply
-for quoting, comments and whitespaces.
+2 mandatory parameters, both integers or a single parameter that is empty double quoted
+string. The same rules as standard_entry apply for quoting, comments and whitespaces.
 *)
-let save_entry = [ indent . key save . del_ws_spc . seconds . del_ws_spc . keys . eol ]
+let save_entry = [ indent . key save . save_val . eol ]
 
 let replicaof = /replicaof|slaveof/
 let ip = [ label "ip" . Quote.do_quote_opt_nil (store Rx.ip) ]

--- a/lenses/tests/test_redis.aug
+++ b/lenses/tests/test_redis.aug
@@ -31,6 +31,9 @@ test Redis.lns get save_entry_quotes =
   { "keys" = "10000" }
 }
 
+let save_entry_empty = "save \"\"\n"
+test Redis.lns get save_entry_empty = { "save" = "" }
+
 let replicaof_entry = "slaveof 192.168.0.10 6379\nreplicaof 192.168.0.11 6380\n"
 test Redis.lns get replicaof_entry =
 { "slaveof"


### PR DESCRIPTION
Before Redis 6.2 removing all the `SAVE` directives in the config file would disable snapshots. 
https://github.com/redis/redis/blob/6.0/redis.conf#L299-L305

In Redis 6.2 removing all the `SAVE` directives in the config file will result in having snapshots enabled.
https://github.com/redis/redis/blob/6.2/redis.conf#L369-L377

To disable snapshots in Redis 6.2 requires setting `SAVE ""` as a line in the config file. This change allows the Redis lens to use `SAVE ""` a valid directive in the Redis configuration. Without this change, snapshots cannot be disabled using this lens.

Using `SAVE ""` to disable snapshots has been valid syntax since Redis 2.8
https://github.com/redis/redis/blob/2.8/redis.conf#L141-L145
