### PR TITLE
fstab: Allow consecutive commas in mount options

### DIFF
--- a/lenses/fstab.aug
+++ b/lenses/fstab.aug
@@ -5,8 +5,8 @@ module Fstab =
 
   let sep_tab = Sep.tab
   let sep_spc = Sep.space
-  let sep_comma_tab = del /,?[ \t]+/ "\t"
-  let comma   = Sep.comma
+  let sep_comma_tab = del /(,+)?[ \t]+/ "\t"
+  let comma   = del /,+/ ","
   let eol     = Util.eol
 
   let comment = Util.comment
@@ -21,7 +21,7 @@ module Fstab =
   let comma_sep_list (l:string) =
     let value = [ label "value" . Util.del_str "=" . ( store Rx.neg1 )? ] in
       let lns = [ label l . store optlabel . value? ] in
-         Build.opt_list lns comma
+         del /,*/ "" . Build.opt_list lns comma
 
   let record = [ seq "mntent" .
                    Util.indent .

--- a/lenses/tests/test_fstab.aug
+++ b/lenses/tests/test_fstab.aug
@@ -167,6 +167,23 @@ module Test_fstab =
     { "passno" = "0" }
   }
 
+  (* Double comma in mount options - empty option between commas
+   * This can occur from manual editing or automated tools
+   *)
+  test Fstab.lns get "/dev/mapper/vg00-vartmp /var/tmp xfs ,,rw,,nodev,nosuid,noexec,relatime,,, 0 0\n" =
+  { "1"
+    { "spec" = "/dev/mapper/vg00-vartmp" }
+    { "file" = "/var/tmp" }
+    { "vfstype" = "xfs" }
+    { "opt" = "rw" }
+    { "opt" = "nodev" }
+    { "opt" = "nosuid" }
+    { "opt" = "noexec" }
+    { "opt" = "relatime" }
+    { "dump" = "0" }
+    { "passno" = "0" }
+  }
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)


### PR DESCRIPTION
Fix the fstab lens to handle consecutive commas in mount options (e.g., "rw,,nodev"). This has been seen in the wild via libguestfs/ virt-v2v:

https://issues.redhat.com/browse/RHEL-77279

The fix changes the comma separator from matching a single comma to matching one or more consecutive commas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)