### PR TITLE
Update lens Resolv: add option trust-ad

### DIFF
--- a/lenses/resolv.aug
+++ b/lenses/resolv.aug
@@ -109,7 +109,8 @@ let options =
                         | Build.flag ("debug"|"rotate"|"no-check-names"
                                      |"inet6"|"ip6-bytestring"|"edns0"
                                      |"single-request"|"single-request-reopen"
-                                     |"no-tld-query"|"use-vc"|"no-reload")
+                                     |"no-tld-query"|"use-vc"|"no-reload"
+                                     |"trust-ad")
                         | ip6_dotint
 
             in Build.key_value_line_comment

--- a/lenses/tests/test_resolv.aug
+++ b/lenses/tests/test_resolv.aug
@@ -12,6 +12,7 @@ sortlist 130.155.160.0/255.255.240.0 130.155.0.0
 
 options ndots:3 debug timeout:2
 options no-ip6-dotint single-request-reopen # and EOL comments
+options attempts:3 rotate no-check-names inet6 ip6-bytestring ip6-dotint edns0 single-request no-tld-query use-vc no-reload trust-ad
 
 lookup file bind
 family inet6 inet4
@@ -42,8 +43,21 @@ test Resolv.lns get conf =
    { "options"
         { "ip6-dotint"
              { "negate" } }
-	{ "single-request-reopen" }
+        { "single-request-reopen" }
         { "#comment" = "and EOL comments" } }
+   { "options"
+        { "attempts" = "3" }
+        { "rotate" }
+        { "no-check-names" }
+        { "inet6" }
+        { "ip6-bytestring" }
+        { "ip6-dotint" }
+        { "edns0" }
+        { "single-request" }
+        { "no-tld-query" }
+        { "use-vc" }
+        { "no-reload" }
+        { "trust-ad" } }
    {}
    { "lookup"
         { "file" }


### PR DESCRIPTION
Update existing lens for /etc/resolv.conf (resolv.aug) to include option `trust-ad`

Updated test `test_resolv.aug` to include `option trust-ad`