### PR TITLE
lenses/fstab.aug: Allow comma after the last option

### DIFF
--- a/lenses/fstab.aug
+++ b/lenses/fstab.aug
@@ -5,6 +5,7 @@ module Fstab =
 
   let sep_tab = Sep.tab
   let sep_spc = Sep.space
+  let sep_comma_tab = del /,?[ \t]+/ "\t"
   let comma   = Sep.comma
   let eol     = Util.eol
 
@@ -28,7 +29,7 @@ module Fstab =
                    [ label "file" . store file ] . sep_tab .
                    comma_sep_list "vfstype" .
                    (sep_tab . comma_sep_list "opt" .
-                    (sep_tab . [ label "dump" . store /[0-9]+/ ] .
+                    (sep_comma_tab . [ label "dump" . store /[0-9]+/ ] .
                      ( sep_spc . [ label "passno" . store /[0-9]+/ ])? )? )?
                  . Util.comment_or_eol ]
 

--- a/lenses/tests/test_fstab.aug
+++ b/lenses/tests/test_fstab.aug
@@ -156,6 +156,17 @@ module Test_fstab =
     { "#comment" = "device at install: /dev/sda3" }
   }
 
+  (* Bug #832 - Allow comma after the last option *)
+  test Fstab.lns get "/dev/mapper/foo-bar / xfs defaults, 0 0\n" =
+  { "1"
+    { "spec" = "/dev/mapper/foo-bar" }
+    { "file" = "/" }
+    { "vfstype" = "xfs" }
+    { "opt" = "defaults" }
+    { "dump" = "0" }
+    { "passno" = "0" }
+  }
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)


### PR DESCRIPTION
This PR adds a new lens that allows a comma after the last option:
```
/dev/mapper/foo-bar / xfs defaults, 0 0
```

Fixes: https://github.com/hercules-team/augeas/issues/832

Signed-off-by: cosmin@redhat.com