### PR TITLE
lenses/iptables.aug: Support ipset module

### DIFF
--- a/lenses/iptables.aug
+++ b/lenses/iptables.aug
@@ -47,6 +47,15 @@ let tcp_flags =
       spc . dels "--tcp-flags" .
       spc . flag_list "mask" . spc . flag_list "set" ]
 
+let ipset_flags =
+  let flags = /src|dst/ in
+  let match_flag (name:string) =
+    Build.opt_list [label name . store flags] (dels ",") in
+  [ label "ipset_flags" .
+      spc . dels "--match-set" .
+      spc . store /[a-zA-Z-][a-zA-Z0-9-]+/ .
+      spc . match_flag "set" ]
+
 (* misses --set-counters *)
 let ipt_match =
   let any_key = /[a-zA-Z-][a-zA-Z0-9-]+/ -
@@ -65,6 +74,7 @@ let ipt_match =
     |neg_param "fragment" "f"
     |param "match" "m"
     |tcp_flags
+    |ipset_flags
     |any_param)*
 
 let chain_action (n:string) (o:string) =


### PR DESCRIPTION
Iptables includes a module for integration with ipset.
However, augeas does not appear to support the second argument required for the iptables module: ```---match-set```.

Example Iptables rule:
```-I INPUT -m set --match-set <setname> src -j DROP```

Example of adding the rule:
```
defnode rule \$filter/insert[.='INPUT'][last()+1] "INPUT"
set \$rule/match "set"
set \$rule/ipset_flags "<setname>"
set \$rule/ipset_flags/set "src"
set \$rule/jump "DROP"
```

Fixes: [hercules-team#860](https://github.com/hercules-team/augeas/issues/860)