### PR TITLE
Make ATTRIBUTE_FALLTHROUGH work cross-compiler

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -197,6 +197,8 @@
 #    else
 #      define ATTRIBUTE_FALLTHROUGH
 #    endif
+#  else
+#    define ATTRIBUTE_FALLTHROUGH
 #  endif
 #endif
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -191,10 +191,12 @@
 /* Allow falling through in switch statements for the few cases where that
    is needed */
 #ifndef ATTRIBUTE_FALLTHROUGH
-#  if __GNUC_PREREQ (7, 0)
-#    define ATTRIBUTE_FALLTHROUGH __attribute__ ((fallthrough))
-#  else
-#    define ATTRIBUTE_FALLTHROUGH
+#  if defined __has_attribute
+#    if __has_attribute (fallthrough)
+#      define ATTRIBUTE_FALLTHROUGH __attribute__ ((fallthrough))
+#    else
+#      define ATTRIBUTE_FALLTHROUGH
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
Current code doesn't work on LLVM. This should fix it so it works on gcc and llvm.