### PR TITLE
tests: run the shell tests without GNU tools

### DIFF
--- a/tests/test-augprint.sh
+++ b/tests/test-augprint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Test that augprint produces the expected output, and that the output
 # can be used to reconstruct the original file
@@ -11,7 +11,8 @@ export AUGEAS_LENS_LIB=$abs_top_srcdir/lenses
 
 # ------------- /etc/hosts ------------
 mkdir -p $AUGEAS_ROOT/etc
-cp --no-preserve=mode --recursive $test_augprint_files/etc/ $AUGEAS_ROOT/
+cp -R $test_augprint_files/etc/ $AUGEAS_ROOT/
+chmod -R u+w $AUGEAS_ROOT/etc
 
 output=$AUGEAS_ROOT/etc.hosts.augprint
 AUGEAS_ROOT=$test_augprint_files augprint --pretty --verbose /etc/hosts > $output
@@ -19,23 +20,23 @@ augtool --load-file=/etc/hosts -f  $output --autosave 1>/dev/null
 # Check that output matches expected output
 diff -bu    $test_augprint_files/etc.hosts.pretty.augprint $output || exit 1
 # Check that file is unchanged
-diff -bu -B $test_augprint_files/etc/hosts $AUGEAS_ROOT/etc/hosts || exit 1
+diff -bu $test_augprint_files/etc/hosts $AUGEAS_ROOT/etc/hosts || exit 1
 
 AUGEAS_ROOT=$test_augprint_files augprint --regexp=2 /etc/hosts > $output
 augtool --load-file=/etc/hosts -f  $output --autosave 1>/dev/null
 # Check that output matches expected output
 diff -bu    $test_augprint_files/etc.hosts.regexp.augprint $output || exit 1
 # Check that file is unchanged
-diff -bu -B $test_augprint_files/etc/hosts $AUGEAS_ROOT/etc/hosts || exit 1
+diff -bu $test_augprint_files/etc/hosts $AUGEAS_ROOT/etc/hosts || exit 1
 
 # ------------- /etc/squid/squid.conf and /etc/pam,d/systemd-auth  ------------
 for test_file in /etc/squid/squid.conf /etc/pam.d/system-auth ; do
 	mkdir -p $(dirname $AUGEAS_ROOT/$test_file)
-  output=${test_file//\//.}
+  output=$(printf '%s' "$test_file" | tr '/' '.')
   output=${AUGEAS_ROOT}/${output#.}.augprint
 	AUGEAS_ROOT=$test_augprint_files augprint $test_file > $output
 	augtool --load-file=$test_file -f $output --autosave 1>/dev/null
 	# Check that file is unchanged
-	diff -bu -B $test_augprint_files/$test_file $AUGEAS_ROOT/$test_file || exit 1
+	diff -bu $test_augprint_files/$test_file $AUGEAS_ROOT/$test_file || exit 1
 done
 

--- a/tests/test-augtool.sh
+++ b/tests/test-augtool.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 TOP_DIR=$(cd $(dirname $0)/.. && pwd)
 TOP_BUILDDIR="$abs_top_builddir"

--- a/tests/test-createfile.sh
+++ b/tests/test-createfile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Test that augeas can create a file based on new paths added to the tree
 # The tree should retain the paths on a subsequent load operation
@@ -22,10 +22,10 @@ match /files/etc/sysctl.d/newfile1.conf/net.ipv4.ip_nonlocal_bind
 EOF
 )
 
-if [[ ! -e $root/$sysctl_file ]]; then
+if [ ! -e "$root/$sysctl_file" ]; then
   echo "Failed to create file $sysctl_file under $root"
   exit 1
-elif ! diff -bq $root/$sysctl_file <(echo "$expected_content") 1>/dev/null 2>&1; then
+elif ! printf '%s\n' "$expected_content" | diff -bq $root/$sysctl_file - 1>/dev/null 2>&1; then
   echo "Contents of $root/sysctl_file are incorrect"
   cat  $root/$sysctl_file
   echo '-- end of file --'
@@ -33,7 +33,7 @@ elif ! diff -bq $root/$sysctl_file <(echo "$expected_content") 1>/dev/null 2>&1;
   echo "$expected_content"
   echo '-- end of file --'
   exit 1
-elif [[ -z "$output" ]]; then
+elif [ -z "$output" ]; then
   echo "Missing /files/$sysctl_file in tree after save"
   exit 1
 else
@@ -56,10 +56,10 @@ save
 EOF
 )
 
-if [[ ! -e $root/$sysctl_file ]]; then
+if [ ! -e "$root/$sysctl_file" ]; then
   echo "Failed to create file $sysctl_file under $root"
   exit 1
-elif ! diff -bq $root/$sysctl_file <(echo "$expected_content") 1>/dev/null 2>&1; then
+elif ! printf '%s\n' "$expected_content" | diff -bq $root/$sysctl_file - 1>/dev/null 2>&1; then
   echo "Contents of $root/sysctl_file are incorrect"
   cat  $root/$sysctl_file
   echo '-- end of file --'
@@ -67,7 +67,7 @@ elif ! diff -bq $root/$sysctl_file <(echo "$expected_content") 1>/dev/null 2>&1;
   echo "$expected_content"
   echo '-- end of file --'
   exit 1
-elif [[ -z "$output" ]]; then
+elif [ -z "$output" ]; then
   echo "Missing /files/$sysctl_file in tree after save"
   exit 1
 else


### PR DESCRIPTION
Three of the 256 shell tests fail on a system whose /bin/sh is not bash and
whose cp and diff come from the base system rather than GNU coreutils. On
OpenBSD 7.9, where /bin/bash does not exist:

```
./test-createfile.sh[28]: syntax error: `(' unexpected
./test-augprint.sh[41]: ${test_file//\//.}: bad substitution
cp: unknown option -- -
diff: unknown option -- B
```

They are the only three of the 256 that ask for bash at all; the rest say
`#!/bin/sh`. What they use of it is small, and there is a POSIX spelling for
each. `cp --no-preserve=mode --recursive` becomes `cp -R` followed by
`chmod -R u+w`. `diff -bu -B` becomes `diff -bu`. `${test_file//\//.}` becomes
`printf` piped through `tr`. `[[ ! -e $f ]]` becomes `[ ! -e "$f" ]`, and
`diff ... <(echo "$x")` becomes `printf` piped into `diff ... -`.

Dropping `-B` is the one worth a second look, since it makes the comparison
stricter rather than looser and so cannot be hiding a difference. The two
files being compared are the same file before and after augprint has
rewritten it.

Measured on OpenBSD 7.9/amd64:

```
before   263 tests, 255 pass, 4 fail   augprint, augtool, createfile, idempotent
after    263 tests, 257 pass, 2 fail   augtool, idempotent
```

test-augtool.sh and test-idempotent.sh fail there for reasons of their own,
before and after, and I left them alone: the first is a content mismatch in
the yum.repos.d comparison, the second exits 1 without printing anything.

FreeBSD's ports tree adds bash and gsed to TEST_DEPENDS and rewrites the
shebangs in a post-patch step to get around this. With these three fixed it
would not have to.

The Build check fails on every pull request at the moment — the workflow
still asks for `ubuntu-20.04` and the runs time out waiting for a runner. It
is not this change.
