### PR TITLE
rsyslog-rainerscript-patch: allow for rainerscript

### DIFF
--- a/lenses/rsyslog.aug
+++ b/lenses/rsyslog.aug
@@ -38,6 +38,21 @@ let config_object =
     config_object_param . ( config_sep . config_object_param )* .
     Sep.rbracket . Util.comment_or_eol ]
 
+(* View: rainer_entry
+   RainerScript selector + action() pair, e.g.:
+     *.info;mail.none action(type="omfile" file="/var/log/messages")
+   Uses label "rainer_entry" (not "entry") so the entries union never sees two
+   alternatives that both produce { "entry" }, avoiding a put-direction conflict. *)
+let rainer_entry =
+  [ label "rainer_entry" .
+    Syslog.selectors . Syslog.sep_tab .
+    [ label "action" .
+      Util.del_str "action" .
+      Sep.lbracket .
+      config_object_param . ( config_sep . config_object_param )* .
+      Sep.rbracket ] .
+    Util.comment_or_eol ]
+
 (* View: users
    Map :omusrmsg: and a list of users, or a single *
 *)
@@ -87,7 +102,7 @@ let prop_filter =
   in [ label "filter" . prop_name . sep . prop_oper . sep . prop_val .
        Sep.space . actions . Util.eol ]
 
-let entries = ( Syslog.empty | Util.comment | entry | macro | config_object | prop_filter )*
+let entries = ( Syslog.empty | Util.comment | entry | rainer_entry | macro | config_object | prop_filter )*
 
 let lns = entries . ( program | hostname )*
 

--- a/lenses/tests/test_rsyslog.aug
+++ b/lenses/tests/test_rsyslog.aug
@@ -200,6 +200,57 @@ test Rsyslog.lns get "module(load=\"imuxsock\" 	  # provides support for local s
     { "#comment" = "Turn off message reception via local log socket;" } }
   { "#comment" = "local messages are retrieved through imjournal now." }
 
+(* RainerScript action() as inline selector action (modern rsyslog.conf style).
+ * Uses "rainer_entry" (not "entry") so the lens union stays unambiguous for put. *)
+test Rsyslog.lns get "*.info;mail.none;authpriv.none;cron.none action(type=\"omfile\" file=\"/var/log/messages\")\n" =
+  { "rainer_entry"
+    { "selector"
+      { "facility" = "*" }
+      { "level" = "info" }
+    }
+    { "selector"
+      { "facility" = "mail" }
+      { "level" = "none" }
+    }
+    { "selector"
+      { "facility" = "authpriv" }
+      { "level" = "none" }
+    }
+    { "selector"
+      { "facility" = "cron" }
+      { "level" = "none" }
+    }
+    { "action"
+      { "type" = "omfile" }
+      { "file" = "/var/log/messages" }
+    }
+  }
+
+test Rsyslog.lns get "*.emerg action(type=\"omusrmsg\" users=\"*\")\n" =
+  { "rainer_entry"
+    { "selector"
+      { "facility" = "*" }
+      { "level" = "emerg" }
+    }
+    { "action"
+      { "type" = "omusrmsg" }
+      { "users" = "*" }
+    }
+  }
+
+test Rsyslog.lns get "mail.* action(type=\"omfile\" file=\"/var/log/maillog\" sync=\"on\")\n" =
+  { "rainer_entry"
+    { "selector"
+      { "facility" = "mail" }
+      { "level" = "*" }
+    }
+    { "action"
+      { "type" = "omfile" }
+      { "file" = "/var/log/maillog" }
+      { "sync" = "on" }
+    }
+  }
+
 (* rsyslog doesn't use bsd-like #! or #+/- specifications *)
 test Rsyslog.lns get "#!prog\n" = { "#comment" = "!prog" }
 test Rsyslog.lns get "#+host\n" = { "#comment" = "+host" }
@@ -258,4 +309,3 @@ local3.err                                              /var/log/nfsen/nfsenlog
     { "action"
       { "file" = "/var/log/also.log" } } }
   {  }
-


### PR DESCRIPTION
Update to handle RainerScript in rsyslog.conf which is now the default on RHEL 9 systems.

<details><summary>Problem</summary>

```markdown
Modern rsyslog (v7+) encourages **RainerScript** syntax in `/etc/rsyslog.conf`, where
logging rules use an inline `action(type=... ...)` config object instead of the
traditional bare file path or `:omusrmsg:` syntax.

Example — RainerScript style (modern):
```
*.info;mail.none;authpriv.none;cron.none action(type="omfile" file="/var/log/messages")
*.emerg action(type="omusrmsg" users="*")
mail.* action(type="omfile" file="/var/log/maillog" sync="on")
```

Example — Traditional style (Alma Linux 8 / legacy):
```
*.info;mail.none;authpriv.none;cron.none    /var/log/messages
*.emerg                                     :omusrmsg:*
mail.*                                      -/var/log/maillog
```

The pre-existing `rsyslog.aug` lens had no rule for the RainerScript inline
`action(...)` form, so modern configs would fail to parse those rule lines.
```
</details>

<details><summary>Summary of changes</summary>

```augeas
let rainer_entry =
  [ label "rainer_entry" .
    Syslog.selectors . Syslog.sep_tab .
    [ label "action" .
      Util.del_str "action" .
      Sep.lbracket .
      config_object_param . ( config_sep . config_object_param )* .
      Sep.rbracket ] .
    Util.comment_or_eol ]
```

**Updated entries union:**
```augeas
let entries = ( Syslog.empty | Util.comment | entry | rainer_entry | macro | config_object | prop_filter )*
```

### `lenses/tests/test_rsyslog.aug`

Added three new test cases:

| Input | Covers |
|---|---|
| `*.info;mail.none;authpriv.none;cron.none action(type="omfile" file="...")` | Multiple selectors, omfile action |
| `*.emerg action(type="omusrmsg" users="*")` | omusrmsg action |
| `mail.* action(type="omfile" file="..." sync="on")` | Extra action parameter (`sync`) |

---

## Backward Compatibility

Verified against `rsyslog-non-rainerscript.conf` (Alma Linux 8 format): all traditional `entry`, `config_object`, `omusrmsg`, and comment nodes parse identically to before. The `rainer_entry` rule is purely additive — it only
fires when the input matches `selector<whitespace>action(...)`.

---
</details>