### PR TITLE
fix(lens): toml: write support

### DIFF
--- a/lenses/tests/test_toml.aug
+++ b/lenses/tests/test_toml.aug
@@ -331,3 +331,14 @@ Likes tater tots and beer." }
     { "entry" = "color"
       { "string" = "gray" } } }
 
+(* Variable: minimal_toml *)
+let minimal_toml = "[root]
+foo = \"bar\"
+"
+
+(* Test: minimal write *)
+test Toml.lns put minimal_toml after
+    set "/table[1]/entry[1]/string" "foo"
+  = "[root]
+foo = \"foo\"
+"

--- a/lenses/tests/test_toml.aug
+++ b/lenses/tests/test_toml.aug
@@ -104,16 +104,14 @@ test Toml.array_norec get "[ \"foo\", \"bar\" ]" =
     { "string" = "foo" } {}
     { "string" = "bar" } {} }
 
-(* Test: Toml.array_norec
+(* Test: Toml.array_rec
      Array of arrays *)
-test Toml.array_rec get "[ [ \"foo\", [ 42, 43 ] ], \"bar\" ]" =
+test Toml.array_rec get "[ [ \"foo\", \"bar\" ], 42 ]" =
   { "array" {}
     { "array" {}
       { "string" = "foo" } {}
-      { "array" {}
-        { "integer" = "42" } {}
-        { "integer" = "43" } {} } {} } {}
-    { "string" = "bar" } {} }
+      { "string" = "bar" } {} } {}
+    { "integer" = "42" } {} }
 
 (* Test: Toml.lns
      Global parameters *)

--- a/lenses/toml.aug
+++ b/lenses/toml.aug
@@ -111,7 +111,9 @@ let array (value:lens) = [ label "array" . lbrack
 
 let array_norec = array norec
 
-let rec array_rec = array (norec | array_rec)
+(* This is actually no real recursive array, instead it is one or two dimensional
+   For more info on this see https://github.com/hercules-team/augeas/issues/715 *)
+let array_rec = array (norec | array_norec)
 
 let entry_base (value:lens) = [ label "entry" . store Rx.word . Sep.space_equal . value ]
 

--- a/lenses/toml.aug
+++ b/lenses/toml.aug
@@ -5,7 +5,7 @@ Module: Toml
 Author: Raphael Pinson <raphael.pinson@camptocamp.com>
 
 About: Reference
-  https://github.com/mojombo/toml/blob/master/README.md
+  https://toml.io/en/v1.0.0
 
 About: License
    This file is licenced under the LGPL v2+, like the rest of Augeas.

--- a/lenses/toml.aug
+++ b/lenses/toml.aug
@@ -8,7 +8,7 @@ About: Reference
   https://toml.io/en/v1.0.0
 
 About: License
-   This file is licenced under the LGPL v2+, like the rest of Augeas.
+   This file is licensed under the LGPL v2+, like the rest of Augeas.
 
 About: Lens Usage
    To be documented


### PR DESCRIPTION
The toml lens fails to save simple toml files due to problems with multi
dimensional (>2) arrays.
Therefore disable arrays with more than 2 dimensions for now to enable
basic usage again.

This commit fixes issue #715 by applying the suggested workaround. If
anyone can come up with a better solution please feel free to do so.

Fixes: 5e1cd313 (TOML lens (#91), 2018-11-29)
Signed-off-by: Richard Leitner <richard.leitner@skidata.com>