### PR TITLE
Replace deprecated 'security_context_t' with 'char *'

### DIFF
--- a/src/transform.c
+++ b/src/transform.c
@@ -918,7 +918,7 @@ static int transfer_file_attrs(FILE *from, FILE *to,
     struct stat st;
     int ret = 0;
     int selinux_enabled = (is_selinux_enabled() > 0);
-    security_context_t con = NULL;
+    char *con = NULL;
 
     int from_fd;
     int to_fd = fileno(to);


### PR DESCRIPTION
https://github.com/SELinuxProject/selinux/commit/7a124ca275
https://github.com/SELinuxProject/selinux/pull/212/files