### PR TITLE
lenses/fstab.aug: Allow empty option items

### DIFF
--- a/lenses/fstab.aug
+++ b/lenses/fstab.aug
@@ -5,8 +5,8 @@ module Fstab =
 
   let sep_tab = Sep.tab
   let sep_spc = Sep.space
-  let sep_comma_tab = del /,?[ \t]+/ "\t"
-  let comma   = Sep.comma
+  let sep_comma_tab = del /,*[ \t]+/ "\t"
+  let comma   = del /,+/ ","
   let eol     = Util.eol
 
   let comment = Util.comment

--- a/lenses/tests/test_fstab.aug
+++ b/lenses/tests/test_fstab.aug
@@ -167,6 +167,19 @@ module Test_fstab =
     { "passno" = "0" }
   }
 
+  (* Allow empty options / double commas *)
+  test Fstab.lns get "/dev/mapper/foo-bar / xfs rw,,nodev,nosuid,, 0 0\n" =
+  { "1"
+    { "spec" = "/dev/mapper/foo-bar" }
+    { "file" = "/" }
+    { "vfstype" = "xfs" }
+    { "opt" = "rw" }
+    { "opt" = "nodev" }
+    { "opt" = "nosuid" }
+    { "dump" = "0" }
+    { "passno" = "0" }
+  }
+
 (* Local Variables: *)
 (* mode: caml       *)
 (* End:             *)


### PR DESCRIPTION
Yet another possible solution to "double commas in mount lines", see #849 and #866.
