### PR TITLE
Simplevars: fix the path of OpenBSD's wsconsctl.conf

### DIFF
--- a/lenses/simplevars.aug
+++ b/lenses/simplevars.aug
@@ -46,7 +46,7 @@ let filter = incl "/etc/kernel-img.conf"
            . incl "/etc/zabbix/*/*.conf"
            . incl "/etc/audit/auditd.conf"
            . incl "/etc/mixerctl.conf"
-           . incl "/etc/wsconsctlctl.conf"
+           . incl "/etc/wsconsctl.conf"
            . incl "/etc/ocsinventory/ocsinventory-agent.cfg"
 
 let xfm = transform lns filter


### PR DESCRIPTION
`/etc/wsconsctlctl.conf` in the `Simplevars` filter has an extra `ctl`. It came
in with aa3bc264 (2013) as one of "two files found on OpenBSD", and has matched
nothing since.

The file OpenBSD actually has is `/etc/wsconsctl.conf`, applied by `/etc/rc`:

```sh
stripcom /etc/wsconsctl.conf |
while read _line; do
        eval "wsconsctl $_line"
```

It holds one `wsconsctl(8)` variable assignment per line:

```
keyboard.encoding=ru
display.screen_off=60000
```

`Rx.word` already allows the dots in those keys, so `Simplevars` parses the file
as it stands:

```
{ "keyboard.encoding" = "ru" }
{ "display.screen_off" = "60000" }
```

`augparse` passes on all 232 lens test modules.

---

The Build check will come back red: `.github/workflows/build.yml` still asks
for `ubuntu-20.04`, and every run since January has waited a day for a runner
and then been cancelled. It is not this change.
