### PR TITLE
cast to unsigned char before ctype calls

### DIFF
--- a/src/augrun.c
+++ b/src/augrun.c
@@ -126,7 +126,7 @@ static char *nexttoken(struct command *cmd, char **line, bool path) {
 
     s = *line;
 
-    while (*s && isblank(*s)) s+= 1;
+    while (*s && isblank((unsigned char) *s)) s+= 1;
     r = s;
     w = s;
     while (*s) {
@@ -190,7 +190,7 @@ static char *nexttoken(struct command *cmd, char **line, bool path) {
                     copy = false;
                 }
 
-                if (!quot && isblank(*s))
+                if (!quot && isblank((unsigned char) *s))
                     break;
             }
         } else {
@@ -265,7 +265,7 @@ static int parseline(struct command *cmd, char *line) {
     int curarg = 0;
     def = cmd->def->opts;
     while (*line != '\0') {
-        while (*line && isblank(*line)) line += 1;
+        while (*line && isblank((unsigned char) *line)) line += 1;
 
         if (curarg >= narg) {
             ERR_REPORT(cmd, AUG_ECMDRUN,
@@ -289,7 +289,7 @@ static int parseline(struct command *cmd, char *line) {
         opt->value = tok;
         curarg += 1;
         def += 1;
-        while (*line && isblank(*line)) line += 1;
+        while (*line && isblank((unsigned char) *line)) line += 1;
     }
 
     if (curarg < narg - nopt) {
@@ -1660,7 +1660,7 @@ int aug_srun(augeas *aug, FILE *out, const char *text) {
 
     while (*text != '\0' && result >= 0) {
         eol = strchrnul(text, '\n');
-        while (isspace(*text) && text < eol) text++;
+        while (isspace((unsigned char) *text) && text < eol) text++;
         if (*text == '\0')
             break;
         if (*text == '#' || text == eol) {

--- a/src/fa.c
+++ b/src/fa.c
@@ -2547,11 +2547,11 @@ int fa_equals(struct fa *fa1, struct fa *fa2) {
 }
 
 static unsigned int chr_score(char c) {
-    if (isalpha(c)) {
+    if (isalpha((unsigned char) c)) {
         return 2;
-    } else if (isalnum(c)) {
+    } else if (isalnum((unsigned char) c)) {
         return 3;
-    } else if (isprint(c)) {
+    } else if (isprint((unsigned char) c)) {
         return 7;
     } else if (c == '\0') {
         return 10000;

--- a/src/internal.c
+++ b/src/internal.c
@@ -214,7 +214,7 @@ char *escape(const char *text, int cnt, const char *extra) {
             len += 2;  /* Escaped as '\x' */
         else if (text[i] && extra && (strchr(extra, text[i]) != NULL))
             len += 2;  /* Escaped as '\x' */
-        else if (! isprint(text[i]))
+        else if (! isprint((unsigned char) text[i]))
             len += 4;  /* Escaped as '\ooo' */
         else
             len += 1;
@@ -230,7 +230,7 @@ char *escape(const char *text, int cnt, const char *extra) {
         } else if (text[i] && extra && (strchr(extra, text[i]) != NULL)) {
             *e++ = '\\';
             *e++ = text[i];
-        } else if (! isprint(text[i])) {
+        } else if (! isprint((unsigned char) text[i])) {
             sprintf(e, "\\%03o", (unsigned char) text[i]);
             e += 4;
         } else {
@@ -416,7 +416,7 @@ static char *cleanstr(char *path, const char sep) {
     if (path == NULL || strlen(path) == 0)
         return path;
     char *e = path + strlen(path) - 1;
-    while (e >= path && (*e == sep || isspace(*e)))
+    while (e >= path && (*e == sep || isspace((unsigned char) *e)))
         *e-- = '\0';
     return path;
 }

--- a/src/pathx.c
+++ b/src/pathx.c
@@ -1745,7 +1745,7 @@ static void check_expr(struct expr *expr, struct state *state) {
  */
 
 static void skipws(struct state *state) {
-    while (isspace(*state->pos)) state->pos += 1;
+    while (isspace((unsigned char) *state->pos)) state->pos += 1;
 }
 
 static int match(struct state *state, char m) {
@@ -1773,7 +1773,7 @@ static int looking_at(struct state *state, const char *token,
                       const char *follow) {
     if (STREQLEN(state->pos, token, strlen(token))) {
         const char *p = state->pos + strlen(token);
-        while (isspace(*p)) p++;
+        while (isspace((unsigned char) *p)) p++;
         if (STREQLEN(p, follow, strlen(follow))) {
             state->pos = p + strlen(follow);
             return 1;
@@ -1835,7 +1835,7 @@ int pathx_escape_name(const char *in, char **out) {
     *out = NULL;
 
     for (p = in; *p; p++) {
-        if (strchr(name_follow, *p) || isspace(*p) || *p == '\\')
+        if (strchr(name_follow, *p) || isspace((unsigned char) *p) || *p == '\\')
             num_to_escape += 1;
     }
 
@@ -1846,7 +1846,7 @@ int pathx_escape_name(const char *in, char **out) {
         return -1;
 
     for (p = in, s = *out; *p; p++) {
-        if (strchr(name_follow, *p) || isspace(*p) || *p == '\\')
+        if (strchr(name_follow, *p) || isspace((unsigned char) *p) || *p == '\\')
             *s++ = '\\';
         *s++ = *p;
     }
@@ -1900,7 +1900,7 @@ static char *parse_name(struct state *state) {
      * and don't strip it as in "x\\ " */
     if (state->pos > s) {
         state->pos -= 1;
-        while (isspace(*state->pos) && state->pos > s
+        while (isspace((unsigned char) *state->pos) && state->pos > s
                && !backslash_escaped(state->pos, s))
             state->pos -= 1;
         state->pos += 1;
@@ -2294,12 +2294,12 @@ static void parse_var(struct state *state) {
     const char *id = state->pos;
     struct expr *expr = NULL;
 
-    if (!isalpha(*id) && *id != '_') {
+    if (!isalpha((unsigned char) *id) && *id != '_') {
         STATE_ERROR(state, PATHX_ENAME);
         return;
     }
     id++;
-    while (isalpha(*id) || isdigit(*id) || *id == '_')
+    while (isalpha((unsigned char) *id) || isdigit((unsigned char) *id) || *id == '_')
         id += 1;
 
     if (ALLOC(expr) < 0)
@@ -2354,8 +2354,8 @@ static int looking_at_primary_expr(struct state *state) {
     /* Or maybe a function call, i.e. a word followed by a '(' ?
      * Note that our function names are only [a-zA-Z]+
      */
-    while (*s != '\0' && isalpha(*s)) s++;
-    while (*s != '\0' && isspace(*s)) s++;
+    while (*s != '\0' && isalpha((unsigned char) *s)) s++;
+    while (*s != '\0' && isspace((unsigned char) *s)) s++;
     return *s == '(';
 }
 
@@ -2722,7 +2722,7 @@ static bool step_matches(struct step *step, struct tree *tree) {
             return false;
         /* label matches if it consists of numeric digits only */
         for( char *s = tree->label; *s ; s++) {
-            if ( ! isdigit(*s) )
+            if ( ! isdigit((unsigned char) *s) )
                 return false;
         }
         return true;


### PR DESCRIPTION
noticed in the path-expression lexer: it, the regex example builder and the error formatter pass a plain `char` to `isspace`/`isalpha`/`isprint`, so a high byte like a utf-8 path label reaches `ctype` as a negative `int` (undefined behavior, an out-of-bounds table read where the ctype table has no negative slots); cast each argument to `unsigned char`.