### PR TITLE
Tmpfiles: few improvements

### DIFF
--- a/lenses/tests/test_tmpfiles.aug
+++ b/lenses/tests/test_tmpfiles.aug
@@ -97,6 +97,60 @@ Tree for <minus_tree> *)
         { "argument" = "-" }
     }
 
+  (* Variable: equal
+Example with an equal sign in the type *)
+  let equal = "d= /tmp/foo 0755 root root - -\n"
+
+  (* Variable: equal_tree
+Tree for <equal> *)
+  let equal_tree =
+    {
+        "1"
+        { "type" = "d=" }
+        { "path" = "/tmp/foo" }
+        { "mode" = "0755" }
+        { "uid" = "root" }
+        { "gid" = "root" }
+        { "age" = "-" }
+        { "argument" = "-" }
+    }
+
+  (* Variable: tilde
+Example with a tilde character in the type *)
+  let tilde = "w~ /tmp/foo 0755 root root - dGVzdAo=\n"
+
+  (* Variable: tilde_tree
+Tree for <tilde> *)
+  let tilde_tree =
+    {
+        "1"
+        { "type" = "w~" }
+        { "path" = "/tmp/foo" }
+        { "mode" = "0755" }
+        { "uid" = "root" }
+        { "gid" = "root" }
+        { "age" = "-" }
+        { "argument" = "dGVzdAo=" }
+    }
+
+  (* Variable: caret
+Example with a caret in the type *)
+  let caret = "f^ /etc/motd.d/50-provision.conf - - - - login.motd\n"
+
+  (* Variable: caret_tree
+Tree for <caret> *)
+  let caret_tree =
+    {
+        "1"
+        { "type" = "f^" }
+        { "path" = "/etc/motd.d/50-provision.conf" }
+        { "mode" = "-" }
+        { "uid" = "-" }
+        { "gid" = "-" }
+        { "age" = "-" }
+        { "argument" = "login.motd" }
+    }
+
   (* Variable: short
 Example with only type and path *)
   let short = "A+ /tmp/foo\n"
@@ -376,6 +430,12 @@ Invalid example that contain invalid mode (letter) *)
   test Tmpfiles.lns get exclamation_mark = exclamation_mark_tree
 
   test Tmpfiles.lns get minus = minus_tree
+
+  test Tmpfiles.lns get equal = equal_tree
+
+  test Tmpfiles.lns get tilde = tilde_tree
+
+  test Tmpfiles.lns get caret = caret_tree
 
   test Tmpfiles.lns get short = short_tree
 

--- a/lenses/tests/test_tmpfiles.aug
+++ b/lenses/tests/test_tmpfiles.aug
@@ -391,6 +391,22 @@ Tree for <mode3> *)
         { "mode" = "755" }
     }
 
+  (* Variable: mode_colon
+Mode field with colon prefix *)
+  let mode_colon = "d- /root :0700 root :root\n"
+
+  (* Variable: mode_colon_tree
+Tree for <mode_colon> *)
+  let mode_colon_tree =
+    {
+        "1"
+        { "type" = "d-" }
+        { "path" = "/root" }
+        { "mode" = ":0700" }
+        { "uid" = "root" }
+        { "gid" = ":root" }
+    }
+
 (************************************************************************
  * Group:                 INVALID EXAMPLES
  *************************************************************************)
@@ -464,6 +480,8 @@ Invalid example that contain invalid mode (letter) *)
   test Tmpfiles.lns get valid_base = valid_base_tree
 
   test Tmpfiles.lns get mode3 = mode3_tree
+
+  test Tmpfiles.lns get mode_colon = mode_colon_tree
 
 
 (* failure cases *)

--- a/lenses/tmpfiles.aug
+++ b/lenses/tmpfiles.aug
@@ -50,11 +50,12 @@ Empty lines *)
 
   (* View: type
 One letter. Some of them can have a "+" and all can have an
-exclamation mark ("!") and/or minus sign ("-").
+exclamation mark ("!"), a minus sign ("-"), an equal sign ("="),
+a tilde character ("~") and/or a caret ("^").
 
 Not all letters are valid.
 *)
-  let type     = /([fFwdDevqQpLcbCxXrRzZtThHaAm]|[fFwpLcbaA]\+)!?-?/
+  let type     = /([fFwdDevqQpLcbCxXrRzZtThHaAm]|[fFwpLcbaA]\+)[-!=~^]*/
 
   (* View: mode
 "-", or 3-4 bytes. Optionally starts with a "~". *)

--- a/lenses/tmpfiles.aug
+++ b/lenses/tmpfiles.aug
@@ -58,8 +58,8 @@ Not all letters are valid.
   let type     = /([fFwdDevqQpLcbCxXrRzZtThHaAm]|[fFwpLcbaA]\+)[-!=~^]*/
 
   (* View: mode
-"-", or 3-4 bytes. Optionally starts with a "~". *)
-  let mode     = /(-|~?[0-7]{3,4})/
+"-", or 3-4 bytes. Optionally starts with a "~" or a ":". *)
+  let mode     = /(-|(~|:)?[0-7]{3,4})/
 
   (* View: age
 "-", or one of the formats seen in the manpage: 10d, 5seconds, 1y5days.


### PR DESCRIPTION
- recognize `=`, `~`, `^` for the type specification (fixes #795)
- allow `:` as prefix for file modes