### PR TITLE
lenses/tmpfiles.aug: Permit '$' character in /usr/lib/tmpfiles.d/*.conf

### DIFF
--- a/lenses/tests/test_tmpfiles.aug
+++ b/lenses/tests/test_tmpfiles.aug
@@ -115,6 +115,24 @@ Tree for <equal> *)
         { "argument" = "-" }
     }
 
+  (* Variable: dollar
+Example with a dollar sign in the type *)
+  let dollar = "d$ /tmp/foo 0755 root root - -\n"
+
+  (* Variable: dollar_tree
+Tree for <dollar> *)
+  let dollar_tree =
+    {
+        "1"
+        { "type" = "d$" }
+        { "path" = "/tmp/foo" }
+        { "mode" = "0755" }
+        { "uid" = "root" }
+        { "gid" = "root" }
+        { "age" = "-" }
+        { "argument" = "-" }
+    }
+
   (* Variable: tilde
 Example with a tilde character in the type *)
   let tilde = "w~ /tmp/foo 0755 root root - dGVzdAo=\n"
@@ -448,6 +466,8 @@ Invalid example that contain invalid mode (letter) *)
   test Tmpfiles.lns get minus = minus_tree
 
   test Tmpfiles.lns get equal = equal_tree
+
+  test Tmpfiles.lns get dollar = dollar_tree
 
   test Tmpfiles.lns get tilde = tilde_tree
 

--- a/lenses/tmpfiles.aug
+++ b/lenses/tmpfiles.aug
@@ -55,7 +55,7 @@ a tilde character ("~") and/or a caret ("^").
 
 Not all letters are valid.
 *)
-  let type     = /([fFwdDevqQpLcbCxXrRzZtThHaAm]|[fFwpLcbaA]\+)[-!=~^]*/
+  let type     = /([fFwdDevqQpLcbCxXrRzZtThHaAm]|[fFwpLcbaA]\+)[-!=~^$]*/
 
   (* View: mode
 "-", or 3-4 bytes. Optionally starts with a "~" or a ":". *)


### PR DESCRIPTION
In Fedora 42 & RHEL 10 we see:

  $ cat /usr/lib/tmpfiles.d/systemd.conf
  ...
  d$ /run/systemd/seats 0755 root root -
  ...

where the '$' means (from tmpfiles.d(5)):

  If the dollar sign ("$") is used, the file becomes subject to
  removal when systemd-tmpfiles is invoked with the --purge
  switch. Lines without this character are unaffected by that switch.

Fixes: https://issues.redhat.com/browse/RHEL-76283