### PR TITLE
Key may be quoted

### DIFF
--- a/lenses/toml.aug
+++ b/lenses/toml.aug
@@ -119,7 +119,10 @@ let inline_table (value:lens) = [ label "inline_table" . lbrace
                    . ( (Build.opt_list (entry_base value) comma . space_or_empty? . rbrace)
                       | rbrace ) ]
 
-let entry = [ label "entry" . Util.indent . store Rx.word . Sep.space_equal
+let key_quoted = Quote.dquote . store Rx.word . Quote.dquote
+let key_unquoted = store Rx.word
+
+let entry = [ label "entry" . Util.indent . (key_quoted | key_unquoted) . Sep.space_equal
             . (norec | array_rec | inline_table (norec|array_norec)) . (eol | comment) ]
 
 (* Group: tables *)


### PR DESCRIPTION
The lens assumed an unquoted word-like key, while it may be unquoted.

Technically, according to the
[spec](https://github.com/toml-lang/toml/blob/cbf3b13128fb717517afbd22f8fcb665a0b0b035/toml.abnf#L73),
it even allows for a few more non-word chars.

Test not adjusted (yet) because the format confused me.