### PR TITLE
Update opendkim.aug

### DIFF
--- a/lenses/opendkim.aug
+++ b/lenses/opendkim.aug
@@ -31,7 +31,7 @@ module Opendkim =
     | /OversignHeaders|PeerList|POPDBFile|RemoveARFrom|ResignMailTo/
     | /SenderHeaders|SignHeaders|SigningTable|TrustSignaturesFrom/
   let stringkv = key stringkv_rx .
-    del /[ \t]+/ " " . store /[0-9a-zA-Z\/][^ \t\n#]+/ . eol
+    del /[ \t]+/ " " . store /[0-9a-zA-Z\/][^ \t\n\*#]+/ . eol
 
   let integerkv_rx = /AutoRestartCount|ClockDrift|DNSTimeout/
     | /LDAPKeepaliveIdle|LDAPKeepaliveInterval|LDAPKeepaliveProbes|LDAPTimeout/


### PR DESCRIPTION
Allow setting Domain parameter to value *. Current version doesn't allow that:


```
Error in /etc/opendkim.conf at node /files/etc/opendkim.conf/ (put_failed)
  Unexpected node '/files/etc/opendkim.conf/Domain': can not match tree

     { "Domain" = "*" }

 with pattern
   (    { /#comment/ = /[^\t\n\r ].*[^\t\n\r ]|[^\t\n\r ]/ }
      | { }
      | { /AutoRestartCount|ClockDrift|DNSTimeout|LDAPKeepaliveIdle|LDAPKeepaliveInterval|LDAPKeepaliveProbes|LDAPTimeout|MaximumHeaders|MaximumSignaturesToVerify|MaximumSignedBytes|MilterDebug|MinimumKeyBits|SignatureTTL|UMask/ = /[0-9]+/ }
      | { /AddAllSignatureResults|ADSPNoSuchDomain|AllowSHA1Only|AlwaysAddARHeader|AuthservIDWithJobID|AutoRestart|Background|CaptureUnknownErrors|Diagnostics|DisableADSP|DisableCryptoInit|DNSConnect|FixCRLF|IdentityHeaderRemove|LDAPDisableCache|LDAPSoftStart|LDAPUseTLS|MultipleSignatures|NoHeaderB|Quarantine|QueryCache|RemoveARAll|RemoveOldSignatures|ResolverTracing|SelectorHeaderRemove|SendADSPReports|SendReports|SoftwareHeader|StrictHeaders|StrictTestMode|SubDomains|Syslog|SyslogSuccess|VBR-TrustedCertifiersOnly|WeakSyntaxChecks|LogWhy/ = /[Tt]rue|[Ff]alse|[Yy]es|[Nn]o|1|0/ }
      | { /ADSPAction|AuthservID|AutoRestartRate|BaseDirectory|BogusKey|BogusPolicy|Canonicalization|ChangeRootDirectory|DiagnosticDirectory|FinalPolicyScript|IdentityHeader|Include|KeyFile|LDAPAuthMechanism|LDAPAuthName|LDAPAuthRealm|LDAPAuthUser|LDAPBindPassword|LDAPBindUser|Minimum|Mode|MTACommand|Nameservers|On-BadSignature|On-Default|On-DNSError|On-InternalError|On-KeyNotFound|On-NoSignature|On-PolicyError|On-Security|On-SignatureError|PidFile|ReplaceRules|ReportAddress|ReportBccAddress|ResolverConfiguration|ScreenPolicyScript|SelectCanonicalizationHeader|Selector|SelectorHeader|SenderMacro|SetupPolicyScript|SignatureAlgorithm|SMTPURI|Socket|StatisticsName|StatisticsPrefix|SyslogFacility|TemporaryDirectory|TestPublicKeys|TrustAnchorFile|UnprotectedKey|UnprotectedPolicy|UserID|VBR-Certifiers|VBR-PurgeFields|VBR-TrustedCertifiers|VBR-Type|BodyLengthDB|Domain|DontSignMailTo|ExemptDomains|ExternalIgnoreList|InternalHosts|KeyTable|LocalADSP|MacroList|MTA|MustBeSigned|OmitHeaders|OversignHeaders|PeerList|POPDBFile|RemoveARFrom|ResignMailTo|SenderHeaders|SignHeaders|SigningTable|TrustSignaturesFrom/ = /[\/-9A-Za-z][^\t\n #]+/ })*

  Lens: /usr/share/augeas/lenses/dist/opendkim.aug:68.12-.38:
```