### PR TITLE
Check that __gcc_personality_v0 links before using -fexceptions

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -21,6 +21,20 @@ AC_DEFUN([AUGEAS_COMPILE_WARNINGS],[
 
     common_flags="-fexceptions -fasynchronous-unwind-tables"
 
+    dnl -fexceptions makes the compiler emit exception tables, and those
+    dnl name __gcc_personality_v0. Deciding the flag by compiling and
+    dnl linking an empty main() does not settle anything, because an empty
+    dnl main() has no exception table and so never mentions the routine:
+    dnl the flag is accepted and the link of the real program fails later.
+    dnl Ask for the routine itself instead.
+    AC_MSG_CHECKING([whether __gcc_personality_v0 can be linked])
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM([[extern void __gcc_personality_v0(void);]],
+                       [[__gcc_personality_v0();]])],
+      [AC_MSG_RESULT([yes])],
+      [AC_MSG_RESULT([no])
+       common_flags=""])
+
     case "$enable_compile_warnings" in
     no)
         try_compiler_flags=""


### PR DESCRIPTION
`AUGEAS_COMPILE_WARNINGS` decides each flag by compiling and linking a program
whose `main()` is empty. For `-fexceptions` that settles nothing: an empty
`main()` has no exception table, so it never names `__gcc_personality_v0`, the
flag is accepted, and the link of the real program fails afterwards.

On OpenBSD 7.9/amd64 with clang 19.1.7 that is exactly what happens. configure
reports the flag as usable, then:

```
ld: error: undefined symbol: _Unwind_GetLanguageSpecificData
>>> referenced by gcc_personality_v0.c:203
>>>   gcc_personality_v0.o:(__gcc_personality_v0)
>>>   in archive /usr/lib/libcompiler_rt.a
```

`libcompiler_rt.a` has the personality routine, but `_Unwind_*` live only in
`libc++abi`, which a C program does not link. Building the 1.14.1 tarball there
fails; dropping the two flags builds it.

Ask for the routine itself instead. Where it links, nothing changes: glibc has
it in libgcc, and FreeBSD 14.3 builds with the flags as they are. Where it does
not, the flags are dropped before they can break the link rather than after.

Measured on OpenBSD 7.9, since the shape of the test matters:

| test program | without the flags | with them |
|---|---|---|
| empty `main()` — what configure uses now | links | links |
| one using `__attribute__((cleanup))` | links | links |
| one naming `__gcc_personality_v0` | **fails** | **fails** |

Only the third tells the two systems apart, and it gives the same answer either
way, which is what makes it usable as a precondition. On a glibc machine the
same program links.

OpenBSD's ports tree has carried a patch emptying `common_flags` since at least
2018.

---

The Build check will come back red: `.github/workflows/build.yml` still asks
for `ubuntu-20.04`, and every run since January has waited a day for a runner
and then been cancelled. It is not this change.
