### PR TITLE
Fix some compiler warnings in lens.c, augmatch.c

### DIFF
--- a/src/augmatch.c
+++ b/src/augmatch.c
@@ -302,7 +302,7 @@ static char *guess_lens_name(const char *file) {
 
 int main(int argc, char **argv) {
     int opt;
-    cleanup(aug_closep) struct augeas *aug;
+    cleanup(aug_closep) struct augeas *aug = NULL;
     cleanup(freep) char *loadpath = NULL;
     size_t loadpath_len = 0;
     cleanup(freep) char *root = NULL;

--- a/src/lens.h
+++ b/src/lens.h
@@ -274,6 +274,8 @@ char *enc_format_indent(const char *e, size_t len, int indent);
 #if ENABLE_DEBUG
 void dump_lens_tree(struct lens *lens);
 void dump_lens(FILE *out, struct lens *lens);
+#else
+#define dump_lens_tree(lens) (void)0
 #endif
 
 #endif


### PR DESCRIPTION
Tested with:

```
./autogen.sh --enable-debug=no --enable-compile-warnings=maximum
make distcheck
```

and

```
./autogen.sh --enable-debug=yes --enable-compile-warnings=maximum
make distcheck
```

Fixes issue #817