### PR TITLE
Fix preview when spans are enabled

### DIFF
--- a/src/augeas.c
+++ b/src/augeas.c
@@ -1933,14 +1933,7 @@ tree_source(const augeas *aug, struct tree *tree) {
         tree = tree->parent;
 
     if (tree->file) {
-        if (tree->span == NULL) {
-            int r;
-            r = ALLOC(tree->span);
-            ERR_NOMEM(r < 0, aug);
-            tree->span->filename = make_string(path_of_tree(tree));
-            ERR_NOMEM(tree->span->filename == NULL, aug);
-        }
-        result = strdup(tree->span->filename->str);
+        result = path_of_tree(tree);
         ERR_NOMEM(result == NULL, aug);
     }
  error:


### PR DESCRIPTION
The `preview` function does not work as expected when the `AUG_ENABLE_SPAN` flag is passed. This path computed by `tree_source` seems incorrect in this case:

* When the spans are not enabled, the `tree_source` call in the test returns `/files/etc/hosts`.
* When the spans are enabled, the `tree_source` call in the test returns `/home/.../augeas/tests/root/etc/hosts` which then makes the preview fail.

The added tests fails, and is fixed by removing the special case when span are defined in `tree_source`, but I don't grasp the possible implications of this change.