### PR TITLE
Update iptables.aug for failing tests, more consistant naming

### DIFF
--- a/lenses/iptables.aug
+++ b/lenses/iptables.aug
@@ -47,6 +47,15 @@ let tcp_flags =
       spc . dels "--tcp-flags" .
       spc . flag_list "mask" . spc . flag_list "set" ]
 
+let ipset_flags =
+  let flags = /src|dst/ in
+  let match_flag (name:string) =
+    Build.opt_list [label name . store flags] (dels ",") in
+  [ label "ipset_flags" .
+      spc . dels "--match-set" .
+      spc . store /[a-zA-Z-][a-zA-Z0-9-]+/ .
+      spc . match_flag "set" ]
+
 (* misses --set-counters *)
 let ipt_match =
   let any_key = /[a-zA-Z-][a-zA-Z0-9-]+/ -
@@ -65,6 +74,7 @@ let ipt_match =
     |neg_param "fragment" "f"
     |param "match" "m"
     |tcp_flags
+    |ipset_flags
     |any_param)*
 
 let chain_action (n:string) (o:string) =


### PR DESCRIPTION
iptables.aug tests were failing due to the chosen node-name "ipset_flags" also
being a possible match for the regular expression any_key

The lens iptables.aug is updated as follows

1) ipset node renamed from "ipset_flags" to "match-set"

This brings the node-name in line with the iptables option name --match-set

This also help to resolve the problem of the tests failing

2) flags node renamed from "set" to "flag"

This makes it consistant with the terminology used in iptables-extensions(8)

3) Excluded the string "match-set" from the RE any_key (internal)

This helps to resolve the problem of the tests failing

5) Added characters to possible ipset names: dot slash underscore

The test lenses/tests/test_iptables.aug is updated as follows

1) Added an example of "--match-set"
