### PR TITLE
lenses: Allow whitespace at the end of kernel commnd line

### DIFF
--- a/lenses/cmdline.aug
+++ b/lenses/cmdline.aug
@@ -13,7 +13,7 @@ module Cmdline =
 
 let entry = [ key Rx.word . Util.del_str "=" . store Rx.no_spaces ] | [ key Rx.word ]
 
-let lns = (Build.opt_list entry Sep.space)? . del /\n?/ ""
+let lns = (Build.opt_list entry Sep.space)? . del /[ \t]*\n?/ ""
 
 let filter = incl "/etc/kernel/cmdline"
            . incl "/proc/cmdline"

--- a/lenses/tests/test_cmdline.aug
+++ b/lenses/tests/test_cmdline.aug
@@ -4,6 +4,7 @@ let lns = Cmdline.lns
 
 test lns get "foo\nbar" = *
 test lns get "foo\n" = { "foo" }
+test lns get "foo \n" = { "foo" }
 test lns get "foo" = { "foo" }
 test lns get "foo bar" = { "foo" } { "bar" }
 test lns get "foo    bar" = { "foo" } { "bar" }


### PR DESCRIPTION
Reported-by: Yongkui Guo
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2159282
Signed-off-by: Richard W.M. Jones <rjones@redhat.com>