### PR TITLE
Only use GNU specific strerror_r() API when __GLIBC__ is defined.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -431,8 +431,8 @@ char *cleanpath(char *path) {
 
 const char *xstrerror(int errnum, char *buf, size_t len) {
 #ifdef HAVE_STRERROR_R
-# ifdef __USE_GNU
-    /* Annoying linux specific API contract */
+# if defined(__USE_GNU) && defined(__GLIBC__)
+    /* Annoying GNU specific API contract */
     return strerror_r(errnum, buf, len);
 # else
     strerror_r(errnum, buf, len);


### PR DESCRIPTION
As reported in https://pkg-status.freebsd.org/gohan05/data/maini386PR265425-default/2022-12-06_12h24m32s/logs/errors/augeas-1.12.0_3.log, augeas uses a GNU specific `strerror_r()` invocation, even when compiling on FreeBSD. This is because gnulib's `regex.h` defines `__USE_GNU` when `_GNU_SOURCE` is used.

It is better to also check for `__GLIBC__`, since the GNU specific variant of `strerror_r()` is really a glibc invention. This will also make the code compile without warnings on Alpine Linux, which uses musl libc.
