### PR TITLE
HACKING.md: describe testing

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -28,7 +28,7 @@ At its simplest, you build Augeas from git by running the following
 commands in the toplevel directory of your Augeas checkout:
 
     ./autogen.sh [--gnulib-srcdir=$GNULIB_CHECKOUT]
-    make && make install
+    make && make check && make install
 
 It is recommended though to turn on a few development features when
 building; in particular, stricter compiler warnings and some debug
@@ -53,6 +53,12 @@ to augtool verbatim
   debugging augtool with commands in `build/augcmds.txt`
 * `./src/try valgrind`: run the commands from `build/augcmds.txt` through
   augtool under valgrind to check for memory leaks
+
+Furthermore, the test suite invoked with `make check` includes a test
+called `test-get.sh`, which ensures that reading the files in
+`tests/root/` with `augtool` does not lead to any errors. (It does not
+verify the parsed syntax tree however; you'll have to extend the
+individual lens tests under `lenses/tests/` for that.)
 
 # Platform specific notes
 


### PR DESCRIPTION
The top-level HACKING document is inexplicably silent on how bugs can be reproduced/triggered and how fixes/features can be verified. That's an unnecessary difficulty for anyone new trying to contribute to augeas.

Document "make check", and highlight the difference between "test-get.sh" and the individual lens tests under "lenses/tests/".

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2155147
Signed-off-by: Laszlo Ersek <lersek@redhat.com>