### PR TITLE
Point the manual pages at the configured lens directory

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -5,3 +5,14 @@ man1_MANS=augtool.1 augparse.1 augmatch.1 augprint.1
 
 %.1: %.pod
 	pod2man -c "Augeas" -r "Augeas $(VERSION)" $< > $@
+
+# The manual pages name the lens directory as an absolute path. What the
+# tools actually search is built from $(datadir) by way of DATADIR in
+# src/internal.h, so the text is only right when the package is configured
+# with --prefix=/usr. Rewrite it on the way in.
+install-data-hook:
+	@for f in $(man1_MANS); do \
+	  p=$(DESTDIR)$(man1dir)/$$f; \
+	  sed -e 's|/usr/share/augeas|$(datadir)/augeas|g' $$p > $$p.tmp \
+	    && mv -f $$p.tmp $$p; \
+	done


### PR DESCRIPTION
`augtool.1`, `augparse.1`, `augmatch.1` and `augprint.1` all say the lenses live
in `/usr/share/augeas/lenses`. What the tools search is `AUGEAS_LENS_DIR`, which
`src/internal.h` builds from `DATADIR`, which configure sets from `$(datadir)`.
The text is therefore only right when the package was configured with
`--prefix=/usr`, and wrong for everyone else: `/usr/local` by default,
`/usr/pkg` or `/opt/pkg` under pkgsrc, whatever `--prefix` says.

There are 15 mentions across the four pages: 5 in `augtool.1`, 5 in
`augmatch.1`, 4 in `augprint.1` and 1 in `augparse.1`.

Rewriting the installed pages rather than the `.pod` sources keeps the sources
readable and needs no extra build step: the substitution has nothing to do until
the paths are known, which is at install time.

Checked with GNU make and with a BSD make against the four pages as shipped,
installed into a staging directory configured with `--prefix=/opt/pkg`: all 15
become `/opt/pkg/share/augeas`, and none are left behind.

OpenBSD's ports tree has been rewriting `augparse.1` in a `pre-configure` step
for the same reason.

---

The Build check will come back red: `.github/workflows/build.yml` still asks
for `ubuntu-20.04`, and every run since January has waited a day for a runner
and then been cancelled. It is not this change.
