### PR TITLE
lenses/iproute2: Ignore Readme, add new directory

### DIFF
--- a/lenses/iproute2.aug
+++ b/lenses/iproute2.aug
@@ -7,4 +7,9 @@ module IPRoute2 =
 
   let lns = ( empty | Util.comment | record ) *
 
-  let xfm = transform lns (incl "/etc/iproute2/*" . Util.stdexcl)
+  let filter = incl "/etc/iproute2/*"
+             . incl "/usr/share/iproute2/*"
+             . excl "/etc/iproute2/README"
+             . Util.stdexcl
+
+  let xfm = transform lns filter


### PR DESCRIPTION
From v6.5.0, iproute2 supports stateless configuration pattern. This means that iproute2 now reads its config from /etc/iproute2/FOO, and, if it does not exist, falls back to /usr/share/iproute2/FOO.

A "README" file in /etc/iproute2 explains the matter, but the file itself needs to be excluded from the lens.