### PR TITLE
TOML: support trailing commas

### DIFF
--- a/lenses/tests/test_toml.aug
+++ b/lenses/tests/test_toml.aug
@@ -104,6 +104,13 @@ test Toml.array_norec get "[ \"foo\", \"bar\" ]" =
     { "string" = "foo" } {}
     { "string" = "bar" } {} }
 
+(* Test: Toml.array_norec
+     Array of strings with trailing comma *)
+test Toml.array_norec get "[ \"foo\", \"bar\", ]" =
+  { "array" {}
+    { "string" = "foo" } {}
+    { "string" = "bar" } {} }
+
 (* Test: Toml.array_rec
      Array of arrays *)
 test Toml.array_rec get "[ [ \"foo\", \"bar\" ], 42 ]" =

--- a/lenses/toml.aug
+++ b/lenses/toml.aug
@@ -106,7 +106,7 @@ let norec = str | str_multi | str_literal
           | datetime | date |  time
 
 let array (value:lens) = [ label "array" . lbrack
-               . ( ( Build.opt_list value comma . space_or_empty? . rbrack )
+               . ( ( Build.opt_list value comma . (del /,?/ "") . space_or_empty? . rbrack )
                    | rbrack ) ]
 
 let array_norec = array norec


### PR DESCRIPTION
Add support for trailing commas in TOML arrays. Fixes #753.