### PR TITLE
Update `nginx.aug` to include snippets directory

### DIFF
--- a/lenses/nginx.aug
+++ b/lenses/nginx.aug
@@ -125,11 +125,11 @@ let filter = incl "/etc/nginx/nginx.conf"
            . incl "/etc/nginx/conf.d/*.conf"
            . incl "/etc/nginx/sites-available/*"
            . incl "/etc/nginx/sites-enabled/*"
+           . incl "/etc/nginx/snippets/*"
            . incl "/usr/portage/www-servers/nginx/files/nginx.conf"
            . incl "/usr/local/etc/nginx/nginx.conf"
            . incl "/usr/local/etc/nginx/conf.d/*.conf"
            . incl "/usr/local/etc/nginx/sites-available/*"
            . incl "/usr/local/etc/nginx/sites-enabled/*"
-           . incl "/etc/nginx/snippets/*"
 
 let xfm = transform lns filter


### PR DESCRIPTION
Hello! 

Just a small addition but one that's saved me a ton of time - doing surveys of nginx installs with `osquery`, and a lot of the configs are getting fragmented with snippets. Not a bad thing, but not something augeas was handling as it didn't see the `/etc/nginx/snippets` directory. 

So this PR is just to add that line to the main `nginx.aug` file - from my testing, augeas  handles the files themselves just fine and all the nodes I need and am expecting in osquery make it through. This might be handy for others, hence the PR.

Many thanks! M.