### PR TITLE
Remove `#include <malloc.h>`

### DIFF
--- a/src/augprint.c
+++ b/src/augprint.c
@@ -69,6 +69,7 @@
 #include <string.h>
 #include <augeas.h>
 #include <errno.h>
+#include <libgen.h>        /* for basename() on FreeBSD and MacOS */
 #include <sys/param.h>     /* for MIN() MAX() */
 #include <unistd.h>
 #include "augprint.h"

--- a/src/augprint.c
+++ b/src/augprint.c
@@ -69,7 +69,6 @@
 #include <string.h>
 #include <augeas.h>
 #include <errno.h>
-#include <malloc.h>
 #include <sys/param.h>     /* for MIN() MAX() */
 #include <unistd.h>
 #include "augprint.h"


### PR DESCRIPTION
Hi! Submitting this patch to fix the build error in Homebrew/homebrew-core#118025.

`<malloc.h>` is not present on all platforms (e.g. macOS). To use `malloc`, `<stdlib.h>` should be the place to look for `malloc`, and it has already been `#include`d.

Signed-off-by: Ruoyu Zhong <zhongruoyu@outlook.com>
