### PR TITLE
CVE-2025-2588: return _REG_ENOSYS if no specific error was set yet pa…

### DIFF
--- a/src/fa.c
+++ b/src/fa.c
@@ -3550,6 +3550,8 @@ static struct re *parse_regexp(struct re_parse *parse) {
     return re;
 
  error:
+    if (re == NULL && parse->error == REG_NOERROR)
+        parse->error = _REG_ENOSYS;
     re_unref(re);
     return NULL;
 }

--- a/src/fa.h
+++ b/src/fa.h
@@ -81,7 +81,8 @@ extern int fa_minimization_algorithm;
  *
  * On success, FA points to the newly allocated automaton constructed for
  * RE, and the function returns REG_NOERROR. Otherwise, FA is NULL, and the
- * return value indicates the error.
+ * return value indicates the error. Special value _REG_ENOSYS indicates
+ * fa_compile() couldn't identify the syntax issue with regexp.
  *
  * The FA is case sensitive. Call FA_NOCASE to switch it to
  * case-insensitive.

--- a/tests/fatest.c
+++ b/tests/fatest.c
@@ -589,6 +589,7 @@ static void testExpandNoCase(CuTest *tc) {
     const char *p1 = "aB";
     const char *p2 = "[a-cUV]";
     const char *p3 = "[^a-z]";
+    const char *wrong_regexp = "{&.{";
     char *s;
     size_t len;
     int r;
@@ -606,6 +607,11 @@ static void testExpandNoCase(CuTest *tc) {
     r = fa_expand_nocase(p3, strlen(p3), &s, &len);
     CuAssertIntEquals(tc, 0, r);
     CuAssertStrEquals(tc, "[^A-Za-z]", s);
+    free(s);
+
+    /* Test that fa_expand_nocase does return _REG_ENOSYS */
+    r = fa_expand_nocase(wrong_regexp, strlen(wrong_regexp), &s, &len);
+    CuAssertIntEquals(tc, _REG_ENOSYS, r);
     free(s);
 }
 


### PR DESCRIPTION
…rse_regexp failed

parse_regexp() supposed to set an error on the parser state in case of a failure. If no specific error was set, return _REG_ENOSYS to indicate a generic failure.

Fixes: https://github.com/hercules-team/augeas/issues/671
Fixes: https://github.com/hercules-team/augeas/issues/778
Fixes: https://github.com/hercules-team/augeas/issues/852