### PR TITLE
Fix bug from PR#691 where the nodes of a newly created file are lost upon a subsequent load operation

### DIFF
--- a/src/augeas.c
+++ b/src/augeas.c
@@ -1516,6 +1516,10 @@ static int tree_save(struct augeas *aug, struct tree *tree,
                 }
             }
             if (transform != NULL) {
+                /* If this file did not previously exist and is being created by augeas,
+                 * then the 'file' flag in the node t will not be set yet. Set it now
+                 */
+                t->file = true;
                 int r = transform_save(aug, transform, tpath, t);
                 if (r == -1)
                     result = -1;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -286,7 +286,7 @@ check_SCRIPTS = \
   test-augtool-empty-line.sh test-augtool-modify-root.sh \
   test-span-rec-lens.sh test-nonwritable.sh test-augmatch.sh \
   test-augprint.sh \
-  test-function-modified.sh
+  test-function-modified.sh test-createfile.sh
 
 EXTRA_DIST = \
   test-augtool test-augprint root lens-test-1 \

--- a/tests/test-createfile.sh
+++ b/tests/test-createfile.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Test that augeas can create a file based on new paths added to the tree
+# The tree should retain the paths on a subsequent load operation
+#
+
+root=${abs_top_builddir:-.}/build/test-createfile
+lenses=${abs_top_srcdir:-.}/lenses
+
+sysctl_file=/etc/sysctl.d/newfile1.conf
+
+rm -rf $root
+mkdir -p $(dirname $root/$sysctl_file)
+
+expected_match="/files/etc/sysctl.d/newfile1.conf/net.ipv4.ip_nonlocal_bind = 1"
+expected_content='net.ipv4.ip_nonlocal_bind = 1'
+
+output=$(augtool --nostdinc -r $root -I $lenses <<EOF | grep "$expected_match"
+set /files/etc/sysctl.d/newfile1.conf/net.ipv4.ip_nonlocal_bind 1
+save
+match /files/etc/sysctl.d/newfile1.conf/net.ipv4.ip_nonlocal_bind
+EOF
+)
+
+if [[ ! -e $root/$sysctl_file ]]; then
+  echo "Failed to create file $sysctl_file under $root"
+  exit 1
+elif ! diff -bq $root/$sysctl_file <(echo "$expected_content") 1>/dev/null 2>&1; then
+  echo "Contents of $root/sysctl_file are incorrect"
+  cat  $root/$sysctl_file
+  echo '-- end of file --'
+  echo "Expected:"
+  echo "$expected_content"
+  echo '-- end of file --'
+  exit 1
+elif [[ -z "$output" ]]; then
+  echo "Missing /files/$sysctl_file in tree after save"
+  exit 1
+else
+  echo "Successfully created $sysctl_file with content:"
+  cat  $root/$sysctl_file
+  echo '-- end of file --'
+fi
+
+sysctl_file=/etc/sysctl.d/newfile2.conf
+
+expected_match="/files/etc/sysctl.d/newfile2.conf/net.ipv4.ip_forward = 1"
+expected_content='net.ipv4.ip_forward = 1'
+
+output=$(augtool --nostdinc -r $root -I $lenses <<EOF | grep "$expected_match"
+set /files/etc/sysctl.d/newfile2.conf/net.ipv4.ip_forward 1
+save
+load
+match /files/etc/sysctl.d/newfile2.conf/*
+save
+EOF
+)
+
+if [[ ! -e $root/$sysctl_file ]]; then
+  echo "Failed to create file $sysctl_file under $root"
+  exit 1
+elif ! diff -bq $root/$sysctl_file <(echo "$expected_content") 1>/dev/null 2>&1; then
+  echo "Contents of $root/sysctl_file are incorrect"
+  cat  $root/$sysctl_file
+  echo '-- end of file --'
+  echo "Expected:"
+  echo "$expected_content"
+  echo '-- end of file --'
+  exit 1
+elif [[ -z "$output" ]]; then
+  echo "Missing /files/$sysctl_file in tree after save"
+  exit 1
+else
+  echo "Successfully created $sysctl_file with content:"
+  cat  $root/$sysctl_file
+  echo '-- end of file --'
+fi


### PR DESCRIPTION
Pull Request #691 introduced a new function to path expressions `modified()`
This function exposed the value of the internal flag `dirty` on a node.
In order for `modifed()` to reflect _only_ the changed nodes, some of the logic around the `dirty` flag was modified.
This caused a bug which appeared after a `save`operation, where upon a subsequent `load` operation, where the nodes of a newly created file were inadvertently  removed.
This PR fixes the inadvertent cleanup on the subsequent load operation, if the file has been saved.
Unsaved nodes under `/files` are still cleaned up by the load operation