### PR TITLE
lenses/crypttab.aug: Add support for link-volume-key option

### DIFF
--- a/lenses/crypttab.aug
+++ b/lenses/crypttab.aug
@@ -58,7 +58,7 @@ module Crypttab =
   let word    = Rx.word
 
    (* Variable: optval *)
-  let optval  = /[A-Za-z0-9\/_.:-]+/
+  let optval  = /[A-Za-z0-9\/_@%.:-]+/
 
   (* Variable: target *)
   let target  = Rx.device_name

--- a/lenses/tests/test_crypttab.aug
+++ b/lenses/tests/test_crypttab.aug
@@ -26,7 +26,7 @@ module Test_crypttab =
         { "target" = "sda1_crypt" }
         { "device" = "/dev/sda1" } }
 
-  let multi_opts = "sda1_crypt\t /dev/sda1\t    /etc/key \t      cipher=aes-cbc-essiv:sha256,verify\n"
+  let multi_opts = "sda1_crypt\t /dev/sda1\t    /etc/key \t      cipher=aes-cbc-essiv:sha256,verify,link-volume-key=@u::%logon:kdump-cryptsetup:vk-d2a5a1c2-f9ab-4490-9a53-737b39746ec0\n"
 
   let multi_opts_tree =
     { "1"
@@ -35,7 +35,9 @@ module Test_crypttab =
         { "password" = "/etc/key" }
         { "opt" = "cipher"
             { "value" = "aes-cbc-essiv:sha256" } }
-        { "opt" = "verify" } }
+        { "opt" = "verify" }
+        { "opt" = "link-volume-key"
+            { "value" = "@u::%logon:kdump-cryptsetup:vk-d2a5a1c2-f9ab-4490-9a53-737b39746ec0" } } }
 
   let uuid = "sda3_crypt UUID=5b8b6e72-acf9-43bc-bd2d-8dbcaee82f99 none luks,keyscript=/usr/share/yubikey-luks/ykluks-keyscript,discard\n"
 


### PR DESCRIPTION
~~Fedora 44 Anaconda adds a new entry to /etc/crypttab:~~
(systemd adds this, see note below)
```
  ...,link-volume-key=@u::%logon:kdump-cryptsetup:<key>
```
The existing lens cannot parse @ or % in the optional value field so failed.

Add the two new characters, plus a test.

Reported-by: Katerina Koukiou

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2452937