### PR TITLE
Fix lens ntp.aug (tos/minclock) and support ntpsec conf file (Debian12)

### DIFF
--- a/lenses/ntp.aug
+++ b/lenses/ntp.aug
@@ -117,8 +117,7 @@ module Ntp =
             orphan stratum | orphanwait delay] *)
 
     let tos =
-      let arg_names = /beacon|ceiling|cohort|floor|maxclock|maxdist|
-                      minclock|mindist|minsane|orphan|orphanwait/ in
+      let arg_names = /beacon|ceiling|cohort|floor|maxclock|maxdist|minclock|mindist|minsane|orphan|orphanwait/ in
       let arg = [ key arg_names . sep_spc . store Rx.decimal ] in
       [ key "tos" . (sep_spc . arg)* . eol ]
 
@@ -135,5 +134,6 @@ module Ntp =
               | auth_command | tinker | tos | interface)*
 
     let filter = (incl "/etc/ntp.conf")
+               . (incl "/etc/ntpsec/ntp.conf")
 
     let xfm = transform lns filter

--- a/lenses/tests/test_ntp.aug
+++ b/lenses/tests/test_ntp.aug
@@ -183,3 +183,9 @@ test Ntp.tinker get "tinker panic 0 huffpuff 3.14\n" =
 test Ntp.tos get "tos maxdist 16\n" =
   { "tos"
     { "maxdist" = "16" } }
+
+(* PR #821: tos minclock directive *)
+test Ntp.tos get "tos minclock 4 minsane 3\n" =
+  { "tos"
+    { "minclock" = "4" }
+    { "minsane" = "3" } }


### PR DESCRIPTION
- fixed lens parser fails on 'tos/minclock' (/etc/ntpsec/ntp.conf on debian12 with that line "tos minclock 4 minsane 3" )
- filter : add /etc/ntpsec/ntp.conf