### PR TITLE
lenses/radicale.aug: Allow semicolon in value

### DIFF
--- a/lenses/radicale.aug
+++ b/lenses/radicale.aug
@@ -15,6 +15,7 @@ module Radicale =
  * /etc/radicale/config only supports "#" as commentary and "=" as separator
  *************************************************************************)
 let comment    = IniFile.comment "#" "#"
+let comment_re = /[#]/
 let sep        = IniFile.sep "=" "="
 
 
@@ -22,7 +23,7 @@ let sep        = IniFile.sep "=" "="
  *                        ENTRY
  * /etc/radicale/config uses standard INI File entries
  *************************************************************************)
-let entry   = IniFile.indented_entry IniFile.entry_re sep comment
+let entry   = IniFile.entry_generic (Util.indent . key IniFile.entry_re) sep comment_re comment
 
 
 (************************************************************************

--- a/lenses/tests/test_radicale.aug
+++ b/lenses/tests/test_radicale.aug
@@ -18,6 +18,7 @@ module Test_radicale =
 [logging]
 
 [headers]
+Content-Security-Policy = default-src 'self'; object-src 'none'
 
 "
 
@@ -40,6 +41,7 @@ module Test_radicale =
       { "logging"
          {} }
       { "headers"
+         { "Content-Security-Policy" = "default-src 'self'; object-src 'none'" }
          {} }
 
     test Radicale.lns put conf after
@@ -48,7 +50,8 @@ module Test_radicale =
        set "well-known/caldav" "/radicale/%(user)s/caldav/";
        set "well-known/cardav" "/radicale/%(user)s/carddav/";
        set "auth/type" "remote_user";
-       set "rights/type" "owner_only"
+       set "rights/type" "owner_only";
+       set "headers/Content-Security-Policy" "default-src 'self'; object-src 'none'"
     = "
 [server]
 
@@ -73,5 +76,6 @@ type=owner_only
 [logging]
 
 [headers]
+Content-Security-Policy = default-src 'self'; object-src 'none'
 
 "


### PR DESCRIPTION
The latest version of radicale calendar server's configuration file does not parse with augeas. This is because it contains the following entry in [headers] section:

Content-Security-Policy = default-src 'self'; object-src 'none'

The semicolon is treated as comment by the lens which is not correct. Fix this by overriding comment_re in the lens.

Tests:

- Updated test case works when using augparse.

- With the patch, latest upstream configuration file parses without errors.