### PR TITLE
Update transform function to check for nfs_shares in /etc/exports.d/* directory

### DIFF
--- a/lenses/exports.aug
+++ b/lenses/exports.aug
@@ -95,4 +95,4 @@ module Exports =
 
   let lns = (Util.empty | Util.comment | entry)*
 
-  let xfm = transform lns (incl "/etc/exports")
+  let xfm = transform lns (incl "/etc/exports") . (incl "/etc/exports.d/*")


### PR DESCRIPTION
Fixed limitation where augeas would only look for nfs shares in /etc/exports not additional nfs configs under /etc/exports.d/*