### PR TITLE
Stop depending on GNU make to list files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,8 +9,8 @@ ACLOCAL_AMFLAGS = -I gnulib/m4
 lensdir=$(datadir)/augeas/lenses/dist
 lenstestdir=$(datadir)/augeas/lenses/dist/tests
 
-dist_lens_DATA=$(wildcard lenses/*.aug)
-dist_lenstest_DATA=$(wildcard lenses/tests/*.aug)
+dist_lens_DATA=@LENS_FILES@
+dist_lenstest_DATA=@LENS_TEST_FILES@
 
 EXTRA_DIST=augeas.spec build/ac-aux/move-if-change Makefile.am HACKING.md
 

--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,17 @@ dnl set PC_SELINUX for use by augeas.pc.in
 PC_SELINUX=$(echo $LIB_SELINUX | sed -e 's/-l/lib/')
 AC_SUBST([PC_SELINUX])
 
+dnl The lens lists used to be $(wildcard lenses/*.aug) in Makefile.am, which
+dnl only GNU make expands: every other make leaves the call as a literal
+dnl string and installs no lens at all. Expand them here instead, so that
+dnl the makefile only ever sees a plain list of file names.
+LENS_FILES=`cd "$srcdir" && echo lenses/*.aug`
+LENS_TEST_FILES=`cd "$srcdir" && echo lenses/tests/*.aug`
+TEST_MODULE_FILES=`cd "$srcdir/tests" && echo modules/*.aug`
+AC_SUBST([LENS_FILES])
+AC_SUBST([LENS_TEST_FILES])
+AC_SUBST([TEST_MODULE_FILES])
+
 PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([LIBXML], [libxml-2.0])
 

--- a/doc/naturaldocs/Makefile.am
+++ b/doc/naturaldocs/Makefile.am
@@ -1,6 +1,12 @@
 
-EXTRA_DIST = $(wildcard conf/Augeas.css conf/c_api/*.txt) \
-             $(wildcard conf/lenses/*.txt) \
+EXTRA_DIST = conf/Augeas.css \
+             conf/c_api/Languages.txt \
+             conf/c_api/Menu.txt \
+             conf/c_api/Topics.txt \
+             conf/lenses/Languages.txt \
+             conf/lenses/Menu.txt \
+             conf/lenses/Menu_Backup.txt \
+             conf/lenses/Topics.txt \
              Modules/NaturalDocs/Languages/Augeas.pm
 
 ND_CONF=$(srcdir)/conf

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,5 +1,5 @@
 
-EXTRA_DIST=$(wildcard *.pod) $(wildcard *.[0-9])
+EXTRA_DIST=augtool.pod augparse.pod augmatch.pod augprint.pod $(man1_MANS)
 
 man1_MANS=augtool.1 augparse.1 augmatch.1 augprint.1
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -291,7 +291,7 @@ check_SCRIPTS = \
 
 EXTRA_DIST = \
   test-augtool test-augprint root lens-test-1 \
-  $(check_SCRIPTS) $(wildcard modules/*.aug) xpath.tests run.tests
+  $(check_SCRIPTS) @TEST_MODULE_FILES@ xpath.tests run.tests
 
 noinst_SCRIPTS = $(check_SCRIPTS)
 


### PR DESCRIPTION
`$(wildcard)` is a GNU make function. Every other make leaves the call as a
literal string, so the variables that use it come out holding
`$(wildcard lenses/*.aug)` rather than a list of names.

For `dist_lens_DATA` and `dist_lenstest_DATA` that means `make install` matches
nothing: not one lens is installed, and `augtool` cannot read a single
configuration file. For the three `EXTRA_DIST` uses it means `make dist` leaves
those files out of the tarball.

Expanding the lists in configure keeps the makefiles to plain lists of names,
which any make can handle. Where the set is small and fixed the names are
written out instead, which is shorter and needs nothing from configure.

**Writing the glob straight into `Makefile.am` is not enough.** It works in
tree, because the install rule hands the list to the shell. Out of tree it does
not: automake installs each entry with

```
for p in $$list; do if test -f "$$p"; then d=; else d="$(srcdir)/"; fi
```

and that fallback needs `$$p` to be a real name. Left as a pattern it is found
neither in the build directory nor in the source directory, and the count drops
back to zero. configure has no such split, because `$srcdir` is known there.

Checked by installing into a staging directory in all four combinations, with
three lenses and three lens tests:

| | GNU make | BSD make |
|---|---|---|
| in tree | 6 | 6 |
| separate build directory | 6 | 6 |
| *present code* | *6* | *0* |

`make dist` was checked the same way, in the top directory and in a
subdirectory, and produces the same tarball under both makes.

**What the dependency costs.** No BSD carries GNU make in base. FreeBSD's ports
tree adds `gmake` to `USES`, OpenBSD's sets `USE_GMAKE`, and pkgsrc would have
to build `devel/gmake`, which compiles GNU make from source, before it could
copy a directory of `.aug` files into place. pkgsrc does not add it, and has
been shipping augeas with no lens at all since 2014.

---

The Build check will come back red: `.github/workflows/build.yml` still asks
for `ubuntu-20.04`, and every run since January has waited a day for a runner
and then been cancelled. It is not this change.
