### PR TITLE
semanage: Fix parsing of ignoredirs

### DIFF
--- a/lenses/semanage.aug
+++ b/lenses/semanage.aug
@@ -23,7 +23,12 @@ let sep = IniFile.sep "=" "="
 let empty = IniFile.empty
 let eol = IniFile.eol
 
-let entry = IniFile.entry IniFile.entry_re sep comment
+let list_keys = "ignoredirs"
+let scl = del ";" ";"
+let fspath = /[^ \t\n;#]+/ (* Rx.fspath without ; or # *)
+
+let entry = IniFile.entry_list list_keys sep fspath scl comment
+          | IniFile.entry (IniFile.entry_re - list_keys) sep comment
           | empty
 
 let title = IniFile.title_label "@group" (IniFile.record_re - /^end$/)

--- a/lenses/tests/test_semanage.aug
+++ b/lenses/tests/test_semanage.aug
@@ -68,7 +68,9 @@ test Semanage.lns get conf =
    { "usepasswd" = "False" }
    { "bzip-small" = "true" }
    { "bzip-blocksize" = "5" }
-   { "ignoredirs" = "/root" }
+   { "ignoredirs"
+     { "1" = "/root" }
+   }
    { }
    { "@group" = "sefcontext_compile"
      { "path" = "/usr/sbin/sefcontext_compile" }

--- a/tests/root/etc/selinux/semanage.conf
+++ b/tests/root/etc/selinux/semanage.conf
@@ -1,0 +1,60 @@
+# Authors: Jason Tang <jtang@tresys.com>
+#
+# Copyright (C) 2004-2005 Tresys Technology, LLC
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# Specify how libsemanage will interact with a SELinux policy manager.
+# The four options are:
+#
+#  "source"     - libsemanage manipulates a source SELinux policy
+#  "direct"     - libsemanage will write directly to a module store.
+#  /foo/bar     - Write by way of a policy management server, whose
+#                 named socket is at /foo/bar.  The path must begin
+#                 with a '/'.
+#  foo.com:4242 - Establish a TCP connection to a remote policy
+#                 management server at foo.com.  If there is a colon
+#                 then the remainder is interpreted as a port number;
+#                 otherwise default to port 4242.
+module-store = direct
+
+# When generating the final linked and expanded policy, by default
+# semanage will set the policy version to POLICYDB_VERSION_MAX, as
+# given in <sepol/policydb.h>.  Change this setting if a different
+# version is necessary.
+#policy-version = 19
+
+# expand-check check neverallow rules when executing all semanage
+# commands. There might be a penalty in execution time if this
+# option is enabled.
+expand-check=0
+
+# usepasswd check tells semanage to scan all pass word records for home directories
+# and setup the labeling correctly. If this is turned off, SELinux will label only /home
+# and home directories of users with SELinux login mappings defined, see
+# semanage login -l for the list of such users.
+# If you want to use a different home directory, you will need to use semanage fcontext command.
+# For example, if you had home dirs in /althome directory you would have to execute
+# semanage fcontext -a -e /home /althome
+usepasswd=False
+bzip-small=true
+bzip-blocksize=5
+ignoredirs=/root;/bin;/boot;/dev;/etc;/lib;/lib64;/proc;/run;/sbin;/sys;/tmp;/usr;/var
+optimize-policy=true
+
+[sefcontext_compile]
+path = /usr/sbin/sefcontext_compile
+args = -r $@
+[end]

--- a/tests/xpath.tests
+++ b/tests/xpath.tests
@@ -109,6 +109,7 @@ test descendant-or-self /files/descendant-or-self :: 4
      /files/etc/ssh/ssh_config/Host/SendEnv[1]/4 = LC_TIME
      /files/etc/ssh/ssh_config/Host/SendEnv[2]/4 = LC_TELEPHONE
      /files/etc/aliases/4
+     /files/etc/selinux/semanage.conf/ignoredirs/4 = /dev
      /files/etc/fstab/4
      /files/etc/pam.d/login/4
      /files/etc/pam.d/newrole/4


### PR DESCRIPTION
From /etc/selinux/semanage.conf from a RHEL 9.1 system, this line
caused problems:

  ignoredirs=/root;/bin;/boot;/dev;/etc [...]

Parse this as a list of Rx.fspath.

Also this adds the RHEL 9 file as another test case and adjusts the
output of the existing test case.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2077120
Signed-off-by: Richard W.M. Jones <rjones@redhat.com>