### PR TITLE
lenses/nginx.aug: Allow types block to be defined

### DIFF
--- a/lenses/nginx.aug
+++ b/lenses/nginx.aug
@@ -33,10 +33,14 @@ autoload xfm
 
 (* Variable: word *)
 let word = /[A-Za-z0-9_.:-]+/
+(* Variable: sub_type_word
+  According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+*)
+let sub_type_work = /[A-Za-z.-]+[0-9_]*/
 
 (* Variable: block_re
      The keywords reserved for block entries *)
-let block_re = "http" | "events" | "server" | "mail" | "stream"
+let block_re = "http" | "events" | "server" | "mail" | "stream" | "types"
 
 (* All block keywords, including the ones we treat specially *)
 let block_re_all = block_re | "if" | "location" | "geo" | "map"
@@ -47,9 +51,10 @@ let block_re_all = block_re | "if" | "location" | "geo" | "map"
 let simple =
      let kw = word - block_re_all
   in let mask = [ label "mask" . Util.del_str "/" . store Rx.integer ]
+  in let sub_type = [ label "sub_type" . Util.del_str "/" . store sub_type_word ]
   in let sto = store /[^ \t\n;#]([^";#]|"[^"]*\")*/
   in [ Util.indent .
-       key kw . mask? .
+       key kw . (sub_type | mask)? .
        (Sep.space . sto)? . Sep.semicolon .
        (Util.eol|Util.comment_eol) ]
 

--- a/lenses/tests/test_nginx.aug
+++ b/lenses/tests/test_nginx.aug
@@ -297,3 +297,15 @@ test lns get "upstream php-handler {
     { "@server"
       { "@address" = "unix:/var/run/php/php7.3-fpm.sock" } } }
 
+test lns get "types {
+    text/html                       html;
+    application/x-bzip2             bz2;
+    application/vnd.ms-powerpoint   ppt;
+}\n" =
+  { "types"
+    { "text" = "html"
+        { "sub_type" = "html" } }
+    { "application" = "bz2"
+      { "sub_type" = "x-bzip2" } }
+    { "application" = "ppt"
+      { "sub_type" = "vnd.ms-powerpoint" } } }


### PR DESCRIPTION
This PR allow types block to be parsed.

Fixes: #834.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>