### PR TITLE
Add the /usr/local paths for PostgreSQL and rsyslog

### DIFF
--- a/lenses/pg_hba.aug
+++ b/lenses/pg_hba.aug
@@ -81,6 +81,7 @@ module Pg_Hba =
     (* View: filter
         The pg_hba.conf conf file *)
     let filter = (incl "/var/lib/pgsql/data/pg_hba.conf" .
+                  incl "/usr/local/pgsql/data/pg_hba.conf" .
                   incl "/var/lib/pgsql/*/data/pg_hba.conf" .
                   incl "/var/lib/postgresql/*/data/pg_hba.conf" .
                   incl "/etc/postgresql/*/*/pg_hba.conf" )

--- a/lenses/postgresql.aug
+++ b/lenses/postgresql.aug
@@ -70,6 +70,7 @@ let lns = (Util.empty | Util.comment | entry)*
 
 (* Variable: filter *)
 let filter = (incl "/var/lib/pgsql/data/postgresql.conf" .
+              incl "/usr/local/pgsql/data/postgresql.conf" .
               incl "/var/lib/pgsql/*/data/postgresql.conf" .
               incl "/var/lib/postgresql/*/data/postgresql.conf" .
               incl "/etc/postgresql/*/*/postgresql.conf" )

--- a/lenses/rsyslog.aug
+++ b/lenses/rsyslog.aug
@@ -93,6 +93,8 @@ let lns = entries . ( program | hostname )*
 
 let filter = incl "/etc/rsyslog.conf"
            . incl "/etc/rsyslog.d/*"
+           . incl "/usr/local/etc/rsyslog.conf"
+           . incl "/usr/local/etc/rsyslog.d/*"
            . Util.stdexcl
 
 let xfm = transform lns filter


### PR DESCRIPTION
Three filters miss files that exist on installations which are not a Linux
distribution's.

**`/usr/local/pgsql/data` is PostgreSQL's own default.** Its installation
documentation says so:

```
mkdir -p /usr/local/pgsql/data
/usr/local/pgsql/bin/initdb -D /usr/local/pgsql/data
```

so anyone who builds PostgreSQL from source with the default prefix lands
there, whatever the operating system. `Pg_Hba` and `Postgresql` already carry
the Red Hat and Debian layouts; this is the third one.

**`/usr/local/etc` is where the BSDs put the configuration of software they did
not ship themselves.** `Rsyslog` is the only lens of its kind without it —
`Dovecot`, `Nginx`, `Php`, `Postfix` (seven lenses), `Puppet` (three lenses),
`Sudoers` and `Systemd` all carry their `/usr/local` counterpart already.

FreeBSD's ports tree has carried these four lines as local patches.

`augparse` passes on all 232 lens test modules.

---

The Build check will come back red: `.github/workflows/build.yml` still asks
for `ubuntu-20.04`, and every run since January has waited a day for a runner
and then been cancelled. It is not this change.
