### PR TITLE
Hold the elapsed time in a type that can hold it

### DIFF
--- a/examples/dump.c
+++ b/examples/dump.c
@@ -117,9 +117,9 @@ static void dump_var(struct augeas *aug, const char *path) {
 
 static void print_time_taken(const struct timeval *start,
                              const struct timeval *stop) {
-    time_t elapsed = (stop->tv_sec - start->tv_sec)*1000
-                   + (stop->tv_usec - start->tv_usec)/1000;
-    fprintf(stderr, "time: %lld ms\n", (long long) elapsed);
+    long long elapsed = (stop->tv_sec - start->tv_sec)*1000
+                      + (stop->tv_usec - start->tv_usec)/1000;
+    fprintf(stderr, "time: %lld ms\n", elapsed);
 }
 
 int main(int argc, char **argv) {

--- a/examples/dump.c
+++ b/examples/dump.c
@@ -119,7 +119,7 @@ static void print_time_taken(const struct timeval *start,
                              const struct timeval *stop) {
     time_t elapsed = (stop->tv_sec - start->tv_sec)*1000
                    + (stop->tv_usec - start->tv_usec)/1000;
-    fprintf(stderr, "time: %ld ms\n", elapsed);
+    fprintf(stderr, "time: %lld ms\n", (long long) elapsed);
 }
 
 int main(int argc, char **argv) {

--- a/src/augtool.c
+++ b/src/augtool.c
@@ -466,7 +466,7 @@ static void print_time_taken(const struct timeval *start,
                              const struct timeval *stop) {
     time_t elapsed = (stop->tv_sec - start->tv_sec)*1000
                    + (stop->tv_usec - start->tv_usec)/1000;
-    printf("Time: %ld ms\n", elapsed);
+    printf("Time: %lld ms\n", (long long) elapsed);
 }
 
 static int run_command(const char *line, bool with_timing) {

--- a/src/augtool.c
+++ b/src/augtool.c
@@ -464,9 +464,9 @@ static void print_version_info(void) {
 
 static void print_time_taken(const struct timeval *start,
                              const struct timeval *stop) {
-    time_t elapsed = (stop->tv_sec - start->tv_sec)*1000
-                   + (stop->tv_usec - start->tv_usec)/1000;
-    printf("Time: %lld ms\n", (long long) elapsed);
+    long long elapsed = (stop->tv_sec - start->tv_sec)*1000
+                      + (stop->tv_usec - start->tv_usec)/1000;
+    printf("Time: %lld ms\n", elapsed);
 }
 
 static int run_command(const char *line, bool with_timing) {


### PR DESCRIPTION
`print_time_taken()` puts a millisecond count in a `time_t`. That is not what
`time_t` is for: the value is a duration, not a point in time, and nothing about
the platform's clock type says how wide a millisecond count needs to be. The
`%ld` that goes with it is right only where `time_t` happens to be `long`.

On NetBSD 11.0/i386 `long` is 4 bytes and `time_t` is 8, and gcc 12.5.0 says

```
warning: format '%ld' expects argument of type 'long int', but argument 2
has type 'time_t' {aka 'long long int'} [-Wformat=]
    6 |     printf("Time: %ld ms\n", elapsed);
      |                   ~~^        ~~~~~~~
      |                   %lld
```

which the package asks for, since it is built with `-Wall -Wformat`. OpenBSD is
in the same position: `time_t` is `__int64_t` on every architecture there, so
its 32 bit ones are affected too.

**What is printed survives in practice.** i386 passes the argument on the stack
and `%ld` reads its low half, so the number is right until the count passes
2^32 ms, about 49 days. Measured on NetBSD 11.0/i386: 1234 prints as 1234, and
5000000000 prints as 705032704. This is therefore a fix for the type and for
the warning, not for anything a user is likely to see.

Declaring the variable `long long` settles both at once and needs no cast at the
call. Checked on the same machine: no warning, and the values come out whole.

OpenBSD's ports tree carries both lines as local patches, changing the format to
`%lld` and leaving the variable a `time_t`. That works where `time_t` is 64 bit,
which on OpenBSD it always is, but not where `time_t` is `long` — FreeBSD/i386,
for one, has a 32 bit `time_t`.

---

The Build check will come back red: `.github/workflows/build.yml` still asks
for `ubuntu-20.04`, and every run since January has waited a day for a runner
and then been cancelled. It is not this change.
