### PR TITLE
Fix installing lenses when doing an out-of-tree build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,8 +9,8 @@ ACLOCAL_AMFLAGS = -I gnulib/m4
 lensdir=$(datadir)/augeas/lenses/dist
 lenstestdir=$(datadir)/augeas/lenses/dist/tests
 
-dist_lens_DATA=$(wildcard lenses/*.aug)
-dist_lenstest_DATA=$(wildcard lenses/tests/*.aug)
+dist_lens_DATA=$(wildcard $(top_srcdir)/lenses/*.aug)
+dist_lenstest_DATA=$(wildcard $(top_srcdir)/lenses/tests/*.aug)
 
 EXTRA_DIST=augeas.spec build/ac-aux/move-if-change Makefile.am HACKING.md
 


### PR DESCRIPTION
When doing an out-of-tree build, the wildcard calls in Makefile.am operate on a nonexistant "lenses" subdirectory of the BUILD directory.

Fix the calls to look in the SOURCE directory, where the lenses exist.