### PR TITLE
Ignore "nobody" groups in test-preserve.sh

### DIFF
--- a/tests/test-preserve.sh
+++ b/tests/test-preserve.sh
@@ -22,7 +22,7 @@ init_dirs
 printf '127.0.0.1\tlocalhost\n' > $hosts
 
 chmod 0600 $hosts
-group=$(groups | tr ' ' '\n' | tail -1)
+group=$(groups | tr ' ' '\n' | grep -v nobody | tail -1)
 chgrp $group $hosts
 
 [ -x /usr/bin/chcon ] && selinux=yes || selinux=no


### PR DESCRIPTION
When building in some unprivileged namespaces (e.g. with bwrap), all supplementary groups are replaced with 65534(nobody); however, nobody is not a valid group for chgrp, so it should be ignored